### PR TITLE
Return an error if setting the request body fails

### DIFF
--- a/client.go
+++ b/client.go
@@ -965,7 +965,11 @@ func (c *Client) PerformRequest(method, path string, params url.Values, body int
 
 		// Set body
 		if body != nil {
-			req.SetBody(body, gzipEnabled)
+			err = req.SetBody(body, gzipEnabled)
+			if err != nil {
+				c.errorf("elastic: couldn't set body %+v for request: %v", body, err)
+				return nil, err
+			}
 		}
 
 		// Tracing

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ package elastic
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"regexp"
@@ -688,5 +689,27 @@ func TestPerformRequestWithMaxRetries(t *testing.T) {
 	// Connection should be marked as dead after it failed
 	if numFailedReqs != 5 {
 		t.Errorf("expected %d failed requests; got: %d", 5, numFailedReqs)
+	}
+}
+
+// failingBody will return an error when json.Marshal is called on it.
+type failingBody struct{}
+
+// MarshalJSON implements the json.Marshaler interface and always returns an error.
+func (fb failingBody) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("failing to marshal")
+}
+
+func TestPerformRequestWithSetBodyError(t *testing.T) {
+	client, err := NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := client.PerformRequest("GET", "/", nil, failingBody{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if res != nil {
+		t.Fatal("expected no response")
 	}
 }


### PR DESCRIPTION
I passed a type with a custom `MarshalJSON` to `BodyJson` and was getting the error `elastic: Error 400 (Bad Request): failed to parse, document is empty [type=mapper_parsing_exception]`. It took me a little while to debug and figure out that the custom `MarshalJSON`, and thus the `json.Marshal` in `setBodyJson`, was returning an error.

Since `setBodyJson` and `setBody` already return the error, this propagates it up to `PerformRequest`.