### PR TITLE
add filter query to function_score

### DIFF
--- a/search_queries_fsq.go
+++ b/search_queries_fsq.go
@@ -13,6 +13,7 @@ package elastic
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
 type FunctionScoreQuery struct {
 	query      Query
+	filter     Query
 	boost      *float64
 	maxBoost   *float64
 	scoreMode  string
@@ -34,6 +35,11 @@ func NewFunctionScoreQuery() *FunctionScoreQuery {
 // Query sets the query for the function score query.
 func (q *FunctionScoreQuery) Query(query Query) *FunctionScoreQuery {
 	q.query = query
+	return q
+}
+
+func (q *FunctionScoreQuery) Filter(filter Query) *FunctionScoreQuery {
+	q.filter = filter
 	return q
 }
 
@@ -98,6 +104,14 @@ func (q *FunctionScoreQuery) Source() (interface{}, error) {
 			return nil, err
 		}
 		query["query"] = src
+	}
+
+	if q.filter != nil {
+		src, err := q.filter.Source()
+		if err != nil {
+			return nil, err
+		}
+		query["filter"] = src
 	}
 
 	if len(q.filters) == 1 && q.filters[0] == nil {

--- a/search_queries_fsq_test.go
+++ b/search_queries_fsq_test.go
@@ -12,6 +12,7 @@ import (
 func TestFunctionScoreQuery(t *testing.T) {
 	q := NewFunctionScoreQuery().
 		Query(NewTermQuery("name.last", "banon")).
+		Filter(NewTermQuery("name.last", "banon")).
 		Add(NewTermQuery("name.last", "banon"), NewWeightFactorFunction(1.5)).
 		AddScoreFunc(NewWeightFactorFunction(3)).
 		AddScoreFunc(NewRandomFunction()).
@@ -27,7 +28,7 @@ func TestFunctionScoreQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"function_score":{"boost":3,"functions":[{"filter":{"term":{"name.last":"banon"}},"weight":1.5},{"weight":3},{"random_score":{}}],"max_boost":10,"query":{"term":{"name.last":"banon"}},"score_mode":"avg"}}`
+	expected := `{"function_score":{"boost":3,"filter":{"term":{"name.last":"banon"}},"functions":[{"filter":{"term":{"name.last":"banon"}},"weight":1.5},{"weight":3},{"random_score":{}}],"max_boost":10,"query":{"term":{"name.last":"banon"}},"score_mode":"avg"}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
I fixed  https://github.com/olivere/elastic/issues/439.

ES2.x Function Score query accept query and filter.
https://www.elastic.co/guide/en/elasticsearch/guide/current/function-score-filters.html