### PR TITLE
Unmarshall the `collate_match` field from a Phrase Suggester with a CollateQuery

### DIFF
--- a/suggest.go
+++ b/suggest.go
@@ -136,8 +136,9 @@ type Suggestion struct {
 }
 
 type suggestionOption struct {
-	Text    string      `json:"text"`
-	Score   float64     `json:"score"`
-	Freq    int         `json:"freq"`
-	Payload interface{} `json:"payload"`
+	Text         string      `json:"text"`
+	Score        float64     `json:"score"`
+	Freq         int         `json:"freq"`
+	Payload      interface{} `json:"payload"`
+	CollateMatch bool        `json:"collate_match,omitempty"`
 }


### PR DESCRIPTION
A [collated phrase suggester](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html#_basic_phrase_suggest_api_parameters) returns an additional field for each suggestion called `CollateMatch` that indicates whether the suggestion matches the collated query or not. 

This pull request simply makes this the field available for deserialization.