### PR TITLE
termvectors: add Score in TermsInfo

### DIFF
--- a/termvectors.go
+++ b/termvectors.go
@@ -429,6 +429,7 @@ type TokenInfo struct {
 
 type TermsInfo struct {
 	DocFreq  int64       `json:"doc_freq"`
+	Score    float64     `json:"score"`
 	TermFreq int64       `json:"term_freq"`
 	Ttf      int64       `json:"ttf"`
 	Tokens   []TokenInfo `json:"tokens"`


### PR DESCRIPTION
Enable to get `score` value in `terms`.

See detail: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html