### PR TITLE
RetryFunc added

### DIFF
--- a/client.go
+++ b/client.go
@@ -79,10 +79,10 @@ const (
 )
 
 var (
-	// DefaultMaxRetriesFunc is the function that decides if a retry should be
+	// DefaultRetryFunc is the function that decides if a retry should be
 	// performed for a single request after Elastic gives up and returns an error.
 	// Retry is disabled by default (i.e. function always returns false).
-	DefaultMaxRetriesFunc = func(int) bool {
+	DefaultRetryFunc = func(int) bool {
 		return false
 	}
 
@@ -192,7 +192,7 @@ func NewClient(options ...ClientOptionFunc) (*Client, error) {
 		cindex:                    -1,
 		scheme:                    DefaultScheme,
 		decoder:                   &DefaultDecoder{},
-		doRetryFunc:               DefaultMaxRetriesFunc,
+		doRetryFunc:               DefaultRetryFunc,
 		healthcheckEnabled:        DefaultHealthcheckEnabled,
 		healthcheckTimeoutStartup: DefaultHealthcheckTimeoutStartup,
 		healthcheckTimeout:        DefaultHealthcheckTimeout,
@@ -466,11 +466,11 @@ func SetMaxRetries(maxRetries int) ClientOptionFunc {
 	}
 }
 
-// SetMaxRetriesFunc sets a function that decides if we should retry the
+// SetRetryFunc sets a function that decides if we should retry the
 // request after ES gives up and returns an error.
 // Function should accept int showing how many retries were already attempted,
 // starting from 1 (i.e. one request have been made).
-func SetMaxRetriesFunc(retriesFunc func(int) bool) ClientOptionFunc {
+func SetRetryFunc(retriesFunc func(int) bool) ClientOptionFunc {
 	return func(c *Client) error {
 		c.doRetryFunc = retriesFunc
 		return nil

--- a/client.go
+++ b/client.go
@@ -452,15 +452,15 @@ func SetHealthcheckInterval(interval time.Duration) ClientOptionFunc {
 	}
 }
 
-// SetMaxRetries sets the maximum number of retries before giving up when
-// performing a HTTP request to Elasticsearch.
+// SetMaxRetries sets the maximum number of Elastic HTTP requests per one
+// client request before giving up when ES returns an error.
 func SetMaxRetries(maxRetries int) ClientOptionFunc {
 	return func(c *Client) error {
 		if maxRetries < 0 {
 			return errors.New("MaxRetries must be greater than or equal to 0")
 		}
 		c.doRetryFunc = func(i int) bool {
-			return i <= maxRetries
+			return i < maxRetries
 		}
 		return nil
 	}


### PR DESCRIPTION
This PR replaces MaxRetries constant with RetryFunc that dynamically decides if a retry should be performed, making it possible to use rate-limiting and various feedback loops set by client's owner.

No APIs are broken except the removal of DefaultMaxRetries constant. It is possible to bring it back, but it would make the code less transparent.

Similar change can be made to every version of the client.