### PR TITLE
Fix suggester score parsing

### DIFF
--- a/search.go
+++ b/search.go
@@ -497,7 +497,7 @@ type SearchSuggestionOption struct {
 	Index  string           `json:"_index"`
 	Type   string           `json:"_type"`
 	Id     string           `json:"_id"`
-	Score  float64          `json:"_score"`
+	Score  float64          `json:"score"`
 	Source *json.RawMessage `json:"_source"`
 }
 


### PR DESCRIPTION
This fixes issue #493.

I am not fully aware of the necessary fields that the type ```elastic.SearchSuggestionOption``` should have or not have, so I did not change anything else, though this likely hints that the block should be refactored to whatever the field names have been renamed to in the latest version of ElasticSearch.

Thank you for your help on this @olivere.