### PR TITLE
method (c *Client)NewRequest reads the fields Client.activeUrl and Client.hasActive that can be mutated in pingUrls which runs in a seperate goroutine, so put them behind a read lock

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,9 +38,9 @@ type Client struct {
 
 	log *log.Logger // output log
 
-	mu        sync.Mutex // mutex for the next two fields
-	activeUrl string     // currently active connection url
-	hasActive bool       // true if we have an active connection
+	mu        sync.RWMutex // mutex for the next two fields
+	activeUrl string       // currently active connection url
+	hasActive bool         // true if we have an active connection
 }
 
 // NewClient creates a new client to work with Elasticsearch.
@@ -99,6 +99,8 @@ func (c *Client) dumpResponse(resp *http.Response) {
 // the base URL to the path. If no active connection to Elasticsearch
 // is available, ErrNoClient is returned.
 func (c *Client) NewRequest(method, path string) (*Request, error) {
+	c.mu.RLock()
+	c.mu.RUnlock()
 	if !c.hasActive {
 		return nil, ErrNoClient
 	}


### PR DESCRIPTION
First off, thank you so much for the great lib it has great to use so far!

Two fields hasActive and activeUrl aren't properly guarded by a mutex in one case giving the following relevant frames with -race

```
WARNING: DATA RACE
Read by goroutine 130:
  github.com/olivere/elastic.(*Client).NewRequest()
      /home/sdubois/development/go/src/github.com/olivere/elastic/client.go:102 +0x57
  github.com/olivere/elastic.(*IndexService).Do()
      /home/sdubois/development/go/src/github.com/olivere/elastic/index.go:209 +0x128f

Previous write by goroutine 20:
  github.com/olivere/elastic.(*Client).pingUrls()
      /home/sdubois/development/go/src/github.com/olivere/elastic/client.go:140 +0x4da
  github.com/olivere/elastic.(*Client).pinger()
      /home/sdubois/development/go/src/github.com/olivere/elastic/client.go:114 +0xa2

Goroutine 130 (running) created at:
 /home/sdubois/development/go/src/github.etsycorp.com/Engineering/Caboose/elasticsearch/elasticsearch.go:182 +0x180


Goroutine 20 (running) created at:
  github.com/olivere/elastic.NewClient()
      /home/sdubois/development/go/src/github.com/olivere/elastic/client.go:63 +0x2ab

```