### PR TITLE
missing value for terms aggregation

### DIFF
--- a/search_aggs_bucket_terms.go
+++ b/search_aggs_bucket_terms.go
@@ -30,6 +30,7 @@ type TermsAggregation struct {
 	showTermDocCountError *bool
 	includeTerms          []string
 	excludeTerms          []string
+	missingTerm           string
 }
 
 func NewTermsAggregation() *TermsAggregation {
@@ -218,6 +219,11 @@ func (a *TermsAggregation) ExcludeTerms(terms ...string) *TermsAggregation {
 	return a
 }
 
+func (a *TermsAggregation) Missing(missingTerm string) *TermsAggregation {
+	a.missingTerm = missingTerm
+	return a
+}
+
 func (a *TermsAggregation) Source() (interface{}, error) {
 	// Example:
 	//	{
@@ -309,6 +315,9 @@ func (a *TermsAggregation) Source() (interface{}, error) {
 		opts["execution_hint"] = a.executionHint
 	}
 
+	if a.missingTerm != "" {
+		opts["missing"] = a.missingTerm
+	}
 	// AggregationBuilder (SubAggregations)
 	if len(a.subAggregations) > 0 {
 		aggsMap := make(map[string]interface{})

--- a/search_aggs_bucket_terms_test.go
+++ b/search_aggs_bucket_terms_test.go
@@ -85,3 +85,20 @@ func TestTermsAggregationWithMetaData(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestTermsAggregationWithMissingField(t *testing.T) {
+	agg := NewTermsAggregation().Field("gender").Size(10).Missing("NotSpecified")
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"terms":{"field":"gender","missing":"NotSpecified","size":10}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
Missing value in terms aggregation has been added. Count of docs which misses the aggregating field will be counted under the given name. 

ES Feature : https://www.elastic.co/guide/en/elasticsearch/reference/2.x/search-aggregations-bucket-terms-aggregation.html#_missing_value_12