### PR TITLE
Add optional format parameter to date range filter and query

### DIFF
--- a/search_filters_range.go
+++ b/search_filters_range.go
@@ -13,6 +13,7 @@ type RangeFilter struct {
 	from         *interface{}
 	to           *interface{}
 	timeZone     string
+	format       string
 	includeLower bool
 	includeUpper bool
 	cache        *bool
@@ -28,6 +29,11 @@ func NewRangeFilter(name string) RangeFilter {
 
 func (f RangeFilter) TimeZone(timeZone string) RangeFilter {
 	f.timeZone = timeZone
+	return f
+}
+
+func (f RangeFilter) Format(format string) RangeFilter {
+	f.format = format
 	return f
 }
 
@@ -116,6 +122,9 @@ func (f RangeFilter) Source() interface{} {
 	params["to"] = f.to
 	if f.timeZone != "" {
 		params["time_zone"] = f.timeZone
+	}
+	if f.format != "" {
+		params["format"] = f.format
 	}
 	params["include_lower"] = f.includeLower
 	params["include_upper"] = f.includeUpper

--- a/search_filters_range_test.go
+++ b/search_filters_range_test.go
@@ -56,3 +56,19 @@ func TestRangeFilterWithTimeZone(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestRangeFilterWithFormat(t *testing.T) {
+	f := NewRangeFilter("born").
+		Gte("2012/01/01").
+		Lte("now").
+		Format("yyyy/MM/dd")
+	data, err := json.Marshal(f.Source())
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"range":{"born":{"format":"yyyy/MM/dd","from":"2012/01/01","include_lower":true,"include_upper":true,"to":"now"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}

--- a/search_queries_range.go
+++ b/search_queries_range.go
@@ -25,9 +25,9 @@ func NewRangeQuery(name string) RangeQuery {
 	return q
 }
 
-func (f RangeQuery) TimeZone(timeZone string) RangeQuery {
-	f.timeZone = timeZone
-	return f
+func (q RangeQuery) TimeZone(timeZone string) RangeQuery {
+	q.timeZone = timeZone
+	return q
 }
 
 func (q RangeQuery) From(from interface{}) RangeQuery {

--- a/search_queries_range.go
+++ b/search_queries_range.go
@@ -13,6 +13,7 @@ type RangeQuery struct {
 	from         *interface{}
 	to           *interface{}
 	timeZone     string
+	format       string
 	includeLower bool
 	includeUpper bool
 	boost        *float64
@@ -31,6 +32,11 @@ func (f RangeQuery) TimeZone(timeZone string) RangeQuery {
 
 func (q RangeQuery) From(from interface{}) RangeQuery {
 	q.from = &from
+	return q
+}
+
+func (q RangeQuery) Format(format string) RangeQuery {
+	q.format = format
 	return q
 }
 
@@ -104,6 +110,9 @@ func (q RangeQuery) Source() interface{} {
 	params["to"] = q.to
 	if q.timeZone != "" {
 		params["time_zone"] = q.timeZone
+	}
+	if q.format != "" {
+		params["format"] = q.format
 	}
 	params["include_lower"] = q.includeLower
 	params["include_upper"] = q.includeUpper

--- a/search_queries_range_test.go
+++ b/search_queries_range_test.go
@@ -53,3 +53,19 @@ func TestRangeQueryWithTimeZone(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestRangeQueryWithFormat(t *testing.T) {
+	f := NewRangeQuery("born").
+		Gte("2012/01/01").
+		Lte("now").
+		Format("yyyy/MM/dd")
+	data, err := json.Marshal(f.Source())
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"range":{"born":{"format":"yyyy/MM/dd","from":"2012/01/01","include_lower":true,"include_upper":true,"to":"now"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
I noticed that the ``format`` parameter was missing in your range query and filter implementations. See also https://github.com/elastic/elasticsearch/commit/462956fd478ba852d05373d9875c5fcd0dd40d28.