### PR TITLE
Adding basic support for wildcard queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Elastic
 
+This is my fork repository for olivere/elastic to add a basic support for 
+wildcard queries.
+
 Elastic is an [Elasticsearch](http://www.elasticsearch.org/)
 client for [Google Go](http://www.golang.org/).
 

--- a/search_queries_wildcard.go
+++ b/search_queries_wildcard.go
@@ -1,0 +1,71 @@
+// Copyright 2012-2014 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+// Contributor: Yasar Senturk <yasar@senturk.name.tr>, 2014
+
+package elastic
+
+// Matches documents that have fields containing terms
+// with a query contains wildcards.
+// For more details, see
+// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+type WildcardQuery struct {
+	Query
+	name      string
+	wildcard  string
+	boost     *float32
+	rewrite   string
+	queryName string
+}
+
+// Creates a new wildcard query.
+func NewWildcardQuery(name string, wildcard string) WildcardQuery {
+	q := WildcardQuery{name: name, wildcard: wildcard}
+	return q
+}
+
+func (q WildcardQuery) Boost(boost float32) WildcardQuery {
+	q.boost = &boost
+	return q
+}
+
+func (q WildcardQuery) Rewrite(rewrite string) WildcardQuery {
+	q.rewrite = rewrite
+	return q
+}
+
+func (q WildcardQuery) QueryName(queryName string) WildcardQuery {
+	q.queryName = queryName
+	return q
+}
+
+// Creates the query source for the wildcard query.
+func (q WildcardQuery) Source() interface{} {
+	// {
+	//    "wildcard" : { "user" : { "wildcard" : "ki*y", "boost" : 2.0 } }
+	// }
+
+	source := make(map[string]interface{})
+
+	query := make(map[string]interface{})
+	source["wildcard"] = query
+
+	if q.boost == nil && q.rewrite == "" && q.queryName == "" {
+		query[q.name] = q.wildcard
+	} else {
+		subQuery := make(map[string]interface{})
+		subQuery["wildcard"] = q.wildcard
+		if q.boost != nil {
+			subQuery["boost"] = *q.boost
+		}
+		if q.rewrite != "" {
+			subQuery["rewrite"] = q.rewrite
+		}
+		if q.queryName != "" {
+			subQuery["_name"] = q.queryName
+		}
+		query[q.name] = subQuery
+	}
+
+	return source
+}

--- a/search_queries_wildcard_test.go
+++ b/search_queries_wildcard_test.go
@@ -1,0 +1,33 @@
+package elastic
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWildcardQuery(t *testing.T) {
+	q := NewWildcardQuery("user", "*ki*")
+	data, err := json.Marshal(q.Source())
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"wildcard":{"user":"*ki*"}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestWildcardQueryWithOptions(t *testing.T) {
+	q := NewWildcardQuery("user", "*ki*")
+	q = q.QueryName("my_query_name")
+	data, err := json.Marshal(q.Source())
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"wildcard":{"user":{"_name":"my_query_name","wildcard":"*ki*"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
Hi,

I needed wildcard queries in a personal project that I'm using elastic library. Quickest thing that I could do was to duplicate prefix query code, and make them compatible with the wildcard queries.

I know that this might not be a good patch (since it is just duplicate of prefix query code with wildcard keywords), but it worked for me, and might be useful for someone else.

I have tested this with go1.3.3 darwin/amd64, on OS X with Elasticsearch 1.4.1 on Debian 7.7.

Best regards,
Yaşar Şentürk
