### PR TITLE
fix sniffing for ES managed by AWS

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,7 +51,8 @@ const (
 	DefaultHealthcheckInterval = 60 * time.Second
 
 	// DefaultSnifferEnabled specifies if the sniffer is enabled by default.
-	DefaultSnifferEnabled = true
+	// ES managed by AWS does not support sniffing = true by default.
+	DefaultSnifferEnabled = false
 
 	// DefaultSnifferInterval is the interval between two sniffing procedures,
 	// i.e. the lookup of all nodes in the cluster and their addition/removal


### PR DESCRIPTION
ES managed by AWS does not support sniffing = true by default.