### PR TITLE
Updates example to provide string to refresh parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ _, err = client.Index().
     Type("tweet").
     Id("1").
     BodyJson(tweet).
-    Refresh(true).
+    Refresh("true").
     Do(ctx)
 if err != nil {
     // Handle error


### PR DESCRIPTION
For reasons I can't find in code/docs, v5 requires a string for `func (s *ExistsService) Refresh` compared to the bool in v4. This simple updates the example in the v5 branch to match the code requirements.

I am also curious why it has changed while the RealTime parameter has not. 