### PR TITLE
Use the provided http client to do the healthcheck on startup.

### DIFF
--- a/client.go
+++ b/client.go
@@ -752,9 +752,8 @@ func (c *Client) startupHealthcheck(timeout time.Duration) error {
 	// If we don't get a connection after "timeout", we bail.
 	start := time.Now()
 	for {
-		cl := &http.Client{Timeout: timeout}
 		for _, url := range urls {
-			res, err := cl.Head(url)
+			res, err := c.c.Head(url)
 			if err == nil && res != nil && res.StatusCode >= 200 && res.StatusCode < 300 {
 				return nil
 			}


### PR DESCRIPTION
If a user provides a custom httpClient in the `NewClient`, we need to use that to do the healthcheck. In my case, I have added basic auth to the transport which is required to do a successful healthcheck.