### PR TITLE
Fix json encode error

### DIFF
--- a/search_aggs.go
+++ b/search_aggs.go
@@ -1010,6 +1010,12 @@ func (a *AggregationBucketKeyItem) UnmarshalJSON(data []byte) error {
 	if v, ok := aggs["key"]; ok && v != nil {
 		json.Unmarshal(*v, &a.Key)
 		json.Unmarshal(*v, &a.KeyNumber)
+		# Verify KeyNumber is really a num
+	        if _, err := a.KeyNumber.Float64(); err != nil {
+	            a.KeyNumber = ""
+	        }
+	        # Always set KeyAsString
+	        json.Unmarshal(*v, &a.KeyAsString)
 	}
 	if v, ok := aggs["key_as_string"]; ok && v != nil {
 		json.Unmarshal(*v, &a.KeyAsString)

--- a/search_aggs.go
+++ b/search_aggs.go
@@ -1010,11 +1010,11 @@ func (a *AggregationBucketKeyItem) UnmarshalJSON(data []byte) error {
 	if v, ok := aggs["key"]; ok && v != nil {
 		json.Unmarshal(*v, &a.Key)
 		json.Unmarshal(*v, &a.KeyNumber)
-		# Verify KeyNumber is really a num
+		// Verify KeyNumber is really a num
 	        if _, err := a.KeyNumber.Float64(); err != nil {
 	            a.KeyNumber = ""
 	        }
-	        # Always set KeyAsString
+	        // Always set KeyAsString
 	        json.Unmarshal(*v, &a.KeyAsString)
 	}
 	if v, ok := aggs["key_as_string"]; ok && v != nil {


### PR DESCRIPTION
When doing a term agg, then attempting to encode the result back to json I was getting an error

Elastic was returning
```json
{
	"buckets": [{
		"key": "DJ-2",
		"doc_count": 24697
	}],
	"doc_count_error_upper_bound": 0,
	"sum_other_doc_count": 0
}
```

So when it decoded, it saw the key field and assumed it was a number and thus when I attempted to re-encode the Aggregations back to json I was getting `json: invalid number literal "DJ-2"`

This change fixes the error and produces

```json
{
	"Aggregations": {
		"buckets": [{
			"key": "DJ-2",
			"doc_count": 24697
		}],
		"doc_count_error_upper_bound": 0,
		"sum_other_doc_count": 0
	},
	"DocCountErrorUpperBound": 0,
	"SumOfOtherDocCount": 0,
	"Buckets": [{
		"Aggregations": {
			"doc_count": 24697,
			"key": "DJ-2"
		},
		"Key": "DJ-2",
		"KeyAsString": "DJ-2",
		"KeyNumber": 0,
		"DocCount": 24697
	}],
	"Meta": null
}
```

This change has been tested against

```json
{
	"name": "silver-elastic-01",
	"cluster_name": "silver-logging",
	"version": {
		"number": "2.0.0",
		"build_hash": "de54438d6af8f9340d50c5c786151783ce7d6be5",
		"build_timestamp": "2015-10-22T08:09:48Z",
		"build_snapshot": false,
		"lucene_version": "5.2.1"
	},
	"tagline": "You Know, for Search"
}
```

and

```json
{
	"name": "Windeagle",
	"cluster_name": "elasticsearch",
	"version": {
		"number": "2.3.3",
		"build_hash": "218bdf10790eef486ff2c41a3df5cfa32dadcfde",
		"build_timestamp": "2016-05-17T15:40:04Z",
		"build_snapshot": false,
		"lucene_version": "5.5.0"
	},
	"tagline": "You Know, for Search"
}
```