### PR TITLE
Feature: Pipeline Stats Bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ See the [wiki](https://github.com/olivere/elastic/wiki) for more details.
   - [x] Bucket Script
   - [x] Bucket Selector
   - [x] Serial Differencing
+  - [x] Stats Bucket
 - [x] Aggregation Metadata
 
 ### Indices APIs

--- a/search_aggs.go
+++ b/search_aggs.go
@@ -503,6 +503,21 @@ func (a Aggregations) SumBucket(name string) (*AggregationPipelineSimpleValue, b
 	return nil, false
 }
 
+// StatsBucket returns stats bucket pipeline aggregation results.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-stats-bucket-aggregation.html
+func (a Aggregations) StatsBucket(name string) (*AggregationPipelineStatsMetric, bool) {
+	if raw, found := a[name]; found {
+		agg := new(AggregationPipelineStatsMetric)
+		if raw == nil {
+			return agg, true
+		}
+		if err := json.Unmarshal(*raw, agg); err == nil {
+			return agg, true
+		}
+	}
+	return nil, false
+}
+
 // MaxBucket returns maximum bucket pipeline aggregation results.
 // See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-max-bucket-aggregation.html
 func (a Aggregations) MaxBucket(name string) (*AggregationPipelineBucketMetricValue, bool) {
@@ -1265,6 +1280,70 @@ func (a *AggregationPipelineDerivative) UnmarshalJSON(data []byte) error {
 	}
 	if v, ok := aggs["normalized_value_as_string"]; ok && v != nil {
 		json.Unmarshal(*v, &a.NormalizedValueAsString)
+	}
+	if v, ok := aggs["meta"]; ok && v != nil {
+		json.Unmarshal(*v, &a.Meta)
+	}
+	a.Aggregations = aggs
+	return nil
+}
+
+// -- Pipeline stats metric --
+
+// AggregationPipelineStatsMetric is a simple value, returned e.g. by a
+// MovAvg aggregation.
+type AggregationPipelineStatsMetric struct {
+	Aggregations
+
+	Count         *float64 // `json:"count"`
+	CountAsString string   // `json:"count_as_string"`
+	Min           *float64 // `json:"min"`
+	MinAsString   string   // `json:"min_as_string"`
+	Max           *float64 // `json:"max"`
+	MaxAsString   string   // `json:"max_as_string"`
+	Avg           *float64 // `json:"avg"`
+	AvgAsString   string   // `json:"avg_as_string"`
+	Sum           *float64 // `json:"sum"`
+	SumAsString   string   // `json:"sum_as_string"`
+
+	Meta map[string]interface{} // `json:"meta,omitempty"`
+}
+
+// UnmarshalJSON decodes JSON data and initializes an AggregationPipelineStatsMetric structure.
+func (a *AggregationPipelineStatsMetric) UnmarshalJSON(data []byte) error {
+	var aggs map[string]*json.RawMessage
+	if err := json.Unmarshal(data, &aggs); err != nil {
+		return err
+	}
+	if v, ok := aggs["count"]; ok && v != nil {
+		json.Unmarshal(*v, &a.Count)
+	}
+	if v, ok := aggs["count_as_string"]; ok && v != nil {
+		json.Unmarshal(*v, &a.CountAsString)
+	}
+	if v, ok := aggs["min"]; ok && v != nil {
+		json.Unmarshal(*v, &a.Min)
+	}
+	if v, ok := aggs["min_as_string"]; ok && v != nil {
+		json.Unmarshal(*v, &a.MinAsString)
+	}
+	if v, ok := aggs["max"]; ok && v != nil {
+		json.Unmarshal(*v, &a.Max)
+	}
+	if v, ok := aggs["max_as_string"]; ok && v != nil {
+		json.Unmarshal(*v, &a.MaxAsString)
+	}
+	if v, ok := aggs["avg"]; ok && v != nil {
+		json.Unmarshal(*v, &a.Avg)
+	}
+	if v, ok := aggs["avg_as_string"]; ok && v != nil {
+		json.Unmarshal(*v, &a.AvgAsString)
+	}
+	if v, ok := aggs["sum"]; ok && v != nil {
+		json.Unmarshal(*v, &a.Sum)
+	}
+	if v, ok := aggs["sum_as_string"]; ok && v != nil {
+		json.Unmarshal(*v, &a.SumAsString)
 	}
 	if v, ok := aggs["meta"]; ok && v != nil {
 		json.Unmarshal(*v, &a.Meta)

--- a/search_aggs_pipeline_stats_bucket.go
+++ b/search_aggs_pipeline_stats_bucket.go
@@ -1,0 +1,113 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+// StatsBucketAggregation is a sibling pipeline aggregation which calculates
+// a variety of stats across all bucket of a specified metric in a sibling aggregation.
+// The specified metric must be numeric and the sibling aggregation must
+// be a multi-bucket aggregation.
+//
+// For more details, see
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-stats-bucket-aggregation.html
+type StatsBucketAggregation struct {
+	format    string
+	gapPolicy string
+
+	subAggregations map[string]Aggregation
+	meta            map[string]interface{}
+	bucketsPaths    []string
+}
+
+// NewStatsBucketAggregation creates and initializes a new StatsBucketAggregation.
+func NewStatsBucketAggregation() *StatsBucketAggregation {
+	return &StatsBucketAggregation{
+		subAggregations: make(map[string]Aggregation),
+		bucketsPaths:    make([]string, 0),
+	}
+}
+
+func (s *StatsBucketAggregation) Format(format string) *StatsBucketAggregation {
+	s.format = format
+	return s
+}
+
+// GapPolicy defines what should be done when a gap in the series is discovered.
+// Valid values include "insert_zeros" or "skip". Default is "insert_zeros".
+func (s *StatsBucketAggregation) GapPolicy(gapPolicy string) *StatsBucketAggregation {
+	s.gapPolicy = gapPolicy
+	return s
+}
+
+// GapInsertZeros inserts zeros for gaps in the series.
+func (s *StatsBucketAggregation) GapInsertZeros() *StatsBucketAggregation {
+	s.gapPolicy = "insert_zeros"
+	return s
+}
+
+// GapSkip skips gaps in the series.
+func (s *StatsBucketAggregation) GapSkip() *StatsBucketAggregation {
+	s.gapPolicy = "skip"
+	return s
+}
+
+// SubAggregation adds a sub-aggregation to this aggregation.
+func (s *StatsBucketAggregation) SubAggregation(name string, subAggregation Aggregation) *StatsBucketAggregation {
+	s.subAggregations[name] = subAggregation
+	return s
+}
+
+// Meta sets the meta data to be included in the aggregation response.
+func (s *StatsBucketAggregation) Meta(metaData map[string]interface{}) *StatsBucketAggregation {
+	s.meta = metaData
+	return s
+}
+
+// BucketsPath sets the paths to the buckets to use for this pipeline aggregator.
+func (s *StatsBucketAggregation) BucketsPath(bucketsPaths ...string) *StatsBucketAggregation {
+	s.bucketsPaths = append(s.bucketsPaths, bucketsPaths...)
+	return s
+}
+
+func (s *StatsBucketAggregation) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+	params := make(map[string]interface{})
+	source["stats_bucket"] = params
+
+	if s.format != "" {
+		params["format"] = s.format
+	}
+	if s.gapPolicy != "" {
+		params["gap_policy"] = s.gapPolicy
+	}
+
+	// Add buckets paths
+	switch len(s.bucketsPaths) {
+	case 0:
+	case 1:
+		params["buckets_path"] = s.bucketsPaths[0]
+	default:
+		params["buckets_path"] = s.bucketsPaths
+	}
+
+	// AggregationBuilder (SubAggregations)
+	if len(s.subAggregations) > 0 {
+		aggsMap := make(map[string]interface{})
+		source["aggregations"] = aggsMap
+		for name, aggregate := range s.subAggregations {
+			src, err := aggregate.Source()
+			if err != nil {
+				return nil, err
+			}
+			aggsMap[name] = src
+		}
+	}
+
+	// Add Meta data if available
+	if len(s.meta) > 0 {
+		source["meta"] = s.meta
+	}
+
+	return source, nil
+}

--- a/search_aggs_pipeline_stats_bucket_test.go
+++ b/search_aggs_pipeline_stats_bucket_test.go
@@ -1,0 +1,27 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStatsBucketAggregation(t *testing.T) {
+	agg := NewStatsBucketAggregation().BucketsPath("the_sum").GapPolicy("skip")
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"stats_bucket":{"buckets_path":"the_sum","gap_policy":"skip"}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}

--- a/search_aggs_test.go
+++ b/search_aggs_test.go
@@ -2967,6 +2967,62 @@ func TestAggsPipelineDerivative(t *testing.T) {
 	}
 }
 
+func TestAggsPipelineStatsBucket(t *testing.T) {
+	s := `{
+	"stats_monthly_sales": {
+	 "count": 3,
+	 "min": 60.0,
+	 "max": 550.0,
+	 "avg": 328.3333333333333,
+	 "sum": 985.0
+  }
+}`
+
+	aggs := new(Aggregations)
+	err := json.Unmarshal([]byte(s), &aggs)
+	if err != nil {
+		t.Fatalf("expected no error decoding; got: %v", err)
+	}
+
+	agg, found := aggs.StatsBucket("stats_monthly_sales")
+	if !found {
+		t.Fatalf("expected aggregation to be found; got: %v", found)
+	}
+	if agg == nil {
+		t.Fatalf("expected aggregation != nil; got: %v", agg)
+	}
+	if agg.Count == nil {
+		t.Fatalf("expected aggregation count != nil; got: %v", agg.Count)
+	}
+	if *agg.Count != float64(3) {
+		t.Fatalf("expected aggregation count = %v; got: %v", float64(3), *agg.Count)
+	}
+	if agg.Min == nil {
+		t.Fatalf("expected aggregation min != nil; got: %v", agg.Min)
+	}
+	if *agg.Min != float64(60.0) {
+		t.Fatalf("expected aggregation min = %v; got: %v", float64(60.0), *agg.Min)
+	}
+	if agg.Max == nil {
+		t.Fatalf("expected aggregation max != nil; got: %v", agg.Max)
+	}
+	if *agg.Max != float64(550.0) {
+		t.Fatalf("expected aggregation max = %v; got: %v", float64(550.0), *agg.Max)
+	}
+	if agg.Avg == nil {
+		t.Fatalf("expected aggregation avg != nil; got: %v", agg.Avg)
+	}
+	if *agg.Avg != float64(328.3333333333333) {
+		t.Fatalf("expected aggregation average = %v; got: %v", float64(328.3333333333333), *agg.Avg)
+	}
+	if agg.Sum == nil {
+		t.Fatalf("expected aggregation sum != nil; got: %v", agg.Sum)
+	}
+	if *agg.Sum != float64(985.0) {
+		t.Fatalf("expected aggregation sum = %v; got: %v", float64(985.0), *agg.Sum)
+	}
+}
+
 func TestAggsPipelineCumulativeSum(t *testing.T) {
 	s := `{
 	"cumulative_sales" : {


### PR DESCRIPTION
This PR adds the operations for a Pipeline Stats Bucket aggregation, which is documented at https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-stats-bucket-aggregation.html.

I'm creating this PR into the `release-branch.v3` as I work with Elasticsearch `v2.3`. If this is not an appropriate PR for this branch, I'm happy to close it. The main impetus for this was having to avoid the necessity of creating several different aggregations for `AvgBucket`, `MinBucket`, `MaxBucket` and `SumBucket`.

If this is worth merging, I can follow up with subsequent PRs for the `ExtendedStatsBucket` and `PercentilesBucket` pipeline aggregations.