### PR TITLE
Add extra info on client related errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -1717,3 +1717,9 @@ func (c *Client) WaitForGreenStatus(timeout string) error {
 func (c *Client) WaitForYellowStatus(timeout string) error {
 	return c.WaitForStatus("yellow", timeout)
 }
+
+// IsConnError unwraps the given error value and checks if it is equal to
+// elastic.ErrNoClient.
+func IsConnErr(err error) bool {
+	return errors.Cause(err) == ErrNoClient
+}

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 func findConn(s string, slice ...*conn) (int, bool) {
@@ -271,7 +272,7 @@ func TestClientHealthcheckStartupTimeout(t *testing.T) {
 	start := time.Now()
 	_, err := NewClient(SetURL("http://localhost:9299"), SetHealthcheckTimeoutStartup(5*time.Second))
 	duration := time.Now().Sub(start)
-	if err != ErrNoClient {
+	if errors.Cause(err) != ErrNoClient {
 		t.Fatal(err)
 	}
 	if duration < 5*time.Second {
@@ -647,9 +648,9 @@ func TestClientSelectConnAllDead(t *testing.T) {
 	client.conns[1].MarkAsDead()
 
 	// If all connections are dead, next should make them alive again, but
-	// still return ErrNoClient when it first finds out.
+	// still return the wrapped error value ErrNoClient when it first finds out.
 	c, err := client.next()
-	if err != ErrNoClient {
+	if errors.Cause(err) != ErrNoClient {
 		t.Fatal(err)
 	}
 	if c != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,8 +16,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 func findConn(s string, slice ...*conn) (int, bool) {
@@ -272,7 +271,7 @@ func TestClientHealthcheckStartupTimeout(t *testing.T) {
 	start := time.Now()
 	_, err := NewClient(SetURL("http://localhost:9299"), SetHealthcheckTimeoutStartup(5*time.Second))
 	duration := time.Now().Sub(start)
-	if errors.Cause(err) != ErrNoClient {
+	if !IsConnErr(err) {
 		t.Fatal(err)
 	}
 	if duration < 5*time.Second {
@@ -648,9 +647,9 @@ func TestClientSelectConnAllDead(t *testing.T) {
 	client.conns[1].MarkAsDead()
 
 	// If all connections are dead, next should make them alive again, but
-	// still return the wrapped error value ErrNoClient when it first finds out.
+	// still return an error when it first finds out.
 	c, err := client.next()
-	if errors.Cause(err) != ErrNoClient {
+	if !IsConnErr(err) {
 		t.Fatal(err)
 	}
 	if c != nil {


### PR DESCRIPTION
Related to issue #510.

@olivere Let me know if you're OK with the level of detail added to `elastic.ErrNoClient`. Thanks.