### PR TITLE
Added BulkUpdateRequest and extra fields in BulkResponse.

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -196,7 +196,9 @@ func (s *BulkService) Do() (*BulkResponse, error) {
 
 // Response to bulk execution.
 type BulkResponse struct {
-	Took int `json:"took"`
+	Took   int `json:"took"`
+	Errors bool
+	Items  []map[string]map[string]interface{}
 }
 
 // Generic interface to bulkable requests.


### PR DESCRIPTION
BulkUpdateRequest: For updating data in elasticsearch in bulk.
Added extra fields (errors, items) in BulkResponse to get errors (if any) from a BulkRequest response.
