### PR TITLE
fix percolation on an existing document

### DIFF
--- a/percolate.go
+++ b/percolate.go
@@ -178,11 +178,20 @@ func (s *PercolateService) BodyString(body string) *PercolateService {
 // buildURL builds the URL for the operation.
 func (s *PercolateService) buildURL() (string, url.Values, error) {
 	// Build URL
-	path, err := uritemplates.Expand("/{index}/{type}/_percolate", map[string]string{
-		"index": s.index,
-		"type":  s.typ,
-		"id":    s.id,
-	})
+	var path string
+	var err error
+	if s.id == "" {
+		path, err = uritemplates.Expand("/{index}/{type}/_percolate", map[string]string{
+			"index": s.index,
+			"type":  s.typ,
+		})
+	} else {
+		path, err = uritemplates.Expand("/{index}/{type}/{id}/_percolate", map[string]string{
+			"index": s.index,
+			"type":  s.typ,
+			"id":    s.id,
+		})
+	}
 	if err != nil {
 		return "", url.Values{}, err
 	}

--- a/percolate_test.go
+++ b/percolate_test.go
@@ -56,4 +56,33 @@ func TestPercolate(t *testing.T) {
 	if matches[0].Id != "1" {
 		t.Errorf("expected to return query %q; got: %q", "1", matches[0].Id)
 	}
+
+	// Percolating an existsing document should return our registered query
+	res, err = client.Percolate().
+		Index(testIndexName).Type("tweet").
+		Id("1").
+		Pretty(true).
+		Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Errorf("expected results != nil; got nil")
+	}
+	if res.Total != 1 {
+		t.Fatalf("expected 1 result; got: %d", res.Total)
+	}
+	if res.Matches == nil {
+		t.Fatalf("expected Matches; got: %v", res.Matches)
+	}
+	matches = res.Matches
+	if matches == nil {
+		t.Fatalf("expected matches as map; got: %v", matches)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected %d registered matches; got: %d", 1, len(matches))
+	}
+	if matches[0].Id != "1" {
+		t.Errorf("expected to return query %q; got: %q", "1", matches[0].Id)
+	}
 }


### PR DESCRIPTION
Percolation on an existing document did not work because id was not being included in the url.