### PR TITLE
Bugfix: AggregationPipelineStatsBucket.Count should be int64, not *float64

### DIFF
--- a/search_aggs.go
+++ b/search_aggs.go
@@ -1295,7 +1295,7 @@ func (a *AggregationPipelineDerivative) UnmarshalJSON(data []byte) error {
 type AggregationPipelineStatsMetric struct {
 	Aggregations
 
-	Count         *float64 // `json:"count"`
+	Count         int64    // `json:"count"`
 	CountAsString string   // `json:"count_as_string"`
 	Min           *float64 // `json:"min"`
 	MinAsString   string   // `json:"min_as_string"`

--- a/search_aggs_test.go
+++ b/search_aggs_test.go
@@ -2993,11 +2993,8 @@ func TestAggsPipelineStatsBucket(t *testing.T) {
 	if agg == nil {
 		t.Fatalf("expected aggregation != nil; got: %v", agg)
 	}
-	if agg.Count == nil {
-		t.Fatalf("expected aggregation count != nil; got: %v", agg.Count)
-	}
-	if *agg.Count != float64(3) {
-		t.Fatalf("expected aggregation count = %v; got: %v", float64(3), *agg.Count)
+	if agg.Count != 3 {
+		t.Fatalf("expected aggregation count = %v; got: %v", 3, agg.Count)
 	}
 	if agg.Min == nil {
 		t.Fatalf("expected aggregation min != nil; got: %v", agg.Min)


### PR DESCRIPTION
I noticed a problem with #422, when I saw that `Count` in [AggregationStatsMetric](https://github.com/olivere/elastic/blob/c39b96138de69a25630c9159ccc0393cab734861/search_aggs.go#L659) is an `int64`. `AggregationPipelineStatsMetric` should also have an `int64` `Count` property, for consistency.