### PR TITLE
Switch to stdlib context package (go1.8+)

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -6,11 +6,10 @@ package elastic
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/bulk_processor.go
+++ b/bulk_processor.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // BulkProcessorService allows to easily process bulk requests. It allows setting

--- a/bulk_processor_test.go
+++ b/bulk_processor_test.go
@@ -5,13 +5,12 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestBulkProcessorDefaults(t *testing.T) {

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestBulk(t *testing.T) {

--- a/clear_scroll.go
+++ b/clear_scroll.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 )
 
 // ClearScrollService clears one or more scroll contexts by their ids.

--- a/clear_scroll_test.go
+++ b/clear_scroll_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	_ "net/http"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestClearScroll(t *testing.T) {

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ package elastic
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 )
 

--- a/client.go
+++ b/client.go
@@ -17,8 +17,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context/ctxhttp"
 )
 
 const (
@@ -1204,7 +1202,7 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 		c.dumpRequest((*http.Request)(req))
 
 		// Get response
-		res, err := ctxhttp.Do(ctx, c.c, (*http.Request)(req))
+		res, err := c.c.Do((*http.Request)(req).WithContext(ctx))
 		if err == context.Canceled || err == context.DeadlineExceeded {
 			// Proceed, but don't mark the node as dead
 			return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ package elastic
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,8 +16,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func findConn(s string, slice ...*conn) (int, bool) {

--- a/cluster-test/cluster-test.go
+++ b/cluster-test/cluster-test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -16,8 +17,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/net/context"
 
 	elastic "gopkg.in/olivere/elastic.v5"
 )

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/cluster_health_test.go
+++ b/cluster_health_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"net/url"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestClusterHealth(t *testing.T) {

--- a/cluster_state.go
+++ b/cluster_state.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/cluster_state_test.go
+++ b/cluster_state_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"net/url"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestClusterState(t *testing.T) {

--- a/cluster_stats.go
+++ b/cluster_stats.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/cluster_stats_test.go
+++ b/cluster_stats_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"net/url"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestClusterStats(t *testing.T) {

--- a/count.go
+++ b/count.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/count_test.go
+++ b/count_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestCountURL(t *testing.T) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -6,11 +6,10 @@ package elastic
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"sync/atomic"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 type decoder struct {

--- a/delete.go
+++ b/delete.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/delete_by_query.go
+++ b/delete_by_query.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/delete_by_query_test.go
+++ b/delete_by_query_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestDeleteByQueryBuildURL(t *testing.T) {

--- a/delete_template.go
+++ b/delete_template.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/delete_template_test.go
+++ b/delete_template_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestDeleteTemplateValidate(t *testing.T) {

--- a/delete_test.go
+++ b/delete_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestDelete(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -5,14 +5,13 @@
 package elastic_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"reflect"
 	"time"
-
-	"golang.org/x/net/context"
 
 	elastic "gopkg.in/olivere/elastic.v5"
 )

--- a/exists.go
+++ b/exists.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/exists_test.go
+++ b/exists_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestExists(t *testing.T) {

--- a/explain.go
+++ b/explain.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/explain_test.go
+++ b/explain_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestExplain(t *testing.T) {

--- a/field_stats.go
+++ b/field_stats.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/get.go
+++ b/get.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/get_template.go
+++ b/get_template.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/get_template_test.go
+++ b/get_template_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestGetPutDeleteTemplate(t *testing.T) {

--- a/get_test.go
+++ b/get_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestGet(t *testing.T) {

--- a/highlight_test.go
+++ b/highlight_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestHighlighterField(t *testing.T) {

--- a/index.go
+++ b/index.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/index_test.go
+++ b/index_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndexLifecycle(t *testing.T) {

--- a/indices_analyze.go
+++ b/indices_analyze.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_analyze_test.go
+++ b/indices_analyze_test.go
@@ -1,9 +1,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesAnalyzeURL(t *testing.T) {

--- a/indices_close.go
+++ b/indices_close.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_close_test.go
+++ b/indices_close_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 // TODO(oe): Find out why this test fails on Travis CI.

--- a/indices_create.go
+++ b/indices_create.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"errors"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_create_test.go
+++ b/indices_create_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesLifecycle(t *testing.T) {

--- a/indices_delete.go
+++ b/indices_delete.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_delete_template.go
+++ b/indices_delete_template.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_delete_test.go
+++ b/indices_delete_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesDeleteValidate(t *testing.T) {

--- a/indices_exists.go
+++ b/indices_exists.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_exists_template.go
+++ b/indices_exists_template.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_exists_template_test.go
+++ b/indices_exists_template_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndexExistsTemplate(t *testing.T) {

--- a/indices_exists_test.go
+++ b/indices_exists_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesExistsWithoutIndex(t *testing.T) {

--- a/indices_exists_type.go
+++ b/indices_exists_type.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_exists_type_test.go
+++ b/indices_exists_type_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesExistsTypeBuildURL(t *testing.T) {

--- a/indices_flush.go
+++ b/indices_flush.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_flush_test.go
+++ b/indices_flush_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestFlush(t *testing.T) {

--- a/indices_forcemerge.go
+++ b/indices_forcemerge.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_forcemerge_test.go
+++ b/indices_forcemerge_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesForcemergeBuildURL(t *testing.T) {

--- a/indices_get.go
+++ b/indices_get.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_get_aliases.go
+++ b/indices_get_aliases.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_get_aliases_test.go
+++ b/indices_get_aliases_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestAliasesBuildURL(t *testing.T) {

--- a/indices_get_field_mapping.go
+++ b/indices_get_field_mapping.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_get_mapping.go
+++ b/indices_get_mapping.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_get_settings.go
+++ b/indices_get_settings.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_get_settings_test.go
+++ b/indices_get_settings_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndexGetSettingsURL(t *testing.T) {

--- a/indices_get_template.go
+++ b/indices_get_template.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_get_test.go
+++ b/indices_get_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesGetValidate(t *testing.T) {

--- a/indices_open.go
+++ b/indices_open.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_open_test.go
+++ b/indices_open_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesOpenValidate(t *testing.T) {

--- a/indices_put_alias.go
+++ b/indices_put_alias.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 // -- Actions --

--- a/indices_put_alias_test.go
+++ b/indices_put_alias_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 const (

--- a/indices_put_mapping.go
+++ b/indices_put_mapping.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_put_mapping_test.go
+++ b/indices_put_mapping_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestPutMappingURL(t *testing.T) {

--- a/indices_put_settings.go
+++ b/indices_put_settings.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_put_settings_test.go
+++ b/indices_put_settings_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndicesPutSettingsBuildURL(t *testing.T) {

--- a/indices_put_template.go
+++ b/indices_put_template.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_refresh.go
+++ b/indices_refresh.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_refresh_test.go
+++ b/indices_refresh_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestRefreshBuildURL(t *testing.T) {

--- a/indices_rollover.go
+++ b/indices_rollover.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_shrink.go
+++ b/indices_shrink.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_stats.go
+++ b/indices_stats.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/indices_stats_test.go
+++ b/indices_stats_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestIndexStatsBuildURL(t *testing.T) {

--- a/ingest_delete_pipeline.go
+++ b/ingest_delete_pipeline.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/ingest_get_pipeline.go
+++ b/ingest_get_pipeline.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/ingest_put_pipeline.go
+++ b/ingest_put_pipeline.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/ingest_simulate_pipeline.go
+++ b/ingest_simulate_pipeline.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/mget.go
+++ b/mget.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 // MgetService allows to get multiple documents based on an index,

--- a/mget_test.go
+++ b/mget_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestMultiGet(t *testing.T) {

--- a/msearch.go
+++ b/msearch.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 // MultiSearch executes one or more searches in one roundtrip.

--- a/msearch_test.go
+++ b/msearch_test.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	_ "net/http"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestMultiSearch(t *testing.T) {

--- a/mtermvectors.go
+++ b/mtermvectors.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/mtermvectors_test.go
+++ b/mtermvectors_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestMultiTermVectorsValidateAndBuildURL(t *testing.T) {

--- a/nodes_info.go
+++ b/nodes_info.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/nodes_info_test.go
+++ b/nodes_info_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestNodesInfo(t *testing.T) {

--- a/nodes_stats.go
+++ b/nodes_stats.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/nodes_stats_test.go
+++ b/nodes_stats_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestNodesStats(t *testing.T) {

--- a/percolate_test.go
+++ b/percolate_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestPercolate(t *testing.T) {

--- a/ping.go
+++ b/ping.go
@@ -5,11 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
 
-	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 )
 

--- a/ping.go
+++ b/ping.go
@@ -9,8 +9,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-
-	"golang.org/x/net/context/ctxhttp"
 )
 
 // PingService checks if an Elasticsearch server on a given URL is alive.
@@ -111,7 +109,7 @@ func (s *PingService) Do(ctx context.Context) (*PingResult, int, error) {
 		req.SetBasicAuth(basicAuthUsername, basicAuthPassword)
 	}
 
-	res, err := ctxhttp.Do(ctx, s.client.c, (*http.Request)(req))
+	res, err := s.client.c.Do((*http.Request)(req).WithContext(ctx))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/ping_test.go
+++ b/ping_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"net/http"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestPingGet(t *testing.T) {

--- a/plugins.go
+++ b/plugins.go
@@ -4,7 +4,7 @@
 
 package elastic
 
-import "golang.org/x/net/context"
+import "context"
 
 // HasPlugin indicates whether the cluster has the named plugin.
 func (c *Client) HasPlugin(name string) (bool, error) {

--- a/put_template.go
+++ b/put_template.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/put_template_test.go
+++ b/put_template_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestSearchTemplatesLifecycle(t *testing.T) {

--- a/recipes/bulk_insert/bulk_insert.go
+++ b/recipes/bulk_insert/bulk_insert.go
@@ -24,6 +24,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"flag"
@@ -33,7 +34,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/olivere/elastic.v5"
 )

--- a/reindex.go
+++ b/reindex.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 )
 
 // ReindexService is a method to copy documents from one index to another.

--- a/reindex_test.go
+++ b/reindex_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestReindexSourceWithBodyMap(t *testing.T) {

--- a/retrier.go
+++ b/retrier.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // RetrierFunc specifies the signature of a Retry function.

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -5,13 +5,12 @@
 package elastic
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 type testRetrier struct {

--- a/scroll.go
+++ b/scroll.go
@@ -5,13 +5,12 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
 	"strings"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/scroll_test.go
+++ b/scroll_test.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	_ "net/http"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestScroll(t *testing.T) {

--- a/search.go
+++ b/search.go
@@ -5,13 +5,12 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/search_aggs_pipeline_test.go
+++ b/search_aggs_pipeline_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestAggsIntegrationAvgBucket(t *testing.T) {

--- a/search_aggs_test.go
+++ b/search_aggs_test.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestAggs(t *testing.T) {

--- a/search_queries_common_terms_test.go
+++ b/search_queries_common_terms_test.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	_ "net/http"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestCommonTermsQuery(t *testing.T) {

--- a/search_queries_more_like_this_test.go
+++ b/search_queries_more_like_this_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestMoreLikeThisQuerySourceWithLikeText(t *testing.T) {

--- a/search_queries_simple_query_string_test.go
+++ b/search_queries_simple_query_string_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestSimpleQueryStringQuery(t *testing.T) {

--- a/search_suggester_test.go
+++ b/search_suggester_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestTermSuggester(t *testing.T) {

--- a/search_test.go
+++ b/search_test.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestSearchMatchAll(t *testing.T) {

--- a/setup_test.go
+++ b/setup_test.go
@@ -5,13 +5,12 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/rand"
 	"os"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 const (

--- a/suggest.go
+++ b/suggest.go
@@ -5,12 +5,11 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/suggest_test.go
+++ b/suggest_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestSuggestBuildURL(t *testing.T) {

--- a/tasks_cancel.go
+++ b/tasks_cancel.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/tasks_list.go
+++ b/tasks_list.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/tasks_list_test.go
+++ b/tasks_list_test.go
@@ -5,9 +5,8 @@
 package elastic
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestTasksListBuildURL(t *testing.T) {

--- a/termvectors.go
+++ b/termvectors.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/update.go
+++ b/update.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/update_by_query.go
+++ b/update_by_query.go
@@ -5,11 +5,10 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
 )

--- a/update_by_query_test.go
+++ b/update_by_query_test.go
@@ -5,10 +5,9 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestUpdateByQueryBuildURL(t *testing.T) {


### PR DESCRIPTION
Unfortunately the `ctxhttp` package is still under the `"x"` directory.  So we're still left with the `"golang.org/x/net/context/ctxhttp"` import path for `client.go` and `ping.go`. Hopefully this would be merged to stdlib in the near future.

This should address issue #425.