### PR TITLE
Rollover API isn't properly setting the Request Body

### DIFF
--- a/indices_rollover.go
+++ b/indices_rollover.go
@@ -236,8 +236,10 @@ func (s *IndicesRolloverService) Do(ctx context.Context) (*IndicesRolloverRespon
 	var body interface{}
 	if s.bodyJson != nil {
 		body = s.bodyJson
-	} else {
+	} else if s.bodyString != "" {
 		body = s.bodyString
+	} else {
+		body = s.getBody()
 	}
 
 	// Get HTTP response

--- a/indices_rollover.go
+++ b/indices_rollover.go
@@ -234,11 +234,12 @@ func (s *IndicesRolloverService) Do(ctx context.Context) (*IndicesRolloverRespon
 
 	// Setup HTTP request body
 	var body interface{}
-	if s.bodyJson != nil {
+	switch {
+	case s.bodyJson != nil:
 		body = s.bodyJson
-	} else if s.bodyString != "" {
+	case s.bodyString != "":
 		body = s.bodyString
-	} else {
+	default:
 		body = s.getBody()
 	}
 


### PR DESCRIPTION
After spending quite a bit of time wondering my rollover code wasn't working, I found that the rollover API doesn't actually set the body unless you call `BodyJson` or `BodyString`. 

Take the following code for example:

    idxSvc := s.RolloverIndex("my_index")
    idxSvc.AddMaxIndexDocsCondition(10)
    idxSvc.Mappings(idxConfig.mapping.Mappings)

    if resp, err = idxSvc.Do(context.TODO()); err != nil {
		fmt.Println(err)
	}

If you enable tracing, this is what you get:

    POST /my_index/_rollover HTTP/1.1
    Host: 127.0.0.1:9200
    User-Agent: elastic/5.0.4 (darwin-amd64)
    Transfer-Encoding: chunked
    Accept: application/json
    Content-Type: application/json
    Accept-Encoding: gzip

    HTTP/1.1 200 OK
    Transfer-Encoding: chunked
    Content-Type: application/json; charset=UTF-8

    {"old_index":"my_index-2016.11.18-000018","new_index":my_index-2016.11.18-000019","rolled_over":true,"dry_run":false,"acknowledged":false,"shards_acknowledged":false,"conditions":{}}

This PR will call `.getBody()` if `bodyString != ""` and `bodyJson == nil` 