### PR TITLE
added wait_for_no_relocating_shards call

### DIFF
--- a/cluster_health.go
+++ b/cluster_health.go
@@ -19,17 +19,18 @@ import (
 // See http://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
 // for details.
 type ClusterHealthService struct {
-	client                  *Client
-	pretty                  bool
-	indices                 []string
-	level                   string
-	local                   *bool
-	masterTimeout           string
-	timeout                 string
-	waitForActiveShards     *int
-	waitForNodes            string
-	waitForRelocatingShards *int
-	waitForStatus           string
+	client                    *Client
+	pretty                    bool
+	indices                   []string
+	level                     string
+	local                     *bool
+	masterTimeout             string
+	timeout                   string
+	waitForActiveShards       *int
+	waitForNodes              string
+	waitForRelocatingShards   *int
+	waitForNoRelocatingShards *bool
+	waitForStatus             string
 }
 
 // NewClusterHealthService creates a new ClusterHealthService.
@@ -84,9 +85,15 @@ func (s *ClusterHealthService) WaitForNodes(waitForNodes string) *ClusterHealthS
 	return s
 }
 
-// WaitForRelocatingShards can be used to wait until the specified number of relocating shards is finished.
+// WaitForRelocatingShards has been removed, use WaitForNoRelocatingShards instead.
 func (s *ClusterHealthService) WaitForRelocatingShards(waitForRelocatingShards int) *ClusterHealthService {
 	s.waitForRelocatingShards = &waitForRelocatingShards
+	return s
+}
+
+// WaitForNoRelocatingShards can be used to wait until all shard relocations are finished.
+func (s *ClusterHealthService) WaitForNoRelocatingShards(waitForNoRelocatingShards bool) *ClusterHealthService {
+	s.waitForNoRelocatingShards = &waitForNoRelocatingShards
 	return s
 }
 
@@ -154,6 +161,9 @@ func (s *ClusterHealthService) buildURL() (string, url.Values, error) {
 	}
 	if s.waitForRelocatingShards != nil {
 		params.Set("wait_for_relocating_shards", fmt.Sprintf("%v", s.waitForRelocatingShards))
+	}
+	if s.waitForNoRelocatingShards != nil {
+		params.Set("wait_for_no_relocating_shards", fmt.Sprintf("%v", *s.waitForNoRelocatingShards))
 	}
 	if s.waitForStatus != "" {
 		params.Set("wait_for_status", s.waitForStatus)

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -28,7 +28,6 @@ type ClusterHealthService struct {
 	timeout                   string
 	waitForActiveShards       *int
 	waitForNodes              string
-	waitForRelocatingShards   *int
 	waitForNoRelocatingShards *bool
 	waitForStatus             string
 }
@@ -82,12 +81,6 @@ func (s *ClusterHealthService) WaitForActiveShards(waitForActiveShards int) *Clu
 // Example: "12" to wait for exact values, ">12" and "<12" for ranges.
 func (s *ClusterHealthService) WaitForNodes(waitForNodes string) *ClusterHealthService {
 	s.waitForNodes = waitForNodes
-	return s
-}
-
-// WaitForRelocatingShards has been removed, use WaitForNoRelocatingShards instead.
-func (s *ClusterHealthService) WaitForRelocatingShards(waitForRelocatingShards int) *ClusterHealthService {
-	s.waitForRelocatingShards = &waitForRelocatingShards
 	return s
 }
 
@@ -158,9 +151,6 @@ func (s *ClusterHealthService) buildURL() (string, url.Values, error) {
 	}
 	if s.waitForNodes != "" {
 		params.Set("wait_for_nodes", s.waitForNodes)
-	}
-	if s.waitForRelocatingShards != nil {
-		params.Set("wait_for_relocating_shards", fmt.Sprintf("%v", s.waitForRelocatingShards))
 	}
 	if s.waitForNoRelocatingShards != nil {
 		params.Set("wait_for_no_relocating_shards", fmt.Sprintf("%v", *s.waitForNoRelocatingShards))


### PR DESCRIPTION
Version 5.0+ has depricated the Cluster Health Check parameter `wait_for_relocating_shards` (which takes a number of shards to wait for) and has replaced it with `wait_for_no_relocating_shards` (which takes a true/false value). See documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html

In v5.0+, using the deprecated parameter returns the response:
> Error 400 (Bad Request): wait_for_relocating_shards has been removed, use wait_for_no_relocating_shards [true/false] instead [type=illegal_argument_exception]

This change documents that the old parameter has been removed and adds the new parameter. I chose to not fully remove the old parameter so that if someone should use it mistakenly after updating to 5.0+ they will still get the error message that alerts them that it has been removed, and they will not assume that it continued to work as intended. 