### PR TITLE
Support clearing scroll queries

### DIFF
--- a/scroll.go
+++ b/scroll.go
@@ -222,6 +222,30 @@ func (s *ScrollService) DoC(ctx context.Context) (*SearchResult, error) {
 	return s.next(ctx)
 }
 
+func (s *ScrollService) Clear(ctx context.Context) error {
+	s.mu.RLock()
+	nextScrollId := s.scrollId
+	s.mu.RUnlock()
+	if len(nextScrollId) == 0 {
+		return nil
+	}
+
+	path := "/_search/scroll"
+	params := url.Values{}
+	body := struct {
+		ScrollId []string `json:"scroll_id,omitempty"`
+	}{
+		ScrollId: []string{s.scrollId},
+	}
+
+	_, err := s.client.PerformRequestC(ctx, "DELETE", path, params, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // -- First --
 
 // first takes the first page of search results.

--- a/scroll_test.go
+++ b/scroll_test.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	_ "net/http"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestScroll(t *testing.T) {
@@ -91,6 +93,16 @@ func TestScroll(t *testing.T) {
 
 	if numDocs != 3 {
 		t.Errorf("expected to retrieve %d hits; got %d", 3, numDocs)
+	}
+
+	err = svc.Clear(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = svc.Do()
+	if err == nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This is helpful if you issue many scroll queries and the automatic
timeout does not suffice.