### PR TITLE
Add Term Vectors API for Elasticsearch 1.x (elastic.v2)

### DIFF
--- a/client.go
+++ b/client.go
@@ -1381,3 +1381,11 @@ func (c *Client) WaitForGreenStatus(timeout string) error {
 func (c *Client) WaitForYellowStatus(timeout string) error {
 	return c.WaitForStatus("yellow", timeout)
 }
+
+// TermVector returns information and statistics on terms in the fields
+// of a particular document.
+func (c *Client) TermVector(index, typ, id string) *TermvectorService {
+	builder := NewTermvectorService(c)
+	builder = builder.Index(index).Type(typ).Id(id)
+	return builder
+}

--- a/client.go
+++ b/client.go
@@ -1384,8 +1384,8 @@ func (c *Client) WaitForYellowStatus(timeout string) error {
 
 // TermVector returns information and statistics on terms in the fields
 // of a particular document.
-func (c *Client) TermVector(index, typ, id string) *TermvectorService {
+func (c *Client) TermVector(index, typ string) *TermvectorService {
 	builder := NewTermvectorService(c)
-	builder = builder.Index(index).Type(typ).Id(id)
+	builder = builder.Index(index).Type(typ)
 	return builder
 }

--- a/termvector.go
+++ b/termvector.go
@@ -44,91 +44,91 @@ func NewTermvectorService(client *Client) *TermvectorService {
 	}
 }
 
-// Index is documented as: The index in which the document resides..
+// Index is documented as: The index in which the document resides.
 func (s *TermvectorService) Index(index string) *TermvectorService {
 	s.index = index
 	return s
 }
 
-// Type is documented as: The type of the document..
+// Type is documented as: The type of the document.
 func (s *TermvectorService) Type(typ string) *TermvectorService {
 	s.typ = typ
 	return s
 }
 
-// Id is documented as: The id of the document..
+// Id is documented as: The id of the document.
 func (s *TermvectorService) Id(id string) *TermvectorService {
 	s.id = id
 	return s
 }
 
-// Doc is documented as: The document to analyze..
+// Doc is documented as: The document to analyze.
 func (s *TermvectorService) Doc(doc map[string]string) *TermvectorService {
 	s.doc = doc
 	return s
 }
 
-// FieldStatistics is documented as: Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned..
+// FieldStatistics is documented as: Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.
 func (s *TermvectorService) FieldStatistics(fieldStatistics bool) *TermvectorService {
 	s.fieldStatistics = &fieldStatistics
 	return s
 }
 
-// Fields is documented as: A comma-separated list of fields to return..
+// Fields is documented as: A comma-separated list of fields to return.
 func (s *TermvectorService) Fields(fields []string) *TermvectorService {
 	s.fields = fields
 	return s
 }
 
-// PerFieldAnalyzer is documented as: A different analyzer than the one at the field may be provided..
+// PerFieldAnalyzer is documented as: A different analyzer than the one at the field may be provided.
 func (s *TermvectorService) PerFieldAnalyzer(perFieldAnalyzer map[string]string) *TermvectorService {
 	s.perFieldAnalyzer = perFieldAnalyzer
 	return s
 }
 
-// Offsets is documented as: Specifies if term offsets should be returned..
+// Offsets is documented as: Specifies if term offsets should be returned.
 func (s *TermvectorService) Offsets(offsets bool) *TermvectorService {
 	s.offsets = &offsets
 	return s
 }
 
-// Parent id of documents..
+// Parent id of documents.
 func (s *TermvectorService) Parent(parent string) *TermvectorService {
 	s.parent = parent
 	return s
 }
 
-// Payloads is documented as: Specifies if term payloads should be returned..
+// Payloads is documented as: Specifies if term payloads should be returned.
 func (s *TermvectorService) Payloads(payloads bool) *TermvectorService {
 	s.payloads = &payloads
 	return s
 }
 
-// Positions is documented as: Specifies if term positions should be returned..
+// Positions is documented as: Specifies if term positions should be returned.
 func (s *TermvectorService) Positions(positions bool) *TermvectorService {
 	s.positions = &positions
 	return s
 }
 
-// Preference is documented as: Specify the node or shard the operation should be performed on (default: random)..
+// Preference is documented as: Specify the node or shard the operation should be performed on (default: random).
 func (s *TermvectorService) Preference(preference string) *TermvectorService {
 	s.preference = preference
 	return s
 }
 
-// Realtime is documented as: Specifies if request is real-time as opposed to near-real-time (default: true)..
+// Realtime is documented as: Specifies if request is real-time as opposed to near-real-time (default: true).
 func (s *TermvectorService) Realtime(realtime bool) *TermvectorService {
 	s.realtime = &realtime
 	return s
 }
 
-// Routing is documented as: Specific routing value..
+// Routing is documented as: Specific routing value.
 func (s *TermvectorService) Routing(routing string) *TermvectorService {
 	s.routing = routing
 	return s
 }
 
-// TermStatistics is documented as: Specifies if total term frequency and document frequency should be returned..
+// TermStatistics is documented as: Specifies if total term frequency and document frequency should be returned.
 func (s *TermvectorService) TermStatistics(termStatistics bool) *TermvectorService {
 	s.termStatistics = &termStatistics
 	return s
@@ -140,13 +140,13 @@ func (s *TermvectorService) Pretty(pretty bool) *TermvectorService {
 	return s
 }
 
-// BodyJson is documented as: Define parameters. See documentation..
+// BodyJson is documented as: Define parameters. See documentation.
 func (s *TermvectorService) BodyJson(body interface{}) *TermvectorService {
 	s.bodyJson = body
 	return s
 }
 
-// BodyString is documented as: Define parameters. See documentation..
+// BodyString is documented as: Define parameters. See documentation.
 func (s *TermvectorService) BodyString(body string) *TermvectorService {
 	s.bodyString = body
 	return s

--- a/termvector.go
+++ b/termvector.go
@@ -265,10 +265,11 @@ type TermVectorsFieldInfo struct {
 
 // TermvectorResponse is the response of TermvectorService.Do.
 type TermvectorResponse struct {
-	Id          string                          `json:"_id"`
 	Index       string                          `json:"_index"`
 	Type        string                          `json:"_type"`
+	Id          string                          `json:"_id,omitempty"`
 	Version     int                             `json:"_version"`
 	Found       bool                            `json:"found"`
+	Took        int64                           `json:"took"`
 	TermVectors map[string]TermVectorsFieldInfo `json:"term_vectors"`
 }

--- a/termvector.go
+++ b/termvector.go
@@ -20,10 +20,10 @@ type TermvectorService struct {
 	index            string
 	typ              string
 	id               string
-	doc              *map[string]string
+	doc              map[string]string
 	fieldStatistics  *bool
 	fields           []string
-	perFieldAnalyzer *map[string]string
+	perFieldAnalyzer map[string]string
 	offsets          *bool
 	parent           string
 	payloads         *bool
@@ -63,7 +63,7 @@ func (s *TermvectorService) Id(id string) *TermvectorService {
 }
 
 // Doc is documented as: The document to analyze..
-func (s *TermvectorService) Doc(doc *map[string]string) *TermvectorService {
+func (s *TermvectorService) Doc(doc map[string]string) *TermvectorService {
 	s.doc = doc
 	return s
 }
@@ -81,7 +81,7 @@ func (s *TermvectorService) Fields(fields []string) *TermvectorService {
 }
 
 // PerFieldAnalyzer is documented as: A different analyzer than the one at the field may be provided..
-func (s *TermvectorService) PerFieldAnalyzer(perFieldAnalyzer *map[string]string) *TermvectorService {
+func (s *TermvectorService) PerFieldAnalyzer(perFieldAnalyzer map[string]string) *TermvectorService {
 	s.perFieldAnalyzer = perFieldAnalyzer
 	return s
 }
@@ -247,11 +247,11 @@ func (s *TermvectorService) Do() (*TermvectorResponse, error) {
 		body = s.bodyString
 	} else if s.doc != nil || s.perFieldAnalyzer != nil {
 		data := make(map[string]map[string]string, 2)
-		if s.doc != nil {
-			data["doc"] = *s.doc
+		if len(s.doc) > 0 {
+			data["doc"] = s.doc
 		}
-		if s.perFieldAnalyzer != nil {
-			data["per_field_analyzer"] = *s.perFieldAnalyzer
+		if len(s.perFieldAnalyzer) > 0 {
+			data["per_field_analyzer"] = s.perFieldAnalyzer
 		}
 		body = data
 	} else {

--- a/termvector.go
+++ b/termvector.go
@@ -1,0 +1,274 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"gopkg.in/olivere/elastic.v2/uritemplates"
+)
+
+// TermvectorService is documented at https://www.elastic.co/guide/en/elasticsearch/reference/1.7/docs-termvectors.html.
+type TermvectorService struct {
+	client          *Client
+	pretty          bool
+	index           string
+	typ             string
+	id              string
+	fieldStatistics *bool
+	fields          []string
+	offsets         *bool
+	parent          string
+	payloads        *bool
+	positions       *bool
+	preference      string
+	realtime        *bool
+	routing         string
+	termStatistics  *bool
+	bodyJson        interface{}
+	bodyString      string
+}
+
+// NewTermvectorService creates a new TermvectorService.
+func NewTermvectorService(client *Client) *TermvectorService {
+	return &TermvectorService{
+		client: client,
+		fields: make([]string, 0),
+	}
+}
+
+// Index is documented as: The index in which the document resides..
+func (s *TermvectorService) Index(index string) *TermvectorService {
+	s.index = index
+	return s
+}
+
+// Type is documented as: The type of the document..
+func (s *TermvectorService) Type(typ string) *TermvectorService {
+	s.typ = typ
+	return s
+}
+
+// Id is documented as: The id of the document..
+func (s *TermvectorService) Id(id string) *TermvectorService {
+	s.id = id
+	return s
+}
+
+// FieldStatistics is documented as: Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned..
+func (s *TermvectorService) FieldStatistics(fieldStatistics bool) *TermvectorService {
+	s.fieldStatistics = &fieldStatistics
+	return s
+}
+
+// Fields is documented as: A comma-separated list of fields to return..
+func (s *TermvectorService) Fields(fields []string) *TermvectorService {
+	s.fields = fields
+	return s
+}
+
+// Offsets is documented as: Specifies if term offsets should be returned..
+func (s *TermvectorService) Offsets(offsets bool) *TermvectorService {
+	s.offsets = &offsets
+	return s
+}
+
+// Parent id of documents..
+func (s *TermvectorService) Parent(parent string) *TermvectorService {
+	s.parent = parent
+	return s
+}
+
+// Payloads is documented as: Specifies if term payloads should be returned..
+func (s *TermvectorService) Payloads(payloads bool) *TermvectorService {
+	s.payloads = &payloads
+	return s
+}
+
+// Positions is documented as: Specifies if term positions should be returned..
+func (s *TermvectorService) Positions(positions bool) *TermvectorService {
+	s.positions = &positions
+	return s
+}
+
+// Preference is documented as: Specify the node or shard the operation should be performed on (default: random)..
+func (s *TermvectorService) Preference(preference string) *TermvectorService {
+	s.preference = preference
+	return s
+}
+
+// Realtime is documented as: Specifies if request is real-time as opposed to near-real-time (default: true)..
+func (s *TermvectorService) Realtime(realtime bool) *TermvectorService {
+	s.realtime = &realtime
+	return s
+}
+
+// Routing is documented as: Specific routing value..
+func (s *TermvectorService) Routing(routing string) *TermvectorService {
+	s.routing = routing
+	return s
+}
+
+// TermStatistics is documented as: Specifies if total term frequency and document frequency should be returned..
+func (s *TermvectorService) TermStatistics(termStatistics bool) *TermvectorService {
+	s.termStatistics = &termStatistics
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *TermvectorService) Pretty(pretty bool) *TermvectorService {
+	s.pretty = pretty
+	return s
+}
+
+// BodyJson is documented as: Define parameters. See documentation..
+func (s *TermvectorService) BodyJson(body interface{}) *TermvectorService {
+	s.bodyJson = body
+	return s
+}
+
+// BodyString is documented as: Define parameters. See documentation..
+func (s *TermvectorService) BodyString(body string) *TermvectorService {
+	s.bodyString = body
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *TermvectorService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/{index}/{type}/{id}/_termvector", map[string]string{
+		"index": s.index,
+		"type":  s.typ,
+		"id":    s.id,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "1")
+	}
+	if s.fieldStatistics != nil {
+		params.Set("field_statistics", fmt.Sprintf("%v", *s.fieldStatistics))
+	}
+	if len(s.fields) > 0 {
+		params.Set("fields", strings.Join(s.fields, ","))
+	}
+	if s.offsets != nil {
+		params.Set("offsets", fmt.Sprintf("%v", *s.offsets))
+	}
+	if s.parent != "" {
+		params.Set("parent", s.parent)
+	}
+	if s.payloads != nil {
+		params.Set("payloads", fmt.Sprintf("%v", *s.payloads))
+	}
+	if s.positions != nil {
+		params.Set("positions", fmt.Sprintf("%v", *s.positions))
+	}
+	if s.preference != "" {
+		params.Set("preference", s.preference)
+	}
+	if s.realtime != nil {
+		params.Set("realtime", fmt.Sprintf("%v", *s.realtime))
+	}
+	if s.routing != "" {
+		params.Set("routing", s.routing)
+	}
+	if s.termStatistics != nil {
+		params.Set("term_statistics", fmt.Sprintf("%v", *s.termStatistics))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *TermvectorService) Validate() error {
+	var invalid []string
+	if s.index == "" {
+		invalid = append(invalid, "Index")
+	}
+	if s.typ == "" {
+		invalid = append(invalid, "Type")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *TermvectorService) Do() (*TermvectorResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup HTTP request body
+	var body interface{}
+	if s.bodyJson != nil {
+		body = s.bodyJson
+	} else {
+		body = s.bodyString
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest("GET", path, params, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(TermvectorResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+type TokenInfo struct {
+	StartOffset int64  `json:"start_offset"`
+	EndOffset   int64  `json:"end_offset"`
+	Position    int64  `json:"position"`
+	Payload     string `json:"payload"`
+}
+
+type TermsInfo struct {
+	DocFreq  int64       `json:"doc_freq"`
+	TermFreq int64       `json:"term_freq"`
+	Ttf      int64       `json:"ttf"`
+	Tokens   []TokenInfo `json:"tokens"`
+}
+
+type FieldStatistics struct {
+	DocCount   int64 `json:"doc_count"`
+	SumDocFreq int64 `json"sum_doc_freq""`
+	SumTtf     int64 `json:"sum_ttf"`
+}
+
+type TermVectorsFieldInfo struct {
+	FieldStatistics FieldStatistics      `json:"field_statistics"`
+	Terms           map[string]TermsInfo `json:"terms"`
+}
+
+// TermvectorResponse is the response of TermvectorService.Do.
+type TermvectorResponse struct {
+	Id          string                          `json:"_id"`
+	Index       string                          `json:"_index"`
+	Type        string                          `json:"_type"`
+	Version     int                             `json:"_version"`
+	Found       bool                            `json:"found"`
+	TermVectors map[string]TermVectorsFieldInfo `json:"term_vectors"`
+}

--- a/termvector_test.go
+++ b/termvector_test.go
@@ -28,7 +28,8 @@ func TestTermVectorWithId(t *testing.T) {
 
 	// TermVectors by specifying ID
 	field := "Message"
-	result, err := client.TermVector(testIndexName, "tweet", "1").
+	result, err := client.TermVector(testIndexName, "tweet").
+		Id("1").
 		Fields([]string{field}).
 		FieldStatistics(true).
 		TermStatistics(true).
@@ -59,7 +60,7 @@ func TestTermVectorWithDoc(t *testing.T) {
 		"fullname": "keyword",
 	}
 
-	result, err := client.TermVector(testIndexName, "tweet", "").
+	result, err := client.TermVector(testIndexName, "tweet").
 		Doc(doc).
 		PerFieldAnalyzer(perFieldAnalyzer).
 		FieldStatistics(true).

--- a/termvector_test.go
+++ b/termvector_test.go
@@ -60,8 +60,8 @@ func TestTermVectorWithDoc(t *testing.T) {
 	}
 
 	result, err := client.TermVector(testIndexName, "tweet", "").
-		Doc(&doc).
-		PerFieldAnalyzer(&perFieldAnalyzer).
+		Doc(doc).
+		PerFieldAnalyzer(perFieldAnalyzer).
 		FieldStatistics(true).
 		TermStatistics(true).
 		Do()

--- a/termvector_test.go
+++ b/termvector_test.go
@@ -42,4 +42,7 @@ func TestTermVector(t *testing.T) {
 	if !result.Found {
 		t.Errorf("expected found to be %v; got: %v", true, result.Found)
 	}
+	if result.Took <= 0 {
+		t.Errorf("expected took in millis > 0 got: %v", result.Took)
+	}
 }

--- a/termvector_test.go
+++ b/termvector_test.go
@@ -6,7 +6,7 @@ package elastic
 
 import "testing"
 
-func TestTermVector(t *testing.T) {
+func TestTermVectorWithId(t *testing.T) {
 	client := setupTestClientAndCreateIndex(t)
 
 	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
@@ -26,10 +26,42 @@ func TestTermVector(t *testing.T) {
 		t.Errorf("expected result to be != nil; got: %v", indexResult)
 	}
 
-	// TermVectors
+	// TermVectors by specifying ID
 	field := "Message"
 	result, err := client.TermVector(testIndexName, "tweet", "1").
 		Fields([]string{field}).
+		FieldStatistics(true).
+		TermStatistics(true).
+		Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil {
+		t.Fatal("expected to return information and statistics")
+	}
+	if !result.Found {
+		t.Errorf("expected found to be %v; got: %v", true, result.Found)
+	}
+	if result.Took <= 0 {
+		t.Errorf("expected took in millis > 0 got: %v", result.Took)
+	}
+}
+
+func TestTermVectorWithDoc(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	// TermVectors by specifying Doc
+	var doc = map[string]string{
+		"fullname": "John Doe",
+		"text":     "twitter test test test",
+	}
+	var perFieldAnalyzer = map[string]string{
+		"fullname": "keyword",
+	}
+
+	result, err := client.TermVector(testIndexName, "tweet", "").
+		Doc(&doc).
+		PerFieldAnalyzer(&perFieldAnalyzer).
 		FieldStatistics(true).
 		TermStatistics(true).
 		Do()

--- a/termvector_test.go
+++ b/termvector_test.go
@@ -1,0 +1,45 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "testing"
+
+func TestTermVector(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
+
+	// Add a document
+	indexResult, err := client.Index().
+		Index(testIndexName).
+		Type("tweet").
+		Id("1").
+		BodyJson(&tweet1).
+		Refresh(true).
+		Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if indexResult == nil {
+		t.Errorf("expected result to be != nil; got: %v", indexResult)
+	}
+
+	// TermVectors
+	field := "Message"
+	result, err := client.TermVector(testIndexName, "tweet", "1").
+		Fields([]string{field}).
+		FieldStatistics(true).
+		TermStatistics(true).
+		Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil {
+		t.Fatal("expected to return information and statistics")
+	}
+	if !result.Found {
+		t.Errorf("expected found to be %v; got: %v", true, result.Found)
+	}
+}

--- a/termvector_test.go
+++ b/termvector_test.go
@@ -79,3 +79,41 @@ func TestTermVectorWithDoc(t *testing.T) {
 		t.Errorf("expected took in millis > 0 got: %v", result.Took)
 	}
 }
+
+func TestTermVectorBuildURL(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	tests := []struct {
+		Index    string
+		Type     string
+		Id       string
+		Expected string
+	}{
+		{
+			"twitter",
+			"tweet",
+			"",
+			"/twitter/tweet/_termvector",
+		},
+		{
+			"twitter",
+			"tweet",
+			"1",
+			"/twitter/tweet/1/_termvector",
+		},
+	}
+
+	for _, test := range tests {
+		builder := client.TermVector(test.Index, test.Type)
+		if test.Id != "" {
+			builder = builder.Id(test.Id)
+		}
+		path, _, err := builder.buildURL()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if path != test.Expected {
+			t.Errorf("expected %q; got: %q", test.Expected, path)
+		}
+	}
+}


### PR DESCRIPTION
I found elastic doesn't support Term Vector API now. So, I have made the mappings to call the *termvector* API. This is my first contribution to elastic. It might not be satisfied with contributing guidelines. If so, tell me how to do completely and I'll fix it.

Term Vector API has improved Elasticsearch 2.x. For example, it renamed _termvector_ to _termvector**s**_ . This PR is for Elasticsearch 1.x.

* https://www.elastic.co/guide/en/elasticsearch/reference/1.7/docs-termvectors.html