### PR TITLE
Add more data on BulkResponseItem

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -305,6 +305,7 @@ type BulkResponseItem struct {
 	Id      string        `json:"_id,omitempty"`
 	Version int64         `json:"_version,omitempty"`
 	Status  int           `json:"status,omitempty"`
+	Result  string        `json:"result,omitempty"`
 	Found   bool          `json:"found,omitempty"`
 	Error   *ErrorDetails `json:"error,omitempty"`
 }

--- a/bulk.go
+++ b/bulk.go
@@ -300,14 +300,15 @@ type BulkResponse struct {
 
 // BulkResponseItem is the result of a single bulk request.
 type BulkResponseItem struct {
-	Index   string        `json:"_index,omitempty"`
-	Type    string        `json:"_type,omitempty"`
-	Id      string        `json:"_id,omitempty"`
-	Version int64         `json:"_version,omitempty"`
-	Status  int           `json:"status,omitempty"`
-	Result  string        `json:"result,omitempty"`
-	Found   bool          `json:"found,omitempty"`
-	Error   *ErrorDetails `json:"error,omitempty"`
+	Index         string        `json:"_index,omitempty"`
+	Type          string        `json:"_type,omitempty"`
+	Id            string        `json:"_id,omitempty"`
+	Version       int64         `json:"_version,omitempty"`
+	Status        int           `json:"status,omitempty"`
+	Result        string        `json:"result,omitempty"`
+	ForcedRefresh bool          `json:"forced_refresh,omitempty"`
+	Found         bool          `json:"found,omitempty"`
+	Error         *ErrorDetails `json:"error,omitempty"`
 }
 
 // Indexed returns all bulk request results of "index" actions.


### PR DESCRIPTION
In order to know if the bulk request returned 'noop' as the result, this commit added one more parameter to the BulkResponseItem struct.