### PR TITLE
Change github imports to gopkg imports

### DIFF
--- a/tasks_cancel.go
+++ b/tasks_cancel.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/olivere/elastic/uritemplates"
+	"gopkg.in/olivere/elastic.v3/uritemplates"
 )
 
 // TasksCancelService can cancel long-running tasks.

--- a/tasks_list.go
+++ b/tasks_list.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/olivere/elastic/uritemplates"
+	"gopkg.in/olivere/elastic.v3/uritemplates"
 )
 
 // TasksListService retrieves the list of currently executing tasks

--- a/update_by_query.go
+++ b/update_by_query.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/olivere/elastic/uritemplates"
+	"gopkg.in/olivere/elastic.v3/uritemplates"
 )
 
 // UpdateByQueryService is documented at https://www.elastic.co/guide/en/elasticsearch/plugins/master/plugins-reindex.html.


### PR DESCRIPTION
Hi Oliver,

I got a compile error on the head of the v3 branch because of some bad imports. I used the equivalent of a `go get gopkg.in/olivere/elastic.v3` to pull down your code.

After fixing the imports, I tried running the tests to make sure I didn't make it worse but didn't have any luck. Here is the output:

```
go test ./...
--- FAIL: TestBulk (0.08s)
	bulk_test.go:151: expected updated tweet retweets = 43; got 42
--- FAIL: TestAggsIntegrationBucketScript (0.06s)
	search_aggs_pipeline_test.go:684: elastic: Error 503 (Service Unavailable): [reduce]  [type=reduce_search_phase_exception] (maybe scripting is disabled?)
--- FAIL: TestAggsIntegrationBucketSelector (0.06s)
	search_aggs_pipeline_test.go:837: elastic: Error 503 (Service Unavailable): [reduce]  [type=reduce_search_phase_exception] (maybe scripting is disabled?)
FAIL
FAIL	gopkg.in/olivere/elastic.v3	26.486s
ok  	gopkg.in/olivere/elastic.v3/backoff	0.086s
?   	gopkg.in/olivere/elastic.v3/cluster-test	[no test files]
ok  	gopkg.in/olivere/elastic.v3/uritemplates	0.009s
```

Let me know what I'm doing wrong and I'll run them again.

Thanks!
Dwayne