### PR TITLE
Added test that validates marshaling and unmarshaling of the aggregation...

### DIFF
--- a/search_aggs_test.go
+++ b/search_aggs_test.go
@@ -6,6 +6,7 @@ package elastic
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -141,6 +142,23 @@ func TestAggs(t *testing.T) {
 	agg := searchResult.Aggregations
 	if agg == nil {
 		t.Fatalf("expected Aggregations != nil; got: nil")
+	}
+
+	// Make sure aggregations aren't unmarshalled into a base64 encoded string
+	res, err := json.Marshal(searchResult.Aggregations)
+	if err != nil {
+		t.Errorf("expexted aggregations to be marshalled into []byte")
+	}
+
+	searchRes := &SearchResult{}
+	err = json.Unmarshal(res, &searchRes.Aggregations)
+
+	if err != nil {
+		t.Errorf("expected aggregations to be json unmarshable %v", err)
+	}
+
+	if !strings.Contains(`{"buckets":[{"key_as_string":"2011-01-01T00:00:00.000Z","key":1293840000000,"doc_count":1},{"key_as_string":"2012-01-01T00:00:00.000Z","key":1325376000000,"doc_count":2}]}`, string(*searchRes.Aggregations["dateHisto"])) {
+		t.Errorf("expected dateHisto aggregations to be a json string and not base64 encoded string: %s", string(*searchRes.Aggregations["dateHisto"]))
 	}
 
 	// Search for non-existent aggregate should return (nil, false)


### PR DESCRIPTION
...s object in the SearchResult struct, make sure it doesn't return a base64 encoded string.

Verifies that the branch solving issue-51 actually works