### PR TITLE
Remove search_type=scan from Scroll, it causes no results to be returned

### DIFF
--- a/scroll.go
+++ b/scroll.go
@@ -129,8 +129,6 @@ func (s *ScrollService) GetFirstPage() (*SearchResult, error) {
 
 	// Parameters
 	params := make(url.Values)
-	// TODO: ES 2.1 deprecates search_type=scan. See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_21_search_changes.html#_literal_search_type_scan_literal_deprecated.
-	params.Set("search_type", "scan")
 	if s.pretty {
 		params.Set("pretty", fmt.Sprintf("%v", s.pretty))
 	}

--- a/scroll_test.go
+++ b/scroll_test.go
@@ -53,7 +53,7 @@ func TestScroll(t *testing.T) {
 	if res.Hits.TotalHits != 3 {
 		t.Errorf("expected results.Hits.TotalHits = %d; got %d", 3, res.Hits.TotalHits)
 	}
-	if len(res.Hits.Hits) != 0 {
+	if len(res.Hits.Hits) != 1 {
 		t.Errorf("expected len(results.Hits.Hits) = %d; got %d", 0, len(res.Hits.Hits))
 	}
 	if res.ScrollId == "" {
@@ -100,7 +100,7 @@ func TestScroll(t *testing.T) {
 		t.Errorf("expected to retrieve at least 1 page; got %d", pages)
 	}
 
-	if numDocs != 3 {
+	if numDocs != 2 {
 		t.Errorf("expected to retrieve %d hits; got %d", 3, numDocs)
 	}
 }


### PR DESCRIPTION
I've just had to remove the search_type=scan parameter for scroll against my elasticsearch version (2.3.2) as its presence caused no results to be returned.

Was this just left in for backwards compatibility?