### PR TITLE
Fix GetResult Fields type

### DIFF
--- a/get.go
+++ b/get.go
@@ -212,12 +212,12 @@ func (b *GetService) Do() (*GetResult, error) {
 // -- Result of a get request.
 
 type GetResult struct {
-	Index   string           `json:"_index"`
-	Type    string           `json:"_type"`
-	Id      string           `json:"_id"`
-	Version int64            `json:"_version,omitempty"`
-	Source  *json.RawMessage `json:"_source,omitempty"`
-	Found   bool             `json:"found,omitempty"`
-	Fields  []string         `json:"fields,omitempty"`
-	Error   string           `json:"error,omitempty"` // used only in MultiGet
+	Index   string                 `json:"_index"`
+	Type    string                 `json:"_type"`
+	Id      string                 `json:"_id"`
+	Version int64                  `json:"_version,omitempty"`
+	Source  *json.RawMessage       `json:"_source,omitempty"`
+	Found   bool                   `json:"found,omitempty"`
+	Fields  map[string]interface{} `json:"fields,omitempty"`
+	Error   string                 `json:"error,omitempty"` // used only in MultiGet
 }

--- a/get_test.go
+++ b/get_test.go
@@ -13,37 +13,9 @@ func TestGet(t *testing.T) {
 	client := setupTestClientAndCreateIndex(t)
 
 	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
-	tweet2 := tweet{User: "olivere", Message: "Another unrelated topic."}
-	tweet3 := tweet{User: "sandrae", Message: "Cycling is fun."}
-
-	// Add all documents
 	_, err := client.Index().Index(testIndexName).Type("tweet").Id("1").BodyJson(&tweet1).Do()
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	_, err = client.Index().Index(testIndexName).Type("tweet").Id("2").BodyJson(&tweet2).Do()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = client.Index().Index(testIndexName).Type("tweet").Id("3").BodyJson(&tweet3).Do()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = client.Flush().Index(testIndexName).Do()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Count documents
-	count, err := client.Count(testIndexName).Do()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if count != 3 {
-		t.Errorf("expected Count = %d; got %d", 3, count)
 	}
 
 	// Get document 1
@@ -75,26 +47,7 @@ func TestGetWithSourceFiltering(t *testing.T) {
 	client := setupTestClientAndCreateIndex(t)
 
 	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
-	tweet2 := tweet{User: "olivere", Message: "Another unrelated topic."}
-	tweet3 := tweet{User: "sandrae", Message: "Cycling is fun."}
-
-	// Add all documents
 	_, err := client.Index().Index(testIndexName).Type("tweet").Id("1").BodyJson(&tweet1).Do()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = client.Index().Index(testIndexName).Type("tweet").Id("2").BodyJson(&tweet2).Do()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = client.Index().Index(testIndexName).Type("tweet").Id("3").BodyJson(&tweet3).Do()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = client.Flush().Index(testIndexName).Do()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,6 +86,56 @@ func TestGetWithSourceFiltering(t *testing.T) {
 	}
 	if tw.Message != "" {
 		t.Errorf("expected message %q; got: %q", "", tw.Message)
+	}
+}
+
+func TestGetWithFields(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
+	_, err := client.Index().Index(testIndexName).Type("tweet").Id("1").Timestamp("12345").BodyJson(&tweet1).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get document 1, specifying fields
+	res, err := client.Get().Index(testIndexName).Type("tweet").Id("1").Fields("message", "_timestamp").Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Found != true {
+		t.Errorf("expected Found = true; got %v", res.Found)
+	}
+
+	timestamp, ok := res.Fields["_timestamp"].(float64)
+	if !ok {
+		t.Fatalf("Cannot retrieve \"_timestamp\" field from document")
+	}
+	if timestamp != 12345 {
+		t.Fatalf("Expected timestamp %v; got %v", 12345, timestamp)
+	}
+
+	messageField, ok := res.Fields["message"]
+	if !ok {
+		t.Fatalf("Cannot retrieve \"message\" field from document")
+	}
+
+	// Depending on the version of elasticsearch the message field will be returned
+	// as a string or a slice of strings. This test works in both cases.
+
+	messageString, ok := messageField.(string)
+	if !ok {
+		messageArray, ok := messageField.([]interface{})
+		if ok {
+			messageString, ok = messageArray[0].(string)
+		}
+		if !ok {
+			t.Fatalf("\"message\" field should be a string or a slice of strings")
+		}
+	}
+
+	if messageString != tweet1.Message {
+		t.Errorf("Expected message %s; got %s", tweet1.Message, messageString)
 	}
 }
 

--- a/index_test.go
+++ b/index_test.go
@@ -23,6 +23,10 @@ const (
 	},
 	"mappings":{
 		"tweet":{
+			"_timestamp": {
+				"enabled": true,
+				"store": "yes"
+			},
 			"properties":{
 				"tags":{
 					"type":"string"


### PR DESCRIPTION
Using Fields in GetService resulted in a marshalling error.

Fixed the type of Fields to map[string]interface{}.

In get_test:
- Added a test that request two fields and asserts their value.
- Simplified two tests that were testing more than the GetService,
and were issuing unnecessary Flush calls.