### PR TITLE
fixes range query syntax for elastic 2.x

### DIFF
--- a/search_queries_bool_test.go
+++ b/search_queries_bool_test.go
@@ -12,7 +12,7 @@ import (
 func TestBoolQuery(t *testing.T) {
 	q := NewBoolQuery()
 	q = q.Must(NewTermQuery("tag", "wow"))
-	q = q.MustNot(NewRangeQuery("age").From(10).To(20))
+	q = q.MustNot(NewRangeQuery("age").Gte(10).Lte(20))
 	q = q.Filter(NewTermQuery("account", "1"))
 	q = q.Should(NewTermQuery("tag", "sometag"), NewTermQuery("tag", "sometagtag"))
 	q = q.Boost(10)
@@ -27,7 +27,7 @@ func TestBoolQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"bool":{"_name":"Test","boost":10,"disable_coord":true,"filter":{"term":{"account":"1"}},"must":{"term":{"tag":"wow"}},"must_not":{"range":{"age":{"from":10,"include_lower":true,"include_upper":true,"to":20}}},"should":[{"term":{"tag":"sometag"}},{"term":{"tag":"sometagtag"}}]}}`
+	expected := `{"bool":{"_name":"Test","boost":10,"disable_coord":true,"filter":{"term":{"account":"1"}},"must":{"term":{"tag":"wow"}},"must_not":{"range":{"age":{"gte":10,"lte":20}}},"should":[{"term":{"tag":"sometag"}},{"term":{"tag":"sometagtag"}}]}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_boosting_test.go
+++ b/search_queries_boosting_test.go
@@ -12,7 +12,7 @@ import (
 func TestBoostingQuery(t *testing.T) {
 	q := NewBoostingQuery()
 	q = q.Positive(NewTermQuery("tag", "wow"))
-	q = q.Negative(NewRangeQuery("age").From(10).To(20))
+	q = q.Negative(NewRangeQuery("age").Gte(10).Lte(20))
 	q = q.NegativeBoost(0.2)
 	src, err := q.Source()
 	if err != nil {
@@ -23,7 +23,7 @@ func TestBoostingQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"boosting":{"negative":{"range":{"age":{"from":10,"include_lower":true,"include_upper":true,"to":20}}},"negative_boost":0.2,"positive":{"term":{"tag":"wow"}}}}`
+	expected := `{"boosting":{"negative":{"range":{"age":{"gte":10,"lte":20}}},"negative_boost":0.2,"positive":{"term":{"tag":"wow"}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_not_test.go
+++ b/search_queries_not_test.go
@@ -27,7 +27,7 @@ func TestNotQuery(t *testing.T) {
 }
 
 func TestNotQueryWithParams(t *testing.T) {
-	postDateFilter := NewRangeQuery("postDate").From("2010-03-01").To("2010-04-01")
+	postDateFilter := NewRangeQuery("postDate").Gte("2010-03-01").Lte("2010-04-01")
 	f := NewNotQuery(postDateFilter)
 	f = f.QueryName("MyQueryName")
 	src, err := f.Source()
@@ -39,7 +39,7 @@ func TestNotQueryWithParams(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"not":{"_name":"MyQueryName","query":{"range":{"postDate":{"from":"2010-03-01","include_lower":true,"include_upper":true,"to":"2010-04-01"}}}}}`
+	expected := `{"not":{"_name":"MyQueryName","query":{"range":{"postDate":{"gte":"2010-03-01","lte":"2010-04-01"}}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_range.go
+++ b/search_queries_range.go
@@ -10,8 +10,10 @@ package elastic
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
 type RangeQuery struct {
 	name         string
-	from         interface{}
-	to           interface{}
+	gt           interface{}
+	gte          interface{}
+	lt           interface{}
+	lte          interface{}
 	timeZone     string
 	includeLower bool
 	includeUpper bool
@@ -25,63 +27,31 @@ func NewRangeQuery(name string) *RangeQuery {
 	return &RangeQuery{name: name, includeLower: true, includeUpper: true}
 }
 
-// From indicates the from part of the RangeQuery.
-// Use nil to indicate an unbounded from part.
-func (q *RangeQuery) From(from interface{}) *RangeQuery {
-	q.from = from
+// Gt indicates a greater-than value.
+// Use nil to indicate an unbounded gt part.
+func (q *RangeQuery) Gt(gt interface{}) *RangeQuery {
+	q.gt = gt
 	return q
 }
 
-// Gt indicates a greater-than value for the from part.
-// Use nil to indicate an unbounded from part.
-func (q *RangeQuery) Gt(from interface{}) *RangeQuery {
-	q.from = from
-	q.includeLower = false
+// Gte indicates a greater-than-equal value.
+// Use nil to indicate an unbounded gte part.
+func (q *RangeQuery) Gte(gte interface{}) *RangeQuery {
+	q.gte = gte
 	return q
 }
 
-// Gte indicates a greater-than-or-equal value for the from part.
-// Use nil to indicate an unbounded from part.
-func (q *RangeQuery) Gte(from interface{}) *RangeQuery {
-	q.from = from
-	q.includeLower = true
-	return q
-}
-
-// To indicates the to part of the RangeQuery.
-// Use nil to indicate an unbounded to part.
-func (q *RangeQuery) To(to interface{}) *RangeQuery {
-	q.to = to
-	return q
-}
-
-// Lt indicates a less-than value for the to part.
-// Use nil to indicate an unbounded to part.
-func (q *RangeQuery) Lt(to interface{}) *RangeQuery {
-	q.to = to
-	q.includeUpper = false
+// Lt indicates a less-than value.
+// Use nil to indicate an unbounded lt part.
+func (q *RangeQuery) Lt(lt interface{}) *RangeQuery {
+	q.lt = lt
 	return q
 }
 
 // Lte indicates a less-than-or-equal value for the to part.
 // Use nil to indicate an unbounded to part.
-func (q *RangeQuery) Lte(to interface{}) *RangeQuery {
-	q.to = to
-	q.includeUpper = true
-	return q
-}
-
-// IncludeLower indicates whether the lower bound should be included or not.
-// Defaults to true.
-func (q *RangeQuery) IncludeLower(includeLower bool) *RangeQuery {
-	q.includeLower = includeLower
-	return q
-}
-
-// IncludeUpper indicates whether the upper bound should be included or not.
-// Defaults to true.
-func (q *RangeQuery) IncludeUpper(includeUpper bool) *RangeQuery {
-	q.includeUpper = includeUpper
+func (q *RangeQuery) Lte(lte interface{}) *RangeQuery {
+	q.lte = lte
 	return q
 }
 
@@ -120,19 +90,31 @@ func (q *RangeQuery) Source() (interface{}, error) {
 	source["range"] = rangeQ
 
 	params := make(map[string]interface{})
+
+	if q.gt != nil {
+		params["gt"] = q.gt
+	}
+
+	if q.gte != nil {
+		params["gte"] = q.gte
+	}
+
+	if q.lt != nil {
+		params["lt"] = q.lt
+	}
+
+	if q.lte != nil {
+		params["lte"] = q.lte
+	}
+
 	rangeQ[q.name] = params
 
-	params["from"] = q.from
-	params["to"] = q.to
 	if q.timeZone != "" {
 		params["time_zone"] = q.timeZone
 	}
 	if q.format != "" {
 		params["format"] = q.format
 	}
-	params["include_lower"] = q.includeLower
-	params["include_upper"] = q.includeUpper
-
 	if q.boost != nil {
 		rangeQ["boost"] = *q.boost
 	}

--- a/search_queries_range_test.go
+++ b/search_queries_range_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRangeQuery(t *testing.T) {
-	q := NewRangeQuery("postDate").From("2010-03-01").To("2010-04-01")
+	q := NewRangeQuery("postDate").Gte("2010-03-01").Lte("2010-04-01")
 	q = q.QueryName("my_query")
 	src, err := q.Source()
 	if err != nil {
@@ -21,7 +21,7 @@ func TestRangeQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"_name":"my_query","postDate":{"from":"2010-03-01","include_lower":true,"include_upper":true,"to":"2010-04-01"}}}`
+	expected := `{"range":{"_name":"my_query","postDate":{"gte":"2010-03-01","lte":"2010-04-01"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -41,7 +41,7 @@ func TestRangeQueryWithTimeZone(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"born":{"from":"2012-01-01","include_lower":true,"include_upper":true,"time_zone":"+1:00","to":"now"}}}`
+	expected := `{"range":{"born":{"gte":"2012-01-01","time_zone":"+1:00","lte":"now"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -61,7 +61,7 @@ func TestRangeQueryWithFormat(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"born":{"format":"yyyy/MM/dd","from":"2012/01/01","include_lower":true,"include_upper":true,"to":"now"}}}`
+	expected := `{"range":{"born":{"format":"yyyy/MM/dd","gte":"2012/01/01","lte":"now"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
- Replaces `From(interface{})` method on elastic.RangeQuery with
  `Gte(interface{})`. Elasticsearch no longer uses `from` argument in
  range query:
  https://www.elastic.co/guide/en/elasticsearch/reference/2.x/query-dsl-range-query.html
- Replaces `To(interface{})` method on elastic.RangeQuery with
  `Lte(interface{})`. Elasticsearch no longer uses `to` argument in range
  query:
  https://www.elastic.co/guide/en/elasticsearch/reference/2.x/query-dsl-range-query.html
- Adds `Lt(interface{})` method on elastic.RangeQuery. Has the same
  effect of `RangeQuery{}.To().IncludeUpper(false)`.
- Adds `Gt(interface{})` method on elastic.RangeQuery. Has the same
  effect of `RangeQuery{}.From().IncludeLower(false)`.
- Removes `IncludeUpper(bool)` on elastic.RangeQuery.
- Removes `IncludeLower(bool)` on elastic.RangeQuery.
- Fixes tests in:
  * search_queries_bool_test.go
  * search_queries_boosting_test.go
  * search_queries_not_test.go
  * search_queries_range_test.go

This fixes #211 