### PR TITLE
searchResult.Hits contains multiple values in v.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ for _, item := range searchResult.Each(reflect.TypeOf(ttyp)) {
 fmt.Printf("Found a total of %d tweets\n", searchResult.TotalHits())
 
 // Here's how you iterate through results with full control over each step.
-if searchResult.Hits != nil {
+if searchResult.Hits.TotalHits != 0 {
     fmt.Printf("Found a total of %d tweets\n", searchResult.Hits.TotalHits)
 
     // Iterate through results


### PR DESCRIPTION
searchResult.Hits contains below three values although there might be no result. 
These three values are: 
      "total": 0,
      "max_score": null,
      "hits": []

So, this not going to be Nil. So, devs may try other options.