### PR TITLE
Fixed issue with fuzzy query in completion suggestions

### DIFF
--- a/suggester_completion_fuzzy.go
+++ b/suggester_completion_fuzzy.go
@@ -139,9 +139,9 @@ func (q FuzzyCompletionSuggester) Source(includeName bool) interface{} {
 	}
 
 	// Fuzzy Completion Suggester fields
-	if q.fuzziness != nil {
-		suggester["fuzziness"] = q.fuzziness
-	}
+    if q.fuzziness != nil {
+        suggester["fuzzy"] = map[string]interface{}{"fuzziness": q.fuzziness}
+    }
 	if q.fuzzyTranspositions != nil {
 		suggester["transpositions"] = *q.fuzzyTranspositions
 	}

--- a/suggester_completion_fuzzy.go
+++ b/suggester_completion_fuzzy.go
@@ -139,9 +139,9 @@ func (q FuzzyCompletionSuggester) Source(includeName bool) interface{} {
 	}
 
 	// Fuzzy Completion Suggester fields
-    if q.fuzziness != nil {
-        suggester["fuzzy"] = map[string]interface{}{"fuzziness": q.fuzziness}
-    }
+	if q.fuzziness != nil {
+		suggester["fuzzy"] = map[string]interface{}{"fuzziness": q.fuzziness}
+	}
 	if q.fuzzyTranspositions != nil {
 		suggester["transpositions"] = *q.fuzzyTranspositions
 	}

--- a/suggester_completion_fuzzy_test.go
+++ b/suggester_completion_fuzzy_test.go
@@ -19,7 +19,7 @@ func TestFuzzyCompletionSuggesterSource(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzzy":{fuzziness":2}}}}`
+	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzzy":{"fuzziness":2}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/suggester_completion_fuzzy_test.go
+++ b/suggester_completion_fuzzy_test.go
@@ -19,7 +19,7 @@ func TestFuzzyCompletionSuggesterSource(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzziness":2}}}`
+	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzzy":{fuzziness":2}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -35,7 +35,7 @@ func TestFuzzyCompletionSuggesterWithStringFuzzinessSource(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzziness":"1..4"}}}`
+	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzzy":{"fuzziness":"1..4"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/suggester_completion_fuzzy_test.go
+++ b/suggester_completion_fuzzy_test.go
@@ -19,7 +19,7 @@ func TestFuzzyCompletionSuggesterSource(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzzy":{fuzziness":2}}}`
+	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzzy":{fuzziness":2}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -35,7 +35,7 @@ func TestFuzzyCompletionSuggesterWithStringFuzzinessSource(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzzy":{"fuzziness":"1..4"}}}`
+	expected := `{"song-suggest":{"text":"n","completion":{"field":"suggest","fuzzy":{"fuzziness":"1..4"}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
Found a minor issue with fuzzy query in completion suggestion. 

File : suggester_completion_fuzzy
Line : 143
Code:
	if q.fuzziness != nil {
		suggester["fuzziness"] = q.fuzziness
	}

Suggestion:
    if q.fuzziness != nil {
        suggester["fuzzy"] = map[string]interface{}{"fuzziness": q.fuzziness}
    }

Kindly review it and give suggestions.