### PR TITLE
Add SetRawSource to ScanService

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -32,6 +32,7 @@ type ScanService struct {
 	indices      []string
 	types        []string
 	keepAlive    string
+	source       interface{}
 	searchSource *SearchSource
 	pretty       bool
 	routing      string
@@ -112,6 +113,11 @@ func (s *ScanService) SearchSource(searchSource *SearchSource) *ScanService {
 	if s.searchSource == nil {
 		s.searchSource = NewSearchSource().Query(NewMatchAllQuery())
 	}
+	return s
+}
+
+func (s *ScanService) SetRawSource(source interface{}) *ScanService {
+	s.source = source
 	return s
 }
 
@@ -263,7 +269,13 @@ func (s *ScanService) Do() (*ScanCursor, error) {
 	}
 
 	// Get response
-	body := s.searchSource.Source()
+	var body interface{}
+	if s.source != nil {
+		body = s.source
+	} else {
+		body = s.searchSource.Source()
+	}
+
 	res, err := s.client.PerformRequest("POST", path, params, body)
 	if err != nil {
 		return nil, err

--- a/scan_test.go
+++ b/scan_test.go
@@ -6,6 +6,7 @@ package elastic
 
 import (
 	"encoding/json"
+	"fmt"
 	_ "net/http"
 	"testing"
 )
@@ -304,6 +305,102 @@ func TestScanWithQuery(t *testing.T) {
 		Do()
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if cursor.Results == nil {
+		t.Fatalf("expected results != nil; got nil")
+	}
+	if cursor.Results.Hits == nil {
+		t.Fatalf("expected results.Hits != nil; got nil")
+	}
+	if cursor.Results.Hits.TotalHits != 2 {
+		t.Fatalf("expected results.Hits.TotalHits = %d; got %d", 2, cursor.Results.Hits.TotalHits)
+	}
+	if len(cursor.Results.Hits.Hits) != 0 {
+		t.Fatalf("expected len(results.Hits.Hits) = %d; got %d", 0, len(cursor.Results.Hits.Hits))
+	}
+
+	pages := 0
+	numDocs := 0
+
+	for {
+		searchResult, err := cursor.Next()
+		if err == EOS {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pages += 1
+
+		for _, hit := range searchResult.Hits.Hits {
+			if hit.Index != testIndexName {
+				t.Fatalf("expected SearchResult.Hits.Hit.Index = %q; got %q", testIndexName, hit.Index)
+			}
+			item := make(map[string]interface{})
+			err := json.Unmarshal(*hit.Source, &item)
+			if err != nil {
+				t.Fatal(err)
+			}
+			numDocs += 1
+		}
+	}
+
+	if pages <= 0 {
+		t.Errorf("expected to retrieve at least 1 page; got %d", pages)
+	}
+
+	if numDocs != 2 {
+		t.Errorf("expected to retrieve %d hits; got %d", 2, numDocs)
+	}
+}
+
+func TestScanWithRawSource(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
+	tweet2 := tweet{User: "olivere", Message: "Another unrelated topic."}
+	tweet3 := tweet{User: "sandrae", Message: "Cycling is fun."}
+
+	// Add all documents
+	_, err := client.Index().Index(testIndexName).Type("tweet").Id("1").BodyJson(&tweet1).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Index().Index(testIndexName).Type("tweet").Id("2").BodyJson(&tweet2).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Index().Index(testIndexName).Type("tweet").Id("3").BodyJson(&tweet3).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Flush().Index(testIndexName).Do()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type (
+		M map[string]interface{}
+	)
+	source := M{
+		"query": M{
+			"query_string": M{
+				"query": "olivere",
+			},
+		},
+	}
+
+	cursor, err := client.Scan(testIndexName).
+		Size(1).
+		SetRawSource(source).
+		Do()
+	if err != nil {
+		fmt.Println(err)
 	}
 
 	if cursor.Results == nil {


### PR DESCRIPTION
SearchService has a Source(query interface{}) method, useful for
performing direct requests crafted somewhere else in the code.
Having this available in ScanService is similarly useful.