### PR TITLE
Simple support for source filtering

### DIFF
--- a/get.go
+++ b/get.go
@@ -22,6 +22,7 @@ type GetService struct {
 	routing    string
 	preference string
 	fields     []string
+	source     []string
 	refresh    *bool
 	realtime   *bool
 }
@@ -82,6 +83,14 @@ func (b *GetService) Fields(fields ...string) *GetService {
 	return b
 }
 
+func (b *GetService) Source(sources ...string) *GetService {
+	if b.source == nil {
+		b.source = make([]string, 0)
+	}
+	b.source = append(b.source, sources...)
+	return b
+}
+
 func (b *GetService) Refresh(refresh bool) *GetService {
 	b.refresh = &refresh
 	return b
@@ -109,6 +118,9 @@ func (b *GetService) Do() (*GetResult, error) {
 	}
 	if len(b.fields) > 0 {
 		params.Add("fields", strings.Join(b.fields, ","))
+	}
+	if len(b.source) > 0 {
+		params.Add("_source", strings.Join(b.source, ","))
 	}
 	if b.routing != "" {
 		params.Add("routing", b.routing)

--- a/get_test.go
+++ b/get_test.go
@@ -6,6 +6,7 @@ package elastic
 
 import (
 	"testing"
+	"encoding/json"
 )
 
 func TestGet(t *testing.T) {
@@ -67,5 +68,22 @@ func TestGet(t *testing.T) {
 	}
 	if res.Source != nil {
 		t.Errorf("expected Source == nil; got %v", res.Source)
+	}
+
+	// Get partial document.  In this case only the User field
+	res, err = client.Get().Index(testIndexName).Type("tweet").Id("3").Source("user").Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tweetRes tweet
+	err = json.Unmarshal(*res.Source, &tweetRes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tweetRes.User != tweet3.User {
+		t.Errorf("expected User = sandrae; got %v", tweetRes.User)
+	}
+	if tweetRes.Message != "" {
+		t.Errorf("expected empty message; got %v", tweetRes.Message)
 	}
 }


### PR DESCRIPTION
I was trying to filter the fields that where returned from a Get() and found the Fields() was not helpful to as it changed the response format.

After some searching I found a way to retrieve only the fields I requested: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-source-filtering.html

There is more work needed here to support all of the options but this seems like a nice start.