### PR TITLE
change "Google Go" to "Go"

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ following things in mind before submitting your pull request:
 Thanks a lot for the great folks working hard on
 [Elasticsearch](http://www.elasticsearch.org/)
 and
-[Google Go](http://www.golang.org/).
+[Go](http://www.golang.org/).
 
 ## LICENSE
 


### PR DESCRIPTION
Is recommended call to language as "Go" or "Go lang" instead of put "Google" according to the Go Team.
