### PR TITLE
Error field of GetResult of type string instead of ErrorDetails

### DIFF
--- a/get.go
+++ b/get.go
@@ -250,7 +250,5 @@ type GetResult struct {
 	Source  *json.RawMessage       `json:"_source,omitempty"`
 	Found   bool                   `json:"found,omitempty"`
 	Fields  map[string]interface{} `json:"fields,omitempty"`
-	//Error     string                 `json:"error,omitempty"` // used only in MultiGet
-	// TODO double-check that MultiGet now returns details error information
-	Error *ErrorDetails `json:"error,omitempty"` // only used in MultiGet
+	Error   string                 `json:"error,omitempty"` // used only in MultiGet
 }

--- a/mget_test.go
+++ b/mget_test.go
@@ -66,7 +66,7 @@ func TestMultiGet(t *testing.T) {
 	}
 
 	item := res.Docs[0]
-	if item.Error != nil {
+	if len(item.Error) != 0 {
 		t.Errorf("expected no error on item 0; got %v", item.Error)
 	}
 	if item.Source == nil {
@@ -81,7 +81,7 @@ func TestMultiGet(t *testing.T) {
 	}
 
 	item = res.Docs[1]
-	if item.Error != nil {
+	if len(item.Error) != 0 {
 		t.Errorf("expected no error on item 1; got %v", item.Error)
 	}
 	if item.Source == nil {


### PR DESCRIPTION
### WHAT
* Change the type of field `Error` to string instead of `ErrorDetails`.

### WHY
* `Error` field is used only in `MultiGet` which returns a `string` error rather than `ErrorDetails`. If an error occurred for one of the documents in the `MultiGet` request this causes the following unmarshalling error:

`json: cannot unmarshal string into Go value of type elastic.ErrorDetails`

this obscured the actual error.

### WHO
@yayalice