### PR TITLE
swap deprecated geo_bbox to geo_bounding_box

### DIFF
--- a/search_queries_geo_bounding_box.go
+++ b/search_queries_geo_bounding_box.go
@@ -83,7 +83,7 @@ func (q *GeoBoundingBoxQuery) QueryName(queryName string) *GeoBoundingBoxQuery {
 // Source returns JSON for the function score query.
 func (q *GeoBoundingBoxQuery) Source() (interface{}, error) {
 	// {
-	//   "geo_bbox" : {
+	//   "geo_bounding_box" : {
 	//     ...
 	//   }
 	// }
@@ -103,7 +103,7 @@ func (q *GeoBoundingBoxQuery) Source() (interface{}, error) {
 
 	source := make(map[string]interface{})
 	params := make(map[string]interface{})
-	source["geo_bbox"] = params
+	source["geo_bounding_box"] = params
 
 	box := make(map[string]interface{})
 	box["top_left"] = []float64{*q.left, *q.top}

--- a/search_queries_geo_bounding_box_test.go
+++ b/search_queries_geo_bounding_box_test.go
@@ -37,7 +37,7 @@ func TestGeoBoundingBoxQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"geo_bbox":{"pin.location":{"bottom_right":[-71.12,40.01],"top_left":[-74.1,40.73]},"type":"memory"}}`
+	expected := `{"geo_bounding_box":{"pin.location":{"bottom_right":[-71.12,40.01],"top_left":[-74.1,40.73]},"type":"memory"}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -56,7 +56,7 @@ func TestGeoBoundingBoxQueryWithGeoPoint(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"geo_bbox":{"pin.location":{"bottom_right":[-71.12,40.01],"top_left":[-74.1,40.73]}}}`
+	expected := `{"geo_bounding_box":{"pin.location":{"bottom_right":[-71.12,40.01],"top_left":[-74.1,40.73]}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
pretty small chore, was getting `Warning: Deprecated field [geo_bbox] used, expected [geo_bounding_box] instead` in my traces.