### PR TITLE
Remove Reindexer.recreateTargetIndex

### DIFF
--- a/reindexer_test.go
+++ b/reindexer_test.go
@@ -24,7 +24,6 @@ func TestReindexer(t *testing.T) {
 	}
 
 	r := NewReindexer(client, testIndexName, testIndexName2)
-	r = r.Shards(1).Replicas(0)
 	ret, err := r.Do()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
That method allowed the caller to specify the index settings for
number_of_shards and number_of_replicas, but otherwise prevented the
user from specifying a mapping.

Removed the method and the two settings.
Now the caller must setup the target index any way he likes before
invoking the reindexer (this is in conformity with the reindexer
package comment)