### PR TITLE
Use capacity instead of length

### DIFF
--- a/search.go
+++ b/search.go
@@ -67,7 +67,7 @@ func (s *SearchService) Index(index string) *SearchService {
 // Indices sets the names of the indices to use for search.
 func (s *SearchService) Indices(indices ...string) *SearchService {
 	if s.indices == nil {
-		s.indices = make([]string, 0)
+		s.indices = make([]string, 0, len(indices))
 	}
 	s.indices = append(s.indices, indices...)
 	return s
@@ -86,7 +86,7 @@ func (s *SearchService) Type(typ string) *SearchService {
 // Types allows to restrict the search to a list of types.
 func (s *SearchService) Types(types ...string) *SearchService {
 	if s.types == nil {
-		s.types = make([]string, len(types))
+		s.types = make([]string, 0, len(types))
 	}
 	s.types = append(s.types, types...)
 	return s


### PR DESCRIPTION
This doesn't cause error, however this currently generates a bit strange path.
So I fixed as follows.

current path
```
http://localhost:9200/my_blog/,,,,titles,contents,tags,comments/_search
```

fixed path
```
http://localhost:9200/my_blog/titles,contents,tags,comments/_search
```