### PR TITLE
Allow nodes which do not run at the base URL.

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -12,7 +12,7 @@ import "net/url"
 // protocol http or https.
 //
 // Example:
-// http://127.0.0.1:9200/path?query=1 -> http://127.0.0.1:9200
+// http://127.0.0.1:9200/path?query=1 -> http://127.0.0.1:9200/path
 func canonicalize(rawurls ...string) []string {
 	canonicalized := make([]string, 0)
 	for _, rawurl := range rawurls {

--- a/canonicalize.go
+++ b/canonicalize.go
@@ -7,7 +7,7 @@ package elastic
 import "net/url"
 
 // canonicalize takes a list of URLs and returns its canonicalized form, i.e.
-// remove anything but scheme, userinfo, host, and port. It also removes the
+// remove anything but scheme, userinfo, host, port, and path. It also removes the
 // slash at the end. It also skips invalid URLs or URLs that do not use
 // protocol http or https.
 //
@@ -19,7 +19,6 @@ func canonicalize(rawurls ...string) []string {
 		u, err := url.Parse(rawurl)
 		if err == nil && (u.Scheme == "http" || u.Scheme == "https") {
 			u.Fragment = ""
-			u.Path = ""
 			u.RawQuery = ""
 			canonicalized = append(canonicalized, u.String())
 		}


### PR DESCRIPTION
Previously, canonicalize removed the path component of the URL before returning.  This prevented connections to elasticsearch nodes which do not run at the base URL (e.g., "http://localhost/elastic/").  Without this change, any query to an elasticsearch node would have the wrong path and give strange results.  Change canonicalize to preserve the path.