### PR TITLE
updates range query syntax for elastic 2.x

### DIFF
--- a/search_aggs_bucket_filter_test.go
+++ b/search_aggs_bucket_filter_test.go
@@ -21,7 +21,7 @@ func TestFilterAggregation(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filter":{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}}}`
+	expected := `{"filter":{"range":{"stock":{"gt":0}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -41,7 +41,7 @@ func TestFilterAggregationWithSubAggregation(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"aggregations":{"avg_price":{"avg":{"field":"price"}}},"filter":{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}}}`
+	expected := `{"aggregations":{"avg_price":{"avg":{"field":"price"}}},"filter":{"range":{"stock":{"gt":0}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -59,7 +59,7 @@ func TestFilterAggregationWithMeta(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filter":{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},"meta":{"name":"Oliver"}}`
+	expected := `{"filter":{"range":{"stock":{"gt":0}}},"meta":{"name":"Oliver"}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_aggs_bucket_filters_test.go
+++ b/search_aggs_bucket_filters_test.go
@@ -22,7 +22,7 @@ func TestFiltersAggregation(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filters":{"filters":[{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"symbol":"GOOG"}}]}}`
+	expected := `{"filters":{"filters":[{"range":{"stock":{"gt":0}}},{"term":{"symbol":"GOOG"}}]}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -42,7 +42,7 @@ func TestFiltersAggregationWithSubAggregation(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"aggregations":{"avg_price":{"avg":{"field":"price"}}},"filters":{"filters":[{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"symbol":"GOOG"}}]}}`
+	expected := `{"aggregations":{"avg_price":{"avg":{"field":"price"}}},"filters":{"filters":[{"range":{"stock":{"gt":0}}},{"term":{"symbol":"GOOG"}}]}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -61,7 +61,7 @@ func TestFiltersAggregationWithMetaData(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filters":{"filters":[{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"symbol":"GOOG"}}]},"meta":{"name":"Oliver"}}`
+	expected := `{"filters":{"filters":[{"range":{"stock":{"gt":0}}},{"term":{"symbol":"GOOG"}}]},"meta":{"name":"Oliver"}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_bool_test.go
+++ b/search_queries_bool_test.go
@@ -12,7 +12,7 @@ import (
 func TestBoolQuery(t *testing.T) {
 	q := NewBoolQuery()
 	q = q.Must(NewTermQuery("tag", "wow"))
-	q = q.MustNot(NewRangeQuery("age").From(10).To(20))
+	q = q.MustNot(NewRangeQuery("age").Gte(10).Lte(20))
 	q = q.Filter(NewTermQuery("account", "1"))
 	q = q.Should(NewTermQuery("tag", "sometag"), NewTermQuery("tag", "sometagtag"))
 	q = q.Boost(10)
@@ -27,7 +27,7 @@ func TestBoolQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"bool":{"_name":"Test","boost":10,"disable_coord":true,"filter":{"term":{"account":"1"}},"must":{"term":{"tag":"wow"}},"must_not":{"range":{"age":{"from":10,"include_lower":true,"include_upper":true,"to":20}}},"should":[{"term":{"tag":"sometag"}},{"term":{"tag":"sometagtag"}}]}}`
+	expected := `{"bool":{"_name":"Test","boost":10,"disable_coord":true,"filter":{"term":{"account":"1"}},"must":{"term":{"tag":"wow"}},"must_not":{"range":{"age":{"gte":10,"lte":20}}},"should":[{"term":{"tag":"sometag"}},{"term":{"tag":"sometagtag"}}]}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_boosting_test.go
+++ b/search_queries_boosting_test.go
@@ -12,7 +12,7 @@ import (
 func TestBoostingQuery(t *testing.T) {
 	q := NewBoostingQuery()
 	q = q.Positive(NewTermQuery("tag", "wow"))
-	q = q.Negative(NewRangeQuery("age").From(10).To(20))
+	q = q.Negative(NewRangeQuery("age").Gte(10).Lte(20))
 	q = q.NegativeBoost(0.2)
 	src, err := q.Source()
 	if err != nil {
@@ -23,7 +23,7 @@ func TestBoostingQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"boosting":{"negative":{"range":{"age":{"from":10,"include_lower":true,"include_upper":true,"to":20}}},"negative_boost":0.2,"positive":{"term":{"tag":"wow"}}}}`
+	expected := `{"boosting":{"negative":{"range":{"age":{"gte":10,"lte":20}}},"negative_boost":0.2,"positive":{"term":{"tag":"wow"}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_nested_test.go
+++ b/search_queries_nested_test.go
@@ -23,7 +23,7 @@ func TestNestedQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"nested":{"_name":"qname","path":"obj1","query":{"bool":{"must":[{"term":{"obj1.name":"blue"}},{"range":{"obj1.count":{"from":5,"include_lower":false,"include_upper":true,"to":null}}}]}}}}`
+	expected := `{"nested":{"_name":"qname","path":"obj1","query":{"bool":{"must":[{"term":{"obj1.name":"blue"}},{"range":{"obj1.count":{"gt":5}}}]}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -45,7 +45,7 @@ func TestNestedQueryWithInnerHit(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"nested":{"_name":"qname","inner_hits":{"name":"comments","query":{"term":{"user":"olivere"}}},"path":"obj1","query":{"bool":{"must":[{"term":{"obj1.name":"blue"}},{"range":{"obj1.count":{"from":5,"include_lower":false,"include_upper":true,"to":null}}}]}}}}`
+	expected := `{"nested":{"_name":"qname","inner_hits":{"name":"comments","query":{"term":{"user":"olivere"}}},"path":"obj1","query":{"bool":{"must":[{"term":{"obj1.name":"blue"}},{"range":{"obj1.count":{"gt":5}}}]}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_not_test.go
+++ b/search_queries_not_test.go
@@ -27,7 +27,7 @@ func TestNotQuery(t *testing.T) {
 }
 
 func TestNotQueryWithParams(t *testing.T) {
-	postDateFilter := NewRangeQuery("postDate").From("2010-03-01").To("2010-04-01")
+	postDateFilter := NewRangeQuery("postDate").Gte("2010-03-01").Lte("2010-04-01")
 	f := NewNotQuery(postDateFilter)
 	f = f.QueryName("MyQueryName")
 	src, err := f.Source()
@@ -39,7 +39,7 @@ func TestNotQueryWithParams(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"not":{"_name":"MyQueryName","query":{"range":{"postDate":{"from":"2010-03-01","include_lower":true,"include_upper":true,"to":"2010-04-01"}}}}}`
+	expected := `{"not":{"_name":"MyQueryName","query":{"range":{"postDate":{"gte":"2010-03-01","lte":"2010-04-01"}}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_range_test.go
+++ b/search_queries_range_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRangeQuery(t *testing.T) {
-	q := NewRangeQuery("postDate").From("2010-03-01").To("2010-04-01")
+	q := NewRangeQuery("postDate").Gte("2010-03-01").Lte("2010-04-01")
 	q = q.QueryName("my_query")
 	src, err := q.Source()
 	if err != nil {
@@ -21,7 +21,7 @@ func TestRangeQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"_name":"my_query","postDate":{"from":"2010-03-01","include_lower":true,"include_upper":true,"to":"2010-04-01"}}}`
+	expected := `{"range":{"_name":"my_query","postDate":{"gte":"2010-03-01","lte":"2010-04-01"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -41,7 +41,7 @@ func TestRangeQueryWithTimeZone(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"born":{"from":"2012-01-01","include_lower":true,"include_upper":true,"time_zone":"+1:00","to":"now"}}}`
+	expected := `{"range":{"born":{"gte":"2012-01-01","lte":"now","time_zone":"+1:00"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -61,7 +61,85 @@ func TestRangeQueryWithFormat(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"born":{"format":"yyyy/MM/dd","from":"2012/01/01","include_lower":true,"include_upper":true,"to":"now"}}}`
+	expected := `{"range":{"born":{"format":"yyyy/MM/dd","gte":"2012/01/01","lte":"now"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestRangeQueryFromProxy(t *testing.T) {
+	q := NewRangeQuery("born").
+		From("2012/01/01").
+		Lte("now")
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"range":{"born":{"gte":"2012/01/01","lte":"now"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestRangeQueryToProxy(t *testing.T) {
+	q := NewRangeQuery("born").
+		From("2012/01/01").
+		To("now")
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"range":{"born":{"gte":"2012/01/01","lte":"now"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestRangeQueryOpenIntervalFormat(t *testing.T) {
+	q := NewRangeQuery("born").
+		Gt("2012/01/01").
+		Lt("now")
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"range":{"born":{"gt":"2012/01/01","lt":"now"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestRangeQueryOpenToClosedIntervalFormat(t *testing.T) {
+	q := NewRangeQuery("born").
+		Gt("2012/01/01").
+		Lt("now").
+		IncludeLower(true).
+		IncludeUpper(true)
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"range":{"born":{"gte":"2012/01/01","lte":"now"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
Elasticsearch documentation omits the `from` and `to` fields on
RangeQuery. This change brings the produced queries in line with the
documentation and proxies old methods through the `Gte` and `Lte`
methods.

https://www.elastic.co/guide/en/elasticsearch/reference/2.x/query-dsl-range-query.html

- Proxy `From(interface{})` method on elastic.RangeQuery through
  `Gte(interface{})`.
- Proxy `To(interface{})` method on elastic.RangeQuery through
  `Lte(interface{})`.
- Adds `Lt(interface{})` method on elastic.RangeQuery. Has the same
  effect of `RangeQuery{}.To().IncludeUpper(false)`.
- Adds `Gt(interface{})` method on elastic.RangeQuery. Has the same
  effect of `RangeQuery{}.From().IncludeLower(false)`.
- Change internal behavior of `IncludeLower(bool)` method on
  elastic.RangeQuery.
- Change internal behavior of `IncludeLower(bool)` method on
  elastic.RangeQuery.
- New tests for updated bounds checking behavior.
- Fixes tests in:
  * search_aggs_bucket_filter_test.go
  * search_aggs_bucket_filters_test.go
  * search_queries_bool_test.go
  * search_queries_boosting_test.go
  * search_queries_nested_test.go
  * search_queries_not_test.go
  * search_queries_range_test.go

Addresses #211 