### PR TITLE
Fix to use healthcheckInterval

### DIFF
--- a/client.go
+++ b/client.go
@@ -871,9 +871,10 @@ func (c *Client) updateConns(conns []*conn) {
 func (c *Client) healthchecker() {
 	c.mu.RLock()
 	timeout := c.healthcheckTimeout
+	interval := c.healthcheckInterval
 	c.mu.RUnlock()
 
-	ticker := time.NewTicker(timeout)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
Why don't you use `c.healthcheckInterval`?
It isn't used anywhere.