### PR TITLE
Multi Search ignore_unavailable option

### DIFF
--- a/search_request.go
+++ b/search_request.go
@@ -13,14 +13,15 @@ import (
 // query details (see SearchSource).
 // It is used in combination with MultiSearch.
 type SearchRequest struct {
-	searchType   string // default in ES is "query_then_fetch"
-	indices      []string
-	types        []string
-	routing      *string
-	preference   *string
-	requestCache *bool
-	scroll       string
-	source       interface{}
+	searchType        string // default in ES is "query_then_fetch"
+	indices           []string
+	types             []string
+	routing           *string
+	preference        *string
+	requestCache      *bool
+	ignoreUnavailable *bool
+	scroll            string
+	source            interface{}
 }
 
 // NewSearchRequest creates a new search request.
@@ -102,6 +103,11 @@ func (r *SearchRequest) RequestCache(requestCache bool) *SearchRequest {
 	return r
 }
 
+func (r *SearchRequest) IgnoreUnavailable(ia bool) *SearchRequest {
+	r.ignoreUnavailable = &ia
+	return r
+}
+
 func (r *SearchRequest) Scroll(scroll string) *SearchRequest {
 	r.scroll = scroll
 	return r
@@ -161,6 +167,10 @@ func (r *SearchRequest) header() interface{} {
 
 	if r.requestCache != nil {
 		h["request_cache"] = fmt.Sprintf("%v", *r.requestCache)
+	}
+
+	if r.ignoreUnavailable != nil {
+		h["ignore_unavailable"] = fmt.Sprintf("%v", *r.ignoreUnavailable)
 	}
 
 	if r.scroll != "" {

--- a/search_request_test.go
+++ b/search_request_test.go
@@ -36,6 +36,20 @@ func TestSearchRequestIndices(t *testing.T) {
 	}
 }
 
+func TestSearchRequestHasIgnoreUnavailable(t *testing.T) {
+	builder := NewSearchRequest().Index("test", "test2")
+	builder.IgnoreUnavailable(true)
+	data, err := json.Marshal(builder.header())
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"indices":["test","test2"],"ignore_unavailable":true}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
 func TestSearchRequestHasIndices(t *testing.T) {
 	builder := NewSearchRequest()
 	if builder.HasIndices() {


### PR DESCRIPTION
Hi there! My company relies on your excellent `olivere/elastic` Go binding, but for several of our uses we require the Multi Search API to expose the `ignore_unavailable` option. This PR adds that option, and a matching builder API call and unit test, to `SearchRequest`.

I submitted the patch applied to `release-branch.v5` but would really appreciate a backport to `release-branch.v3` if possible, should this PR be accepted. I have tested this code against `gopkg.in/olivere/elastic.v3` and it seems to work as expected.

 Thanks again for the great library! 