### PR TITLE
Create ClientOptionFunc to set custom request headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -108,30 +108,31 @@ type Client struct {
 	conns   []*conn      // all connections
 	cindex  int          // index into conns
 
-	mu                        sync.RWMutex  // guards the next block
-	urls                      []string      // set of URLs passed initially to the client
-	running                   bool          // true if the client's background processes are running
-	errorlog                  Logger        // error log for critical messages
-	infolog                   Logger        // information log for e.g. response times
-	tracelog                  Logger        // trace log for debugging
-	maxRetries                int           // max. number of retries
-	scheme                    string        // http or https
-	healthcheckEnabled        bool          // healthchecks enabled or disabled
-	healthcheckTimeoutStartup time.Duration // time the healthcheck waits for a response from Elasticsearch on startup
-	healthcheckTimeout        time.Duration // time the healthcheck waits for a response from Elasticsearch
-	healthcheckInterval       time.Duration // interval between healthchecks
-	healthcheckStop           chan bool     // notify healthchecker to stop, and notify back
-	snifferEnabled            bool          // sniffer enabled or disabled
-	snifferTimeoutStartup     time.Duration // time the sniffer waits for a response from nodes info API on startup
-	snifferTimeout            time.Duration // time the sniffer waits for a response from nodes info API
-	snifferInterval           time.Duration // interval between sniffing
-	snifferStop               chan bool     // notify sniffer to stop, and notify back
-	decoder                   Decoder       // used to decode data sent from Elasticsearch
-	basicAuth                 bool          // indicates whether to send HTTP Basic Auth credentials
-	basicAuthUsername         string        // username for HTTP Basic Auth
-	basicAuthPassword         string        // password for HTTP Basic Auth
-	sendGetBodyAs             string        // override for when sending a GET with a body
-	gzipEnabled               bool          // gzip compression enabled or disabled (default)
+	mu                        sync.RWMutex      // guards the next block
+	urls                      []string          // set of URLs passed initially to the client
+	running                   bool              // true if the client's background processes are running
+	errorlog                  Logger            // error log for critical messages
+	infolog                   Logger            // information log for e.g. response times
+	tracelog                  Logger            // trace log for debugging
+	maxRetries                int               // max. number of retries
+	scheme                    string            // http or https
+	healthcheckEnabled        bool              // healthchecks enabled or disabled
+	healthcheckTimeoutStartup time.Duration     // time the healthcheck waits for a response from Elasticsearch on startup
+	healthcheckTimeout        time.Duration     // time the healthcheck waits for a response from Elasticsearch
+	healthcheckInterval       time.Duration     // interval between healthchecks
+	healthcheckStop           chan bool         // notify healthchecker to stop, and notify back
+	snifferEnabled            bool              // sniffer enabled or disabled
+	snifferTimeoutStartup     time.Duration     // time the sniffer waits for a response from nodes info API on startup
+	snifferTimeout            time.Duration     // time the sniffer waits for a response from nodes info API
+	snifferInterval           time.Duration     // interval between sniffing
+	snifferStop               chan bool         // notify sniffer to stop, and notify back
+	decoder                   Decoder           // used to decode data sent from Elasticsearch
+	basicAuth                 bool              // indicates whether to send HTTP Basic Auth credentials
+	basicAuthUsername         string            // username for HTTP Basic Auth
+	basicAuthPassword         string            // password for HTTP Basic Auth
+	sendGetBodyAs             string            // override for when sending a GET with a body
+	gzipEnabled               bool              // gzip compression enabled or disabled (default)
+	headers                   map[string]string // headers added to each request
 }
 
 // NewClient creates a new client to work with Elasticsearch.
@@ -367,6 +368,14 @@ func SetURL(urls ...string) ClientOptionFunc {
 func SetScheme(scheme string) ClientOptionFunc {
 	return func(c *Client) error {
 		c.scheme = scheme
+		return nil
+	}
+}
+
+// SetHeaders sets http headers that will be added to each request
+func SetHeaders(headers map[string]string) ClientOptionFunc {
+	return func(c *Client) error {
+		c.headers = headers
 		return nil
 	}
 }
@@ -858,6 +867,10 @@ func (c *Client) healthcheck(timeout time.Duration, force bool) {
 		params.Set("timeout", fmt.Sprintf("%dms", timeoutInMillis))
 		req, err := NewRequest("HEAD", conn.URL()+"/?"+params.Encode())
 		if err == nil {
+			for headerName, headerValue := range c.headers {
+				req.Header.Add(headerName, headerValue)
+			}
+
 			if basicAuth {
 				req.SetBasicAuth(basicAuthUsername, basicAuthPassword)
 			}
@@ -907,6 +920,11 @@ func (c *Client) startupHealthcheck(timeout time.Duration) error {
 			if err != nil {
 				return err
 			}
+
+			for headerName, headerValue := range c.headers {
+				req.Header.Add(headerName, headerValue)
+			}
+
 			if basicAuth {
 				req.SetBasicAuth(basicAuthUsername, basicAuthPassword)
 			}
@@ -1037,6 +1055,10 @@ func (c *Client) PerformRequest(method, path string, params url.Values, body int
 		if err != nil {
 			c.errorf("elastic: cannot create request for %s %s: %v", strings.ToUpper(method), conn.URL()+pathWithParams, err)
 			return nil, err
+		}
+
+		for headerName, headerValue := range c.headers {
+			req.Header.Add(headerName, headerValue)
 		}
 
 		if basicAuth {

--- a/request.go
+++ b/request.go
@@ -26,6 +26,7 @@ func NewRequest(method, url string) (*Request, error) {
 	}
 	req.Header.Add("User-Agent", "elastic/"+Version+" ("+runtime.GOOS+"-"+runtime.GOARCH+")")
 	req.Header.Add("Accept", "application/json")
+
 	return (*Request)(req), nil
 }
 


### PR DESCRIPTION
The Elasticsearch cluster I'm calling with the elastic package is going to start enforcing that custom headers are set on each request. I've updated the elastic package to allow custom headers to be passed to a Client as a ClientOptionFunc.