### PR TITLE
Fix memory leak NewTicker -> After

### DIFF
--- a/client.go
+++ b/client.go
@@ -512,7 +512,7 @@ func (c *Client) sniffer() {
 	for {
 		c.mu.RLock()
 		timeout := c.snifferTimeout
-		ticker := time.NewTicker(c.snifferInterval)
+		ticker := time.After(c.snifferInterval)
 		c.mu.RUnlock()
 
 		select {
@@ -520,7 +520,7 @@ func (c *Client) sniffer() {
 			// we are asked to stop, so we signal back that we're stopping now
 			c.snifferStop <- true
 			return
-		case <-ticker.C:
+		case <-ticker:
 			c.sniff(timeout)
 		}
 	}
@@ -678,7 +678,7 @@ func (c *Client) healthchecker() {
 	for {
 		c.mu.RLock()
 		timeout := c.healthcheckTimeout
-		ticker := time.NewTicker(c.healthcheckInterval)
+		ticker := time.After(c.healthcheckInterval)
 		c.mu.RUnlock()
 
 		select {
@@ -686,7 +686,7 @@ func (c *Client) healthchecker() {
 			// we are asked to stop, so we signal back that we're stopping now
 			c.healthcheckStop <- true
 			return
-		case <-ticker.C:
+		case <-ticker:
 			c.healthcheck(timeout, false)
 		}
 	}


### PR DESCRIPTION
My long running application is showing a memory leak that profiles to the elastic search client.  Calling time. NewTicker() without calling Stop() on the ticker will create a memory leak.  Replace with After() to resolve.