### PR TITLE
Use an interface for logging

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
@@ -112,9 +111,9 @@ type Client struct {
 	mu                        sync.RWMutex  // guards the next block
 	urls                      []string      // set of URLs passed initially to the client
 	running                   bool          // true if the client's background processes are running
-	errorlog                  *log.Logger   // error log for critical messages
-	infolog                   *log.Logger   // information log for e.g. response times
-	tracelog                  *log.Logger   // trace log for debugging
+	errorlog                  Logger        // error log for critical messages
+	infolog                   Logger        // information log for e.g. response times
+	tracelog                  Logger        // trace log for debugging
 	maxRetries                int           // max. number of retries
 	scheme                    string        // http or https
 	healthcheckEnabled        bool          // healthchecks enabled or disabled
@@ -522,7 +521,7 @@ func SetRequiredPlugins(plugins ...string) ClientOptionFunc {
 
 // SetErrorLog sets the logger for critical messages like nodes joining
 // or leaving the cluster or failing requests. It is nil by default.
-func SetErrorLog(logger *log.Logger) ClientOptionFunc {
+func SetErrorLog(logger Logger) ClientOptionFunc {
 	return func(c *Client) error {
 		c.errorlog = logger
 		return nil
@@ -531,7 +530,7 @@ func SetErrorLog(logger *log.Logger) ClientOptionFunc {
 
 // SetInfoLog sets the logger for informational messages, e.g. requests
 // and their response times. It is nil by default.
-func SetInfoLog(logger *log.Logger) ClientOptionFunc {
+func SetInfoLog(logger Logger) ClientOptionFunc {
 	return func(c *Client) error {
 		c.infolog = logger
 		return nil
@@ -540,7 +539,7 @@ func SetInfoLog(logger *log.Logger) ClientOptionFunc {
 
 // SetTraceLog specifies the log.Logger to use for output of HTTP requests
 // and responses which is helpful during debugging. It is nil by default.
-func SetTraceLog(logger *log.Logger) ClientOptionFunc {
+func SetTraceLog(logger Logger) ClientOptionFunc {
 	return func(c *Client) error {
 		c.tracelog = logger
 		return nil

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,15 @@
+package elastic
+
+type Logger interface {
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+
+	Fatal(...interface{})
+	Fatalf(string, ...interface{})
+	Fatalln(...interface{})
+
+	Panic(...interface{})
+	Panicf(string, ...interface{})
+	Panicln(...interface{})
+}


### PR DESCRIPTION
This PR changes the log.Logger usage to an interface
so that you can now use your own custom logger 

This fixes #217.