### PR TITLE
Generic handler

### DIFF
--- a/client.go
+++ b/client.go
@@ -1219,5 +1219,5 @@ func (c *Client) NodesInfo() *NodesInfoService {
 // http://www.elastic.co/guide/en/elasticsearch/guide/current/reindex.html
 // for more information about reindexing.
 func (c *Client) Reindex(sourceIndex, targetIndex string) *Reindexer {
-	return NewReindexer(c, sourceIndex, targetIndex)
+	return NewReindexer(c, sourceIndex, CopyToTargetIndex(targetIndex))
 }

--- a/index_test.go
+++ b/index_test.go
@@ -22,11 +22,17 @@ const (
 		"number_of_replicas":0
 	},
 	"mappings":{
-		"tweet":{
+		"_default_": {
 			"_timestamp": {
 				"enabled": true,
 				"store": "yes"
 			},
+			"_ttl": {
+				"enabled": true,
+				"store": "yes"
+			}
+		},
+		"tweet":{
 			"properties":{
 				"tags":{
 					"type":"string"

--- a/index_test.go
+++ b/index_test.go
@@ -39,6 +39,11 @@ const (
 					"payloads":true
 				}
 			}
+		},
+		"comment":{
+			"_parent": {
+				"type":	"tweet"
+			}
 		}
 	}
 }
@@ -58,6 +63,16 @@ type tweet struct {
 
 func (t tweet) String() string {
 	return fmt.Sprintf("tweet{User:%q,Message:%q,Retweets:%d}", t.User, t.Message, t.Retweets)
+}
+
+type comment struct {
+	User    string    `json:"user"`
+	Comment string    `json:"comment"`
+	Created time.Time `json:"created,omitempty"`
+}
+
+func (c comment) String() string {
+	return fmt.Sprintf("comment{User:%q,Comment:%q}", c.User, c.Comment)
 }
 
 func isTravis() bool {
@@ -123,6 +138,7 @@ func setupTestClientAndCreateIndexAndAddDocs(t logger, options ...ClientOptionFu
 	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
 	tweet2 := tweet{User: "olivere", Message: "Another unrelated topic."}
 	tweet3 := tweet{User: "sandrae", Message: "Cycling is fun."}
+	comment1 := comment{User: "nico", Comment: "You bet."}
 
 	_, err := client.Index().Index(testIndexName).Type("tweet").Id("1").BodyJson(&tweet1).Do()
 	if err != nil {
@@ -132,7 +148,11 @@ func setupTestClientAndCreateIndexAndAddDocs(t logger, options ...ClientOptionFu
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = client.Index().Index(testIndexName).Type("tweet").Id("3").BodyJson(&tweet3).Do()
+	_, err = client.Index().Index(testIndexName).Type("tweet").Id("3").Routing("someroutingkey").BodyJson(&tweet3).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Index().Index(testIndexName).Type("comment").Id("1").Parent("3").BodyJson(&comment1).Do()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/reindexer_test.go
+++ b/reindexer_test.go
@@ -1,10 +1,9 @@
 package elastic
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestReindexer(t *testing.T) {
+
 	client := setupTestClientAndCreateIndexAndAddDocs(t)
 
 	sourceCount, err := client.Count(testIndexName).Do()

--- a/reindexer_test.go
+++ b/reindexer_test.go
@@ -1,6 +1,9 @@
 package elastic
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestReindexer(t *testing.T) {
 
@@ -22,7 +25,7 @@ func TestReindexer(t *testing.T) {
 		t.Fatalf("expected %d documents; got: %d", 0, targetCount)
 	}
 
-	r := NewReindexer(client, testIndexName, testIndexName2)
+	r := NewReindexer(client, testIndexName, CopyToTargetIndex(testIndexName2))
 	ret, err := r.Do()
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +77,7 @@ func TestReindexerWithQuery(t *testing.T) {
 		t.Fatalf("expected %d documents; got: %d", 0, targetCount)
 	}
 
-	r := NewReindexer(client, testIndexName, testIndexName2)
+	r := NewReindexer(client, testIndexName, CopyToTargetIndex(testIndexName2))
 	r = r.Query(q)
 	ret, err := r.Do()
 	if err != nil {
@@ -124,7 +127,7 @@ func TestReindexerProgress(t *testing.T) {
 		totalsOk = totalsOk && total == sourceCount
 	}
 
-	r := NewReindexer(client, testIndexName, testIndexName2)
+	r := NewReindexer(client, testIndexName, CopyToTargetIndex(testIndexName2))
 	r = r.Progress(progress)
 	ret, err := r.Do()
 	if err != nil {
@@ -174,7 +177,7 @@ func TestReindexerWithTargetClient(t *testing.T) {
 		t.Fatalf("expected %d documents; got: %d", 0, targetCount)
 	}
 
-	r := NewReindexer(sourceClient, testIndexName, testIndexName2)
+	r := NewReindexer(sourceClient, testIndexName, CopyToTargetIndex(testIndexName2))
 	r = r.TargetClient(targetClient)
 	ret, err := r.Do()
 	if err != nil {
@@ -204,4 +207,82 @@ func TestReindexerWithTargetClient(t *testing.T) {
 	if targetCount != sourceCount {
 		t.Fatalf("expected %d documents; got: %d", sourceCount, targetCount)
 	}
+}
+
+// TestReindexerPreservingTTL shows how a caller can take control of the
+// copying process by providing ScanFields and a custom HitHandler.
+func TestReindexerPreservingTTL(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
+
+	_, err := client.Index().Index(testIndexName).Type("tweet").Id("1").TTL("999999").Version(10).VersionType("external").BodyJson(&tweet1).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Flush().Index(testIndexName).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sourceCount, err := client.Count(testIndexName).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sourceCount <= 0 {
+		t.Fatalf("expected more than %d documents; got: %d", 0, sourceCount)
+	}
+
+	targetCount, err := client.Count(testIndexName2).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targetCount != 0 {
+		t.Fatalf("expected %d documents; got: %d", 0, targetCount)
+	}
+
+	// Carries over the source item's ttl to the reindexed item
+	copyWithTTL := func(hit *SearchHit, bulkService *BulkService) error {
+		source := make(map[string]interface{})
+		if err := json.Unmarshal(*hit.Source, &source); err != nil {
+			return err
+		}
+		req := NewBulkIndexRequest().Index(testIndexName2).Type(hit.Type).Id(hit.Id).Doc(source)
+		if ttl, ok := hit.Fields["_ttl"].(float64); ok {
+			req.Ttl(int64(ttl))
+		}
+		bulkService.Add(req)
+		return nil
+	}
+
+	r := NewReindexer(client, testIndexName, copyWithTTL).ScanFields("_source", "_ttl")
+
+	ret, err := r.Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ret == nil {
+		t.Fatalf("expected result != %v; got: %v", nil, ret)
+	}
+	if ret.Success != sourceCount {
+		t.Errorf("expected success = %d; got: %d", sourceCount, ret.Success)
+	}
+	if ret.Failed != 0 {
+		t.Errorf("expected failed = %d; got: %d", 0, ret.Failed)
+	}
+	if len(ret.Errors) != 0 {
+		t.Errorf("expected to return no errors by default; got: %v", ret.Errors)
+	}
+
+	getResult, err := client.Get().Index(testIndexName2).Id("1").Fields("_source", "_ttl").Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok := getResult.Fields["_ttl"].(float64)
+	if !ok {
+		t.Errorf("Cannot retrieve TTL from reindexed document")
+	}
+
 }

--- a/reindexer_test.go
+++ b/reindexer_test.go
@@ -210,7 +210,7 @@ func TestReindexerWithTargetClient(t *testing.T) {
 }
 
 // TestReindexerPreservingTTL shows how a caller can take control of the
-// copying process by providing ScanFields and a custom HitHandler.
+// copying process by providing ScanFields and a custom ReindexerFunc.
 func TestReindexerPreservingTTL(t *testing.T) {
 	client := setupTestClientAndCreateIndex(t)
 

--- a/scan.go
+++ b/scan.go
@@ -32,6 +32,7 @@ type ScanService struct {
 	indices   []string
 	types     []string
 	keepAlive string
+	fields    []string
 	query     Query
 	size      *int
 	pretty    bool
@@ -88,6 +89,13 @@ func (s *ScanService) Scroll(keepAlive string) *ScanService {
 // available before expiration (e.g. "5m" for 5 minutes).
 func (s *ScanService) KeepAlive(keepAlive string) *ScanService {
 	s.keepAlive = keepAlive
+	return s
+}
+
+// Fields specifies the fields the scan query should load.
+// By default fields is nil so _source is loaded
+func (s *ScanService) Fields(fields ...string) *ScanService {
+	s.fields = fields
 	return s
 }
 
@@ -156,6 +164,9 @@ func (s *ScanService) Do() (*ScanCursor, error) {
 	}
 	if s.size != nil && *s.size > 0 {
 		params.Set("size", fmt.Sprintf("%d", *s.size))
+	}
+	if s.fields != nil {
+		params.Set("fields", strings.Join(s.fields, ","))
 	}
 
 	// Set body

--- a/search_test.go
+++ b/search_test.go
@@ -24,11 +24,11 @@ func TestSearchMatchAll(t *testing.T) {
 	if searchResult.Hits == nil {
 		t.Errorf("expected SearchResult.Hits != nil; got nil")
 	}
-	if searchResult.Hits.TotalHits != 3 {
-		t.Errorf("expected SearchResult.Hits.TotalHits = %d; got %d", 3, searchResult.Hits.TotalHits)
+	if searchResult.Hits.TotalHits != 4 {
+		t.Errorf("expected SearchResult.Hits.TotalHits = %d; got %d", 4, searchResult.Hits.TotalHits)
 	}
-	if len(searchResult.Hits.Hits) != 3 {
-		t.Errorf("expected len(SearchResult.Hits.Hits) = %d; got %d", 3, len(searchResult.Hits.Hits))
+	if len(searchResult.Hits.Hits) != 4 {
+		t.Errorf("expected len(SearchResult.Hits.Hits) = %d; got %d", 4, len(searchResult.Hits.Hits))
 	}
 
 	for _, hit := range searchResult.Hits.Hits {
@@ -56,11 +56,11 @@ func BenchmarkSearchMatchAll(b *testing.B) {
 		if searchResult.Hits == nil {
 			b.Errorf("expected SearchResult.Hits != nil; got nil")
 		}
-		if searchResult.Hits.TotalHits != 3 {
-			b.Errorf("expected SearchResult.Hits.TotalHits = %d; got %d", 3, searchResult.Hits.TotalHits)
+		if searchResult.Hits.TotalHits != 4 {
+			b.Errorf("expected SearchResult.Hits.TotalHits = %d; got %d", 4, searchResult.Hits.TotalHits)
 		}
-		if len(searchResult.Hits.Hits) != 3 {
-			b.Errorf("expected len(SearchResult.Hits.Hits) = %d; got %d", 3, len(searchResult.Hits.Hits))
+		if len(searchResult.Hits.Hits) != 4 {
+			b.Errorf("expected len(SearchResult.Hits.Hits) = %d; got %d", 4, len(searchResult.Hits.Hits))
 		}
 	}
 }


### PR DESCRIPTION
The reindexer now takes a HitHandler than can emit any kind of BulkRequest
We provide a CopyToTargetIndex function to handle the common case of straighforward copying from one index to another.

