### PR TITLE
Add "version" field to IndicesGetTemplateResponse

### DIFF
--- a/indices_get_template.go
+++ b/indices_get_template.go
@@ -122,6 +122,7 @@ func (s *IndicesGetTemplateService) Do(ctx context.Context) (map[string]*Indices
 // IndicesGetTemplateResponse is the response of IndicesGetTemplateService.Do.
 type IndicesGetTemplateResponse struct {
 	Order    int                    `json:"order,omitempty"`
+	Version  int                    `json:"version,omitempty"`
 	Template string                 `json:"template,omitempty"`
 	Settings map[string]interface{} `json:"settings,omitempty"`
 	Mappings map[string]interface{} `json:"mappings,omitempty"`


### PR DESCRIPTION
As per the Elasticsearch [docs][0], you can provide a "version" field that is used for external management of templates.  This adds the field to the response message so it can be read.

[0]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#versioning-templates