### PR TITLE
Allow setting routing value on alias creation

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -7,29 +7,75 @@ package elastic
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
+
+type AliasAction struct {
+	// "add" or "remove"
+	actionType string
+	// Index name
+	index string
+	// Alias name
+	alias string
+
+	// Below only apply to "add" actions
+
+	// Filter
+	filter Filter
+	// Routing value
+	routing string
+	// Search routing value
+	searchRouting string
+	// Index routing value
+	indexRouting string
+}
+
+func NewAliasAddAction(index, alias string) AliasAction {
+	return AliasAction{
+		actionType: "add",
+		index:      index,
+		alias:      alias,
+	}
+}
+
+func (a AliasAction) Filter(filter Filter) AliasAction {
+	a.filter = filter
+	return a
+}
+
+func (a AliasAction) Routing(routing string) AliasAction {
+	a.routing = routing
+	return a
+}
+
+func (a AliasAction) IndexRouting(routing string) AliasAction {
+	a.indexRouting = routing
+	return a
+}
+
+func (a AliasAction) SearchRouting(routings ...string) AliasAction {
+	a.searchRouting = strings.Join(routings, ",")
+	return a
+}
+
+func NewAliasRemoveAction(index, alias string) AliasAction {
+	return AliasAction{
+		actionType: "remove",
+		index:      index,
+		alias:      alias,
+	}
+}
 
 type AliasService struct {
 	client  *Client
-	actions []aliasAction
+	actions []AliasAction
 	pretty  bool
-}
-
-type aliasAction struct {
-	// "add" or "remove"
-	Type string
-	// Index name
-	Index string
-	// Alias name
-	Alias string
-	// Filter
-	Filter *Filter
 }
 
 func NewAliasService(client *Client) *AliasService {
 	builder := &AliasService{
 		client:  client,
-		actions: make([]aliasAction, 0),
+		actions: make([]AliasAction, 0),
 	}
 	return builder
 }
@@ -40,20 +86,29 @@ func (s *AliasService) Pretty(pretty bool) *AliasService {
 }
 
 func (s *AliasService) Add(indexName string, aliasName string) *AliasService {
-	action := aliasAction{Type: "add", Index: indexName, Alias: aliasName}
+	action := AliasAction{actionType: "add", index: indexName, alias: aliasName}
 	s.actions = append(s.actions, action)
 	return s
 }
 
 func (s *AliasService) AddWithFilter(indexName string, aliasName string, filter *Filter) *AliasService {
-	action := aliasAction{Type: "add", Index: indexName, Alias: aliasName, Filter: filter}
+	var f Filter
+	if filter != nil {
+		f = *filter
+	}
+	action := AliasAction{actionType: "add", index: indexName, alias: aliasName, filter: f}
 	s.actions = append(s.actions, action)
 	return s
 }
 
 func (s *AliasService) Remove(indexName string, aliasName string) *AliasService {
-	action := aliasAction{Type: "remove", Index: indexName, Alias: aliasName}
+	action := AliasAction{actionType: "remove", index: indexName, alias: aliasName}
 	s.actions = append(s.actions, action)
+	return s
+}
+
+func (s *AliasService) Actions(actions ...AliasAction) *AliasService {
+	s.actions = append(actions)
 	return s
 }
 
@@ -74,12 +129,21 @@ func (s *AliasService) Do() (*AliasResult, error) {
 	for _, action := range s.actions {
 		actionJson := make(map[string]interface{})
 		detailsJson := make(map[string]interface{})
-		detailsJson["index"] = action.Index
-		detailsJson["alias"] = action.Alias
-		if action.Filter != nil {
-			detailsJson["filter"] = (*action.Filter).Source()
+		detailsJson["index"] = action.index
+		detailsJson["alias"] = action.alias
+		if action.filter != nil {
+			detailsJson["filter"] = action.filter.Source()
 		}
-		actionJson[action.Type] = detailsJson
+		if action.routing != "" {
+			detailsJson["routing"] = action.routing
+		}
+		if action.indexRouting != "" {
+			detailsJson["index_routing"] = action.indexRouting
+		}
+		if action.searchRouting != "" {
+			detailsJson["search_routing"] = action.searchRouting
+		}
+		actionJson[action.actionType] = detailsJson
 		actionsJson = append(actionsJson, actionJson)
 	}
 


### PR DESCRIPTION
In order to avoid making a lot of new functions to encapsulate all possible combinations, this commit exposes the `AliasAction` type and adds the `Actions` method to `AliasService`. Existing functions are kept for backwards-compatibility.

Worked on the `v2` branch as I've been working against ES 1.5, but these changes should map cleanly to `v3`'s `index_put_alias.go` file.