### PR TITLE
Cache calls to Source. Prevent unnecessary string creation

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -118,10 +118,10 @@ func (s *BulkService) estimateSizeInBytes(r BulkableRequest) int64 {
 	lines, _ := r.Source()
 	size := 0
 	for _, line := range lines {
-		size += len(line)
+		// +1 for the \n
+		size += len(line) + 1
 	}
-	// +1 for the \n
-	return int64(1 + size)
+	return int64(size)
 }
 
 // NumberOfActions returns the number of bulkable requests that need to

--- a/bulk_delete_request.go
+++ b/bulk_delete_request.go
@@ -22,6 +22,8 @@ type BulkDeleteRequest struct {
 	refresh     *bool
 	version     int64  // default is MATCH_ANY
 	versionType string // default is "internal"
+
+	source []string
 }
 
 func NewBulkDeleteRequest() *BulkDeleteRequest {
@@ -30,31 +32,37 @@ func NewBulkDeleteRequest() *BulkDeleteRequest {
 
 func (r *BulkDeleteRequest) Index(index string) *BulkDeleteRequest {
 	r.index = index
+	r.source = nil
 	return r
 }
 
 func (r *BulkDeleteRequest) Type(typ string) *BulkDeleteRequest {
 	r.typ = typ
+	r.source = nil
 	return r
 }
 
 func (r *BulkDeleteRequest) Id(id string) *BulkDeleteRequest {
 	r.id = id
+	r.source = nil
 	return r
 }
 
 func (r *BulkDeleteRequest) Routing(routing string) *BulkDeleteRequest {
 	r.routing = routing
+	r.source = nil
 	return r
 }
 
 func (r *BulkDeleteRequest) Refresh(refresh bool) *BulkDeleteRequest {
 	r.refresh = &refresh
+	r.source = nil
 	return r
 }
 
 func (r *BulkDeleteRequest) Version(version int64) *BulkDeleteRequest {
 	r.version = version
+	r.source = nil
 	return r
 }
 
@@ -62,6 +70,7 @@ func (r *BulkDeleteRequest) Version(version int64) *BulkDeleteRequest {
 // "external_gt", or "force".
 func (r *BulkDeleteRequest) VersionType(versionType string) *BulkDeleteRequest {
 	r.versionType = versionType
+	r.source = nil
 	return r
 }
 
@@ -74,6 +83,9 @@ func (r *BulkDeleteRequest) String() string {
 }
 
 func (r *BulkDeleteRequest) Source() ([]string, error) {
+	if r.source != nil {
+		return r.source, nil
+	}
 	lines := make([]string, 1)
 
 	source := make(map[string]interface{})
@@ -107,6 +119,7 @@ func (r *BulkDeleteRequest) Source() ([]string, error) {
 	}
 
 	lines[0] = string(body)
+	r.source = lines
 
 	return lines, nil
 }

--- a/bulk_delete_request_test.go
+++ b/bulk_delete_request_test.go
@@ -48,6 +48,7 @@ func BenchmarkBulkDeleteRequestSerialization(b *testing.B) {
 	var s string
 	for n := 0; n < b.N; n++ {
 		s = r.String()
+		r.source = nil // Don't let caching spoil the benchmark
 	}
 	bulkDeleteRequestSerializationResult = s // ensure the compiler doesn't optimize
 }

--- a/bulk_index_request.go
+++ b/bulk_index_request.go
@@ -25,6 +25,8 @@ type BulkIndexRequest struct {
 	version     int64  // default is MATCH_ANY
 	versionType string // default is "internal"
 	doc         interface{}
+
+	source []string
 }
 
 func NewBulkIndexRequest() *BulkIndexRequest {
@@ -35,61 +37,73 @@ func NewBulkIndexRequest() *BulkIndexRequest {
 
 func (r *BulkIndexRequest) Index(index string) *BulkIndexRequest {
 	r.index = index
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Type(typ string) *BulkIndexRequest {
 	r.typ = typ
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Id(id string) *BulkIndexRequest {
 	r.id = id
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) OpType(opType string) *BulkIndexRequest {
 	r.opType = opType
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Routing(routing string) *BulkIndexRequest {
 	r.routing = routing
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Parent(parent string) *BulkIndexRequest {
 	r.parent = parent
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Timestamp(timestamp string) *BulkIndexRequest {
 	r.timestamp = timestamp
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Ttl(ttl int64) *BulkIndexRequest {
 	r.ttl = ttl
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Refresh(refresh bool) *BulkIndexRequest {
 	r.refresh = &refresh
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Version(version int64) *BulkIndexRequest {
 	r.version = version
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) VersionType(versionType string) *BulkIndexRequest {
 	r.versionType = versionType
+	r.source = nil
 	return r
 }
 
 func (r *BulkIndexRequest) Doc(doc interface{}) *BulkIndexRequest {
 	r.doc = doc
+	r.source = nil
 	return r
 }
 
@@ -104,6 +118,10 @@ func (r *BulkIndexRequest) String() string {
 func (r *BulkIndexRequest) Source() ([]string, error) {
 	// { "index" : { "_index" : "test", "_type" : "type1", "_id" : "1" } }
 	// { "field1" : "value1" }
+
+	if r.source != nil {
+		return r.source, nil
+	}
 
 	lines := make([]string, 2)
 
@@ -169,5 +187,6 @@ func (r *BulkIndexRequest) Source() ([]string, error) {
 		lines[1] = "{}"
 	}
 
+	r.source = lines
 	return lines, nil
 }

--- a/bulk_index_request_test.go
+++ b/bulk_index_request_test.go
@@ -70,6 +70,7 @@ func BenchmarkBulkIndexRequestSerialization(b *testing.B) {
 	var s string
 	for n := 0; n < b.N; n++ {
 		s = r.String()
+		r.source = nil // Don't let caching spoil the benchmark
 	}
 	bulkIndexRequestSerializationResult = s // ensure the compiler doesn't optimize
 }

--- a/bulk_update_request.go
+++ b/bulk_update_request.go
@@ -29,6 +29,8 @@ type BulkUpdateRequest struct {
 	doc             interface{}
 	ttl             int64
 	timestamp       string
+
+	source []string
 }
 
 func NewBulkUpdateRequest() *BulkUpdateRequest {
@@ -37,41 +39,49 @@ func NewBulkUpdateRequest() *BulkUpdateRequest {
 
 func (r *BulkUpdateRequest) Index(index string) *BulkUpdateRequest {
 	r.index = index
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Type(typ string) *BulkUpdateRequest {
 	r.typ = typ
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Id(id string) *BulkUpdateRequest {
 	r.id = id
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Routing(routing string) *BulkUpdateRequest {
 	r.routing = routing
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Parent(parent string) *BulkUpdateRequest {
 	r.parent = parent
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Script(script *Script) *BulkUpdateRequest {
 	r.script = script
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) RetryOnConflict(retryOnConflict int) *BulkUpdateRequest {
 	r.retryOnConflict = &retryOnConflict
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Version(version int64) *BulkUpdateRequest {
 	r.version = version
+	r.source = nil
 	return r
 }
 
@@ -79,36 +89,44 @@ func (r *BulkUpdateRequest) Version(version int64) *BulkUpdateRequest {
 // "external_gt", or "force".
 func (r *BulkUpdateRequest) VersionType(versionType string) *BulkUpdateRequest {
 	r.versionType = versionType
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Refresh(refresh bool) *BulkUpdateRequest {
 	r.refresh = &refresh
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Doc(doc interface{}) *BulkUpdateRequest {
 	r.doc = doc
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) DocAsUpsert(docAsUpsert bool) *BulkUpdateRequest {
 	r.docAsUpsert = &docAsUpsert
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Upsert(doc interface{}) *BulkUpdateRequest {
 	r.upsert = doc
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Ttl(ttl int64) *BulkUpdateRequest {
 	r.ttl = ttl
+	r.source = nil
+	r.source = nil
 	return r
 }
 
 func (r *BulkUpdateRequest) Timestamp(timestamp string) *BulkUpdateRequest {
 	r.timestamp = timestamp
+	r.source = nil
 	return r
 }
 
@@ -145,6 +163,10 @@ func (r BulkUpdateRequest) Source() ([]string, error) {
 	// or
 	// { "update" : { "_index" : "test", "_type" : "type1", "_id" : "1", ... } }
 	// { "script" : { ... } }
+
+	if r.source != nil {
+		return r.source, nil
+	}
 
 	lines := make([]string, 2)
 
@@ -215,5 +237,6 @@ func (r BulkUpdateRequest) Source() ([]string, error) {
 		return nil, err
 	}
 
+	r.source = lines
 	return lines, nil
 }

--- a/bulk_update_request.go
+++ b/bulk_update_request.go
@@ -120,7 +120,6 @@ func (r *BulkUpdateRequest) Upsert(doc interface{}) *BulkUpdateRequest {
 func (r *BulkUpdateRequest) Ttl(ttl int64) *BulkUpdateRequest {
 	r.ttl = ttl
 	r.source = nil
-	r.source = nil
 	return r
 }
 

--- a/bulk_update_request_test.go
+++ b/bulk_update_request_test.go
@@ -31,10 +31,10 @@ func TestBulkUpdateRequestSerialization(t *testing.T) {
 				RetryOnConflict(3).
 				DocAsUpsert(true).
 				Doc(struct {
-					Counter int64 `json:"counter"`
-				}{
-					Counter: 42,
-				}),
+				Counter int64 `json:"counter"`
+			}{
+				Counter: 42,
+			}),
 			Expected: []string{
 				`{"update":{"_id":"1","_index":"index1","_retry_on_conflict":3,"_type":"tweet"}}`,
 				`{"doc":{"counter":42},"doc_as_upsert":true}`,
@@ -46,10 +46,10 @@ func TestBulkUpdateRequestSerialization(t *testing.T) {
 				RetryOnConflict(3).
 				Script(NewScript(`ctx._source.retweets += param1`).Lang("javascript").Param("param1", 42)).
 				Upsert(struct {
-					Counter int64 `json:"counter"`
-				}{
-					Counter: 42,
-				}),
+				Counter int64 `json:"counter"`
+			}{
+				Counter: 42,
+			}),
 			Expected: []string{
 				`{"update":{"_id":"1","_index":"index1","_retry_on_conflict":3,"_type":"tweet"}}`,
 				`{"script":{"inline":"ctx._source.retweets += param1","lang":"javascript","params":{"param1":42}},"upsert":{"counter":42}}`,
@@ -87,6 +87,7 @@ func BenchmarkBulkUpdateRequestSerialization(b *testing.B) {
 	var s string
 	for n := 0; n < b.N; n++ {
 		s = r.String()
+		r.source = nil // Don't let caching spoil the benchmark
 	}
 	bulkUpdateRequestSerializationResult = s // ensure the compiler doesn't optimize
 }


### PR DESCRIPTION
When `BulkableRequest.Source()` is called, the underlying objects
now cache the result, preventing future calls from going through the
JSON marshaling process yet again.

`estimatedSizeInBytes` now acts directly on the values returned
by Source instead of calling String to avoid creating a bit of garbage. 
In addition, this does undo the change I mentioned in #252 as well, so that `estimatedSizeInBytes` is only called once per `BulkableRequest`. 

In my testing, these changes combined give a 20-30% increase in documents indexed per second compared to code at commit 629ba26e184081ae0b8d577ea45a253a88dd8615 (before the change to `estimatedSizeInBytes`). 

Fixes #252.