### PR TITLE
Add services to get, put and delete warmers

### DIFF
--- a/client.go
+++ b/client.go
@@ -1287,6 +1287,21 @@ func (c *Client) PutMapping() *PutMappingService {
 	return NewPutMappingService(c)
 }
 
+// GetWarmer gets a mapping.
+func (c *Client) GetWarmer() *GetWarmerService {
+	return NewGetWarmerService(c)
+}
+
+// PutWarmer registers a warmer.
+func (c *Client) PutWarmer() *PutWarmerService {
+	return NewPutWarmerService(c)
+}
+
+// DeleteWarmer deletes a warmer.
+func (c *Client) DeleteWarmer() *DeleteWarmerService {
+	return NewDeleteWarmerService(c)
+}
+
 // -- cat APIs --
 
 // TODO cat aliases

--- a/indices_delete_warmer.go
+++ b/indices_delete_warmer.go
@@ -1,0 +1,142 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/olivere/elastic/uritemplates"
+)
+
+var (
+	_ = fmt.Print
+	_ = httputil.DumpRequest
+	_ = log.Print
+	_ = strings.Index
+	_ = uritemplates.Expand
+	_ = url.Parse
+)
+
+// DeleteWarmerService allows to delete a warmer.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-warmers.html.
+type DeleteWarmerService struct {
+	client        *Client
+	pretty        bool
+	index         []string
+	name          []string
+	masterTimeout string
+}
+
+// NewDeleteWarmerService creates a new DeleteWarmerService.
+func NewDeleteWarmerService(client *Client) *DeleteWarmerService {
+	return &DeleteWarmerService{
+		client: client,
+		index:  make([]string, 0),
+		name:   make([]string, 0),
+	}
+}
+
+// Index is a list of index names the mapping should be added to
+// (supports wildcards); use `_all` or omit to add the mapping on all indices.
+func (s *DeleteWarmerService) Index(indices ...string) *DeleteWarmerService {
+	s.index = append(s.index, indices...)
+	return s
+}
+
+// Name is a list of warmer names to delete (supports wildcards);
+// use `_all` to delete all warmers in the specified indices.
+func (s *DeleteWarmerService) Name(name ...string) *DeleteWarmerService {
+	s.name = append(s.name, name...)
+	return s
+}
+
+// MasterTimeout specifies the timeout for connection to master.
+func (s *DeleteWarmerService) MasterTimeout(masterTimeout string) *DeleteWarmerService {
+	s.masterTimeout = masterTimeout
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *DeleteWarmerService) Pretty(pretty bool) *DeleteWarmerService {
+	s.pretty = pretty
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *DeleteWarmerService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/{index}/_warmer/{name}", map[string]string{
+		"index": strings.Join(s.index, ","),
+		"name":  strings.Join(s.name, ","),
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "1")
+	}
+	if s.masterTimeout != "" {
+		params.Set("master_timeout", s.masterTimeout)
+	}
+	if len(s.name) > 0 {
+		params.Set("name", strings.Join(s.name, ","))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *DeleteWarmerService) Validate() error {
+	var invalid []string
+	if len(s.index) == 0 {
+		invalid = append(invalid, "Index")
+	}
+	if len(s.name) == 0 {
+		invalid = append(invalid, "Name")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *DeleteWarmerService) Do() (*DeleteWarmerResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest("DELETE", path, params, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(DeleteWarmerResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// DeleteWarmerResponse is the response of DeleteWarmerService.Do.
+type DeleteWarmerResponse struct {
+	Acknowledged bool `json:"acknowledged"`
+}

--- a/indices_get_warmer.go
+++ b/indices_get_warmer.go
@@ -1,0 +1,187 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/olivere/elastic/uritemplates"
+)
+
+var (
+	_ = fmt.Print
+	_ = httputil.DumpRequest
+	_ = log.Print
+	_ = strings.Index
+	_ = uritemplates.Expand
+	_ = url.Parse
+)
+
+// GetWarmerService allows to get the definition of a warmer.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-warmers.html.
+type GetWarmerService struct {
+	client            *Client
+	pretty            bool
+	index             []string
+	name              []string
+	typ               []string
+	allowNoIndices    *bool
+	expandWildcards   string
+	ignoreUnavailable *bool
+	local             *bool
+}
+
+// NewGetWarmerService creates a new GetWarmerService.
+func NewGetWarmerService(client *Client) *GetWarmerService {
+	return &GetWarmerService{
+		client: client,
+		typ:    make([]string, 0),
+		index:  make([]string, 0),
+		name:   make([]string, 0),
+	}
+}
+
+// Index is a list of index names to restrict the operation; use `_all` to perform the operation on all indices.
+func (s *GetWarmerService) Index(indices ...string) *GetWarmerService {
+	s.index = append(s.index, indices...)
+	return s
+}
+
+// Name is the name of the warmer (supports wildcards); leave empty to get all warmers.
+func (s *GetWarmerService) Name(name ...string) *GetWarmerService {
+	s.name = append(s.name, name...)
+	return s
+}
+
+// Type is a list of type names the mapping should be added to
+// (supports wildcards); use `_all` or omit to add the mapping on all types.
+func (s *GetWarmerService) Type(typ ...string) *GetWarmerService {
+	s.typ = append(s.typ, typ...)
+	return s
+}
+
+// AllowNoIndices indicates whether to ignore if a wildcard indices
+// expression resolves into no concrete indices.
+// This includes `_all` string or when no indices have been specified.
+func (s *GetWarmerService) AllowNoIndices(allowNoIndices bool) *GetWarmerService {
+	s.allowNoIndices = &allowNoIndices
+	return s
+}
+
+// ExpandWildcards indicates whether to expand wildcard expression to
+// concrete indices that are open, closed or both.
+func (s *GetWarmerService) ExpandWildcards(expandWildcards string) *GetWarmerService {
+	s.expandWildcards = expandWildcards
+	return s
+}
+
+// IgnoreUnavailable indicates whether specified concrete indices should be
+// ignored when unavailable (missing or closed).
+func (s *GetWarmerService) IgnoreUnavailable(ignoreUnavailable bool) *GetWarmerService {
+	s.ignoreUnavailable = &ignoreUnavailable
+	return s
+}
+
+// Local indicates wether or not to return local information,
+// do not retrieve the state from master node (default: false).
+func (s *GetWarmerService) Local(local bool) *GetWarmerService {
+	s.local = &local
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *GetWarmerService) Pretty(pretty bool) *GetWarmerService {
+	s.pretty = pretty
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *GetWarmerService) buildURL() (string, url.Values, error) {
+	var index, typ, name []string
+
+	if len(s.index) > 0 {
+		index = s.index
+	} else {
+		index = []string{"_all"}
+	}
+
+	if len(s.typ) > 0 {
+		typ = s.typ
+	} else {
+		typ = []string{"*"}
+	}
+
+	if len(s.name) > 0 {
+		name = s.name
+	} else {
+		name = []string{"_all"}
+	}
+
+	// Build URL
+	path, err := uritemplates.Expand("/{index}/{type}/_warmer/{name}", map[string]string{
+		"index": strings.Join(index, ","),
+		"type":  strings.Join(typ, ","),
+		"name":  strings.Join(name, ","),
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "1")
+	}
+	if s.allowNoIndices != nil {
+		params.Set("allow_no_indices", fmt.Sprintf("%v", *s.allowNoIndices))
+	}
+	if s.expandWildcards != "" {
+		params.Set("expand_wildcards", s.expandWildcards)
+	}
+	if s.ignoreUnavailable != nil {
+		params.Set("ignore_unavailable", fmt.Sprintf("%v", *s.ignoreUnavailable))
+	}
+	if s.local != nil {
+		params.Set("local", fmt.Sprintf("%v", *s.local))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *GetWarmerService) Validate() error {
+	return nil
+}
+
+// Do executes the operation.
+func (s *GetWarmerService) Do() (map[string]interface{}, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest("GET", path, params, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	var ret map[string]interface{}
+	if err := json.Unmarshal(res.Body, &ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}

--- a/indices_put_warmer.go
+++ b/indices_put_warmer.go
@@ -1,0 +1,227 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"gopkg.in/olivere/elastic.v3/uritemplates"
+)
+
+var (
+	_ = fmt.Print
+	_ = log.Print
+	_ = strings.Index
+	_ = uritemplates.Expand
+	_ = url.Parse
+)
+
+// PutWarmerService allows to register a warmer.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-warmers.html.
+type PutWarmerService struct {
+	client            *Client
+	pretty            bool
+	typ               []string
+	index             []string
+	name              string
+	masterTimeout     string
+	ignoreUnavailable *bool
+	allowNoIndices    *bool
+	requestCache      *bool
+	expandWildcards   string
+	bodyJson          map[string]interface{}
+	bodyString        string
+}
+
+// NewPutWarmerService creates a new PutWarmerService.
+func NewPutWarmerService(client *Client) *PutWarmerService {
+	return &PutWarmerService{
+		client: client,
+		index:  make([]string, 0),
+		typ:    make([]string, 0),
+	}
+}
+
+// Index is a list of index names the mapping should be added to
+// (supports wildcards); use `_all` or omit to add the mapping on all indices.
+func (s *PutWarmerService) Index(indices ...string) *PutWarmerService {
+	s.index = append(s.index, indices...)
+	return s
+}
+
+// Type is a list of type names the mapping should be added to
+// (supports wildcards); use `_all` or omit to add the mapping on all types.
+func (s *PutWarmerService) Type(typ ...string) *PutWarmerService {
+	s.typ = append(s.typ, typ...)
+	return s
+}
+
+// Name specifies the name of the warmer (supports wildcards);
+// leave empty to get all warmers
+func (s *PutWarmerService) Name(name string) *PutWarmerService {
+	s.name = name
+	return s
+}
+
+// MasterTimeout specifies the timeout for connection to master.
+func (s *PutWarmerService) MasterTimeout(masterTimeout string) *PutWarmerService {
+	s.masterTimeout = masterTimeout
+	return s
+}
+
+// IgnoreUnavailable indicates whether specified concrete indices should be
+// ignored when unavailable (missing or closed).
+func (s *PutWarmerService) IgnoreUnavailable(ignoreUnavailable bool) *PutWarmerService {
+	s.ignoreUnavailable = &ignoreUnavailable
+	return s
+}
+
+// AllowNoIndices indicates whether to ignore if a wildcard indices
+// expression resolves into no concrete indices.
+// This includes `_all` string or when no indices have been specified.
+func (s *PutWarmerService) AllowNoIndices(allowNoIndices bool) *PutWarmerService {
+	s.allowNoIndices = &allowNoIndices
+	return s
+}
+
+// RequestCache specifies whether the request to be warmed should use the request cache,
+// defaults to index level setting
+func (s *PutWarmerService) RequestCache(requestCache bool) *PutWarmerService {
+	s.requestCache = &requestCache
+	return s
+}
+
+// ExpandWildcards indicates whether to expand wildcard expression to
+// concrete indices that are open, closed or both.
+func (s *PutWarmerService) ExpandWildcards(expandWildcards string) *PutWarmerService {
+	s.expandWildcards = expandWildcards
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *PutWarmerService) Pretty(pretty bool) *PutWarmerService {
+	s.pretty = pretty
+	return s
+}
+
+// BodyJson contains the mapping definition.
+func (s *PutWarmerService) BodyJson(mapping map[string]interface{}) *PutWarmerService {
+	s.bodyJson = mapping
+	return s
+}
+
+// BodyString is the mapping definition serialized as a string.
+func (s *PutWarmerService) BodyString(mapping string) *PutWarmerService {
+	s.bodyString = mapping
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *PutWarmerService) buildURL() (string, url.Values, error) {
+	var index, typ []string
+
+	if len(s.index) > 0 {
+		index = s.index
+	} else {
+		index = []string{"_all"}
+	}
+
+	if len(s.typ) > 0 {
+		typ = s.typ
+	} else {
+		typ = []string{"_all"}
+	}
+
+	// Build URL: Name MUST be specified and is verified in Validate.
+	path, err := uritemplates.Expand("/{index}/{type}/_warmer/{name}", map[string]string{
+		"index": strings.Join(index, ","),
+		"type":  strings.Join(typ, ","),
+		"name":  s.name,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "1")
+	}
+	if s.ignoreUnavailable != nil {
+		params.Set("ignore_unavailable", fmt.Sprintf("%v", *s.ignoreUnavailable))
+	}
+	if s.allowNoIndices != nil {
+		params.Set("allow_no_indices", fmt.Sprintf("%v", *s.allowNoIndices))
+	}
+	if s.requestCache != nil {
+		params.Set("request_cache", fmt.Sprintf("%v", *s.requestCache))
+	}
+	if s.expandWildcards != "" {
+		params.Set("expand_wildcards", s.expandWildcards)
+	}
+	if s.masterTimeout != "" {
+		params.Set("master_timeout", s.masterTimeout)
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *PutWarmerService) Validate() error {
+	var invalid []string
+	if s.name == "" {
+		invalid = append(invalid, "Name")
+	}
+	if s.bodyString == "" && s.bodyJson == nil {
+		invalid = append(invalid, "BodyJson")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *PutWarmerService) Do() (*PutWarmerResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup HTTP request body
+	var body interface{}
+	if s.bodyJson != nil {
+		body = s.bodyJson
+	} else {
+		body = s.bodyString
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest("PUT", path, params, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(PutWarmerResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// PutWarmerResponse is the response of PutWarmerService.Do.
+type PutWarmerResponse struct {
+	Acknowledged bool `json:"acknowledged"`
+}

--- a/indices_put_warmer_test.go
+++ b/indices_put_warmer_test.go
@@ -1,0 +1,97 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "testing"
+
+func TestPutWarmerURL(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	tests := []struct {
+		Indices  []string
+		Types    []string
+		Name     string
+		Expected string
+	}{
+		{
+			[]string{},
+			[]string{},
+			"warmer_1",
+			"/_warmer/warmer_1",
+		},
+		{
+			[]string{"*"},
+			[]string{},
+			"warmer_1",
+			"/%2A/_warmer/warmer_1",
+		},
+		{
+			[]string{},
+			[]string{"*"},
+			"warmer_1",
+			"/_all/%2A/_warmer/warmer_1",
+		},
+		{
+			[]string{"index-1", "index-2"},
+			[]string{"type-1", "type-2"},
+			"warmer_1",
+			"/index-1%2Cindex-2/type-1%2Ctype-2/_warmer/warmer_1",
+		},
+	}
+
+	for _, test := range tests {
+		path, _, err := client.PutWarmer().Index(test.Indices...).Type(test.Types...).Name(test.Name).buildURL()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if path != test.Expected {
+			t.Errorf("expected %q; got: %q", test.Expected, path)
+		}
+	}
+}
+
+func TestWarmerLifecycle(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	mapping := `{
+		"query": {
+			"match_all": {}
+		}
+	}`
+
+	putresp, err := client.PutWarmer().Index(testIndexName2).Type("tweet").Name("warmer_1").BodyString(mapping).Do()
+	if err != nil {
+		t.Fatalf("expected put warmer to succeed; got: %v", err)
+	}
+	if putresp == nil {
+		t.Fatalf("expected put warmer response; got: %v", putresp)
+	}
+	if !putresp.Acknowledged {
+		t.Fatalf("expected put warmer ack; got: %v", putresp.Acknowledged)
+	}
+
+	getresp, err := client.GetWarmer().Index(testIndexName2).Name("warmer_1").Do()
+	if err != nil {
+		t.Fatalf("expected get warmer to succeed; got: %v", err)
+	}
+	if getresp == nil {
+		t.Fatalf("expected get warmer response; got: %v", getresp)
+	}
+	props, ok := getresp[testIndexName2]
+	if !ok {
+		t.Fatalf("expected JSON root to be of type map[string]interface{}; got: %#v", props)
+	}
+
+	delresp, err := client.DeleteWarmer().Index(testIndexName2).Name("warmer_1").Do()
+	if err != nil {
+		t.Fatalf("expected del warmer to succeed; got: %v", err)
+	}
+	if delresp == nil {
+		t.Fatalf("expected del warmer response; got: %v", getresp)
+	}
+	if !delresp.Acknowledged {
+		t.Fatalf("expected del warmer ack; got: %v", delresp.Acknowledged)
+	}
+}

--- a/indices_put_warmer_test.go
+++ b/indices_put_warmer_test.go
@@ -19,13 +19,13 @@ func TestPutWarmerURL(t *testing.T) {
 			[]string{},
 			[]string{},
 			"warmer_1",
-			"/_warmer/warmer_1",
+			"/_all/_all/_warmer/warmer_1",
 		},
 		{
 			[]string{"*"},
 			[]string{},
 			"warmer_1",
-			"/%2A/_warmer/warmer_1",
+			"/%2A/_all/_warmer/warmer_1",
 		},
 		{
 			[]string{},


### PR DESCRIPTION
This change adds the missing services for get, put and delete requests against the warmer api.

I'm not a 100% sure about the implementation of the get url. The response differs slightly if there is a type present in the url. I've used * as the fallback if no type is set for the request, which results in the second case in the following example. I think, while the response we get back is different, that we don't lose any important information.

Example: we have 2 indices (index_1, index_2) and a warmer (warmer_1) in index_1.

If we use the url `/_all/_warmer` there response would be
```
{
  "index_1": {
    "warmers": {
      "warmer_1": {
        "types": [
          "type_1"
        ],
        "source": {
          "query": {
            "match_all": {}
          }
        }
      }
    }
  },
  "index_2": {
    "warmers": {}
  }
}
```

We could also get the warmers with the following url `/_all/*/_warmer/_all`

```
{
  "index_1": {
    "warmers": {
      "warmer_1": {
        "types": [
          "type_1"
        ],
        "source": {
          "query": {
            "match_all": {}
          }
        }
      }
    }
  }
}
```