### PR TITLE
Eli/search profile api

### DIFF
--- a/search_source.go
+++ b/search_source.go
@@ -37,6 +37,7 @@ type SearchSource struct {
 	indexBoosts              map[string]float64
 	stats                    []string
 	innerHits                map[string]*InnerHit
+	profile                  bool
 }
 
 // NewSearchSource initializes a new SearchSource.
@@ -54,6 +55,13 @@ func NewSearchSource() *SearchSource {
 // Query sets the query to use with this search source.
 func (s *SearchSource) Query(query Query) *SearchSource {
 	s.query = query
+	return s
+}
+
+// Profile specifies that this search source should activate the
+// Profile API for queries made on it.
+func (s *SearchSource) Profile(should bool) *SearchSource {
+	s.profile = should
 	return s
 }
 
@@ -346,6 +354,9 @@ func (s *SearchSource) Source() (interface{}, error) {
 	}
 	if s.explain != nil {
 		source["explain"] = *s.explain
+	}
+	if s.profile {
+		source["profile"] = s.profile
 	}
 	if s.fetchSourceContext != nil {
 		src, err := s.fetchSourceContext.Source()

--- a/search_source_test.go
+++ b/search_source_test.go
@@ -275,3 +275,21 @@ func TestSearchSourceSearchAfter(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestSearchSourceProfiledQuery(t *testing.T) {
+	matchAllQ := NewMatchAllQuery()
+	builder := NewSearchSource().Query(matchAllQ).Profile(true)
+	src, err := builder.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"profile":true,"query":{"match_all":{}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}

--- a/search_test.go
+++ b/search_test.go
@@ -121,6 +121,20 @@ func TestSearchResultTotalHits(t *testing.T) {
 	}
 }
 
+func TestSearchResultWithProfiling(t *testing.T) {
+	client := setupTestClientAndCreateIndexAndAddDocs(t)
+
+	all := NewMatchAllQuery()
+	searchResult, err := client.Search().Index(testIndexName).Query(all).Profile(true).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if searchResult.Profile == nil {
+		t.Fatal("Profiled MatchAll query did not return profiling data with results")
+	}
+}
+
 func TestSearchResultEach(t *testing.T) {
 	client := setupTestClientAndCreateIndexAndAddDocs(t)
 


### PR DESCRIPTION
Just adds support for the [Profile API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-profile.html). Same deal as last time, was hoping to get this back ported to `olivere/elastic.v3` if you accept for `elastic.v5`. Tested and works with `elastic.v3` in my env. Thanks again!