### PR TITLE
Multi Get must not use underscore for 'fields'

### DIFF
--- a/multi_get.go
+++ b/multi_get.go
@@ -172,7 +172,7 @@ func (item *MultiGetItem) Source() interface{} {
 		source["_source"] = item.fsc.Source()
 	}
 	if item.fields != nil {
-		source["_fields"] = item.fields
+		source["fields"] = item.fields
 	}
 	if item.routing != "" {
 		source["_routing"] = item.routing


### PR DESCRIPTION
Regarding documentation mget must not use underscore for "fields": 
https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html#mget-fields

You can check it by this way:
curl -XGET es1:9200/_mget -d '{"docs" : [{"_id":1,"_index": "test_index","_fields":["name"]}]}’
curl -XGET es1:9200/_mget -d '{"docs" : [{"_id":1,"_index": "test_index","fields":["name"]}]}'