### PR TITLE
elasticsearch docs in comments for 2.x are leading to 404 page, update to avoid broken references

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -24,7 +24,7 @@ import (
 // reuse BulkService to send many batches. You do not have to create a new
 // BulkService for each batch.
 //
-// See https://www.elastic.co/guide/en/elasticsearch/reference/2.x/docs-bulk.html
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
 // for more details.
 type BulkService struct {
 	client *Client

--- a/bulk_update_request.go
+++ b/bulk_update_request.go
@@ -79,8 +79,8 @@ func (r *BulkUpdateRequest) Parent(parent string) *BulkUpdateRequest {
 }
 
 // Script specifies an update script.
-// See https://www.elastic.co/guide/en/elasticsearch/reference/2.x/docs-bulk.html#bulk-update
-// and https://www.elastic.co/guide/en/elasticsearch/reference/2.x/modules-scripting.html
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-update
+// and https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
 // for details.
 func (r *BulkUpdateRequest) Script(script *Script) *BulkUpdateRequest {
 	r.script = script
@@ -130,7 +130,7 @@ func (r *BulkUpdateRequest) Doc(doc interface{}) *BulkUpdateRequest {
 // DocAsUpsert indicates whether the contents of Doc should be used as
 // the Upsert value.
 //
-// See https://www.elastic.co/guide/en/elasticsearch/reference/2.x/docs-update.html#_literal_doc_as_upsert_literal
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html#_literal_doc_as_upsert_literal
 // for details.
 func (r *BulkUpdateRequest) DocAsUpsert(docAsUpsert bool) *BulkUpdateRequest {
 	r.docAsUpsert = &docAsUpsert

--- a/scan_test.go
+++ b/scan_test.go
@@ -182,7 +182,7 @@ func TestScanWithSort(t *testing.T) {
 func TestScanWithSortByDoc(t *testing.T) {
 	// Sorting by doc is introduced in Elasticsearch 2.1,
 	// and replaces the deprecated search_type=scan.
-	// See https://www.elastic.co/guide/en/elasticsearch/reference/2.x/breaking_21_search_changes.html#_literal_search_type_scan_literal_deprecated
+	// See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_21_search_changes.html#_literal_search_type_scan_literal_deprecated
 	client := setupTestClientAndCreateIndex(t)
 
 	esversion, err := client.ElasticsearchVersion(DefaultURL)

--- a/search_aggs_bucket_sampler.go
+++ b/search_aggs_bucket_sampler.go
@@ -8,7 +8,7 @@ package elastic
 // sub aggregations' processing to a sample of the top-scoring documents.
 // Optionally, diversity settings can be used to limit the number of matches
 // that share a common value such as an "author".
-// See: https://www.elastic.co/guide/en/elasticsearch/reference/2.x/search-aggregations-bucket-sampler-aggregation.html
+// See: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-sampler-aggregation.html
 type SamplerAggregation struct {
 	field           string
 	script          *Script


### PR DESCRIPTION
Hi,
Simple change just to help people finding the right reference documentation.

Actual docs refer to broken 404 page:

```
404 Well, That about Wraps It Up for This Page
`I refuse to prove that I exist,’ says Page, `for proof denies faith, and without faith I am nothing.’

`But,’ says Man, `The Babel fish is a dead giveaway, isn’t it? It could not have evolved by chance. It proves you exist, and so therefore, by your own arguments, you don’t. QED.’

`Oh dear,’ says Page, `I hadn’t thought of that,’ and promptly disappears in a puff of logic.
```

Cheers.
