### PR TITLE
Backport the TimeZone option for QueryStringQuery

### DIFF
--- a/search_queries_query_string.go
+++ b/search_queries_query_string.go
@@ -38,6 +38,7 @@ type QueryStringQuery struct {
 	rewrite                   string
 	minimumShouldMatch        string
 	lenient                   *bool
+	timeZone                  string
 }
 
 // Creates a new query string query.
@@ -161,6 +162,11 @@ func (q QueryStringQuery) Lenient(lenient bool) QueryStringQuery {
 	return q
 }
 
+func (q QueryStringQuery) TimeZone(timeZone string) QueryStringQuery {
+	q.timeZone = timeZone
+	return q
+}
+
 // Creates the query source for the query string query.
 func (q QueryStringQuery) Source() interface{} {
 	// {
@@ -275,6 +281,10 @@ func (q QueryStringQuery) Source() interface{} {
 
 	if q.lenient != nil {
 		query["lenient"] = *q.lenient
+	}
+
+	if q.timeZone != "" {
+		query["time_zone"] = q.timeZone
 	}
 
 	return source


### PR DESCRIPTION
## What Changed & Why

Added support for setting the `"time_zone"` option for a query string query, via the `TimeZone` setter.  This option is supported in Elasticsearch 1.5.x and up, and we need to use it against an Elasticsearch 1.7 installation.  I've tried to mirror the time zone implementation from `release-branch.v3` as close as possible.

## Testing
There are not any tests for the existing options, so I have just ensured that [search_queries_query_string_test.go](./search_queries_query_string_test.go) still passes.  I've also used the fork in our code to ensure the option is set properly.

## Documentation
https://www.elastic.co/guide/en/elasticsearch/reference/1.7/query-dsl-query-string-query.html