### PR TITLE
Feature/bulk delete request parent

### DIFF
--- a/bulk_delete_request.go
+++ b/bulk_delete_request.go
@@ -18,6 +18,7 @@ type BulkDeleteRequest struct {
 	index       string
 	typ         string
 	id          string
+	parent      string
 	routing     string
 	refresh     *bool
 	version     int64  // default is MATCH_ANY
@@ -40,6 +41,11 @@ func (r *BulkDeleteRequest) Type(typ string) *BulkDeleteRequest {
 
 func (r *BulkDeleteRequest) Id(id string) *BulkDeleteRequest {
 	r.id = id
+	return r
+}
+
+func (r *BulkDeleteRequest) Parent(parent string) *BulkDeleteRequest {
+	r.parent = parent
 	return r
 }
 
@@ -86,6 +92,9 @@ func (r *BulkDeleteRequest) Source() ([]string, error) {
 	}
 	if r.id != "" {
 		deleteCommand["_id"] = r.id
+	}
+	if r.parent != "" {
+		deleteCommand["_parent"] = r.parent
 	}
 	if r.routing != "" {
 		deleteCommand["_routing"] = r.routing

--- a/bulk_delete_request_test.go
+++ b/bulk_delete_request_test.go
@@ -20,6 +20,12 @@ func TestBulkDeleteRequestSerialization(t *testing.T) {
 				`{"delete":{"_id":"1","_index":"index1","_type":"tweet"}}`,
 			},
 		},
+		{
+			Request: NewBulkDeleteRequest().Index("index1").Type("tweet").Id("1").Parent("2"),
+			Expected: []string{
+				`{"delete":{"_id":"1","_index":"index1","_parent":"2","_type":"tweet"}}`,
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
When deleting children records in ES, you must specify the id of the parent with the _parent field. This means that you are currently unable to delete children records using the BulkDeleteRequest interface. (unless there is a way with Routing?).