### PR TITLE
Highlighting boundary chars

### DIFF
--- a/highlight.go
+++ b/highlight.go
@@ -19,7 +19,7 @@ type Highlight struct {
 	encoder               *string
 	requireFieldMatch     *bool
 	boundaryMaxScan       *int
-	boundaryChars         []rune
+	boundaryChars         *string
 	highlighterType       *string
 	fragmenter            *string
 	highlightQuery        Query
@@ -35,7 +35,6 @@ func NewHighlight() *Highlight {
 		fields:        make([]*HighlighterField, 0),
 		preTags:       make([]string, 0),
 		postTags:      make([]string, 0),
-		boundaryChars: make([]rune, 0),
 		options:       make(map[string]interface{}),
 	}
 	return hl
@@ -102,8 +101,8 @@ func (hl *Highlight) BoundaryMaxScan(boundaryMaxScan int) *Highlight {
 	return hl
 }
 
-func (hl *Highlight) BoundaryChars(boundaryChars ...rune) *Highlight {
-	hl.boundaryChars = append(hl.boundaryChars, boundaryChars...)
+func (hl *Highlight) BoundaryChars(boundaryChars string) *Highlight {
+	hl.boundaryChars = &boundaryChars //append(hl.boundaryChars, boundaryChars...)
 	return hl
 }
 
@@ -179,7 +178,7 @@ func (hl *Highlight) Source() (interface{}, error) {
 	if hl.boundaryMaxScan != nil {
 		source["boundary_max_scan"] = *hl.boundaryMaxScan
 	}
-	if hl.boundaryChars != nil && len(hl.boundaryChars) > 0 {
+	if hl.boundaryChars != nil {
 		source["boundary_chars"] = hl.boundaryChars
 	}
 	if hl.highlighterType != nil {

--- a/highlight.go
+++ b/highlight.go
@@ -102,7 +102,7 @@ func (hl *Highlight) BoundaryMaxScan(boundaryMaxScan int) *Highlight {
 }
 
 func (hl *Highlight) BoundaryChars(boundaryChars string) *Highlight {
-	hl.boundaryChars = &boundaryChars //append(hl.boundaryChars, boundaryChars...)
+	hl.boundaryChars = &boundaryChars
 	return hl
 }
 


### PR DESCRIPTION
It seems that the package currently generates the highlight boundary chars as an array:

```
{
   "boundary_chars":[
      32,
      9,
      10
   ],
   "fields":{
      "text":{}
   },
   "type":"fvh"
}
```

While ElasticSearch 5.1.1 wants a string:

```
{
   "boundary_chars":" \\t\\n",
   "fields":{
      "text":{}
   },
   "type":"fvh"
}
```

Otherwise throwing an error:

> elastic: Error 400 (Bad Request): [highlight] boundary_chars doesn't support values of type: START_ARRAY [type=illegal_argument_exception] 

