### PR TITLE
EstimatedSizeInBytes optimization

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -25,8 +25,6 @@ type BulkService struct {
 	timeout string
 	refresh *bool
 	pretty  bool
-
-	sizeInBytes int64
 }
 
 func NewBulkService(client *Client) *BulkService {
@@ -39,7 +37,6 @@ func NewBulkService(client *Client) *BulkService {
 
 func (s *BulkService) reset() {
 	s.requests = make([]BulkableRequest, 0)
-	s.sizeInBytes = 0
 }
 
 func (s *BulkService) Index(index string) *BulkService {
@@ -69,17 +66,20 @@ func (s *BulkService) Pretty(pretty bool) *BulkService {
 
 func (s *BulkService) Add(r BulkableRequest) *BulkService {
 	s.requests = append(s.requests, r)
-	s.sizeInBytes += s.estimateSizeInBytes(r)
 	return s
 }
 
 func (s *BulkService) EstimatedSizeInBytes() int64 {
-	return s.sizeInBytes
+	var sizeInBytes int64
+	for _, r := range s.requests {
+		sizeInBytes += s.estimateSizeInBytes(r)
+	}
+	return sizeInBytes
 }
 
 func (s *BulkService) estimateSizeInBytes(r BulkableRequest) int64 {
 	// +1 for the \n
-	return int64(1 + len([]byte(r.String())))
+	return int64(1 + len(r.String()))
 }
 
 func (s *BulkService) NumberOfActions() int {


### PR DESCRIPTION
This simple change, reduced number of GCs by half:
<img width="700" alt="screenshot at mar 22 11-48-47" src="https://cloud.githubusercontent.com/assets/1191700/13949261/3bbe3660-f024-11e5-89dd-85f14b9b2272.png">

If you like it please port to the v3 version.