### PR TITLE
parse update result when the body contain error info and status

### DIFF
--- a/update.go
+++ b/update.go
@@ -20,6 +20,8 @@ type UpdateResult struct {
 	Id        string     `json:"_id"`
 	Version   int        `json:"_version"`
 	Created   bool       `json:"created"`
+	Error     string     `json:"error"`
+	Status    int        `json:"status"`
 	GetResult *GetResult `json:"get"`
 }
 


### PR DESCRIPTION
I found when i update an index not exist. the elastic server will get this error 
`{
  "error": "DocumentMissingException[[xxxxx][1] [room][56334545f6576e24c6000001_56334545f6576e24c6000005]: document missing]",
  "status": 404
}`

but i can't find the define in the UpdateResult, so i can't get the all info of the result.

so I add these two fields in the UpdateResult struct Error for get error info, Status for get Status info.