### PR TITLE
Prefix query new format

### DIFF
--- a/search_queries_prefix.go
+++ b/search_queries_prefix.go
@@ -50,7 +50,7 @@ func (q *PrefixQuery) Source() (interface{}, error) {
 		query[q.name] = q.prefix
 	} else {
 		subQuery := make(map[string]interface{})
-		subQuery["prefix"] = q.prefix
+		subQuery["value"] = q.prefix
 		if q.boost != nil {
 			subQuery["boost"] = *q.boost
 		}

--- a/search_queries_prefix_test.go
+++ b/search_queries_prefix_test.go
@@ -20,7 +20,7 @@ func TestPrefixQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"prefix":{"user":"ki"}}`
+	expected := `{"value":{"user":"ki"}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -38,7 +38,7 @@ func TestPrefixQueryWithOptions(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"prefix":{"user":{"_name":"my_query_name","prefix":"ki"}}}`
+	expected := `{"prefix":{"user":{"_name":"my_query_name","value":"ki"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
Use field `value` instead of `prefix` to get rid of deprecated warning.