### PR TITLE
Allow sorting the results of an elasticsearch scroll

### DIFF
--- a/scan_test.go
+++ b/scan_test.go
@@ -93,6 +93,95 @@ func TestScan(t *testing.T) {
 	}
 }
 
+func TestScanWithSort(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch.", Retweets: 4}
+	tweet2 := tweet{User: "olivere", Message: "Another unrelated topic.", Retweets: 10}
+	tweet3 := tweet{User: "sandrae", Message: "Cycling is fun.", Retweets: 3}
+
+	// Add all documents
+	_, err := client.Index().Index(testIndexName).Type("tweet").Id("1").BodyJson(&tweet1).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Index().Index(testIndexName).Type("tweet").Id("2").BodyJson(&tweet2).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Index().Index(testIndexName).Type("tweet").Id("3").BodyJson(&tweet3).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Flush().Index(testIndexName).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We sort on a numerical field, because sorting on the 'message' string field would
+	// raise the whole question of tokenizing and analyzing.
+	cursor, err := client.Scan(testIndexName).Sort("retweets", true).Size(1).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cursor.Results == nil {
+		t.Errorf("expected results != nil; got nil")
+	}
+	if cursor.Results.Hits == nil {
+		t.Errorf("expected results.Hits != nil; got nil")
+	}
+	if cursor.Results.Hits.TotalHits != 3 {
+		t.Errorf("expected results.Hits.TotalHits = %d; got %d", 3, cursor.Results.Hits.TotalHits)
+	}
+	if len(cursor.Results.Hits.Hits) != 1 {
+		t.Errorf("expected len(results.Hits.Hits) = %d; got %d", 1, len(cursor.Results.Hits.Hits))
+	}
+
+	if cursor.Results.Hits.Hits[0].Id != "3" {
+		t.Errorf("expected hitID = %d; got %d", "3", cursor.Results.Hits.Hits[0].Id)
+
+	}
+
+	numDocs := 1 // The cursor already gave us a result
+	pages := 0
+
+	for {
+		searchResult, err := cursor.Next()
+		if err == EOS {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pages += 1
+
+		for _, hit := range searchResult.Hits.Hits {
+			if hit.Index != testIndexName {
+				t.Errorf("expected SearchResult.Hits.Hit.Index = %q; got %q", testIndexName, hit.Index)
+			}
+			item := make(map[string]interface{})
+			err := json.Unmarshal(*hit.Source, &item)
+			if err != nil {
+				t.Fatal(err)
+			}
+			numDocs += 1
+		}
+	}
+
+	if pages <= 0 {
+		t.Errorf("expected to retrieve at least 1 page; got %d", pages)
+	}
+
+	if numDocs != 3 {
+		t.Errorf("expected to retrieve %d hits; got %d", 3, numDocs)
+	}
+}
+
 func TestScanWithQuery(t *testing.T) {
 	client := setupTestClientAndCreateIndex(t)
 


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html

- Added two methods (a simple one + a comprehensive one) to specify the sort.
- Only set the search_type to scan if there is no sort applied.
- A unit test that shows a scroll request with a sort