### PR TITLE
Feature: Adds support for percentiles bucket pipeline aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ See the [wiki](https://github.com/olivere/elastic/wiki) for more details.
   - [x] Sum Bucket
   - [x] Stats Bucket
   - [ ] Extended Stats Bucket
-  - [ ] Percentiles Bucket
+  - [x] Percentiles Bucket
   - [x] Moving Average
   - [x] Cumulative Sum
   - [x] Bucket Script

--- a/search_aggs_pipeline_percentiles_bucket.go
+++ b/search_aggs_pipeline_percentiles_bucket.go
@@ -1,0 +1,113 @@
+// Copyright 2012-2015 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+// PercentilesBucketAggregation is a sibling pipeline aggregation which calculates
+// percentiles across all bucket of a specified metric in a sibling aggregation.
+// The specified metric must be numeric and the sibling aggregation must
+// be a multi-bucket aggregation.
+//
+// For more details, see
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-percentiles-bucket-aggregation.html
+type PercentilesBucketAggregation struct {
+	format    string
+	gapPolicy string
+
+	subAggregations map[string]Aggregation
+	meta            map[string]interface{}
+	bucketsPaths    []string
+}
+
+// NewPercentilesBucketAggregation creates and initializes a new PercentilesBucketAggregation.
+func NewPercentilesBucketAggregation() *PercentilesBucketAggregation {
+	return &PercentilesBucketAggregation{
+		subAggregations: make(map[string]Aggregation),
+		bucketsPaths:    make([]string, 0),
+	}
+}
+
+func (p *PercentilesBucketAggregation) Format(format string) *PercentilesBucketAggregation {
+	p.format = format
+	return p
+}
+
+// GapPolicy defines what should be done when a gap in the series is discovered.
+// Valid values include "insert_zeros" or "skip". Default is "insert_zeros".
+func (p *PercentilesBucketAggregation) GapPolicy(gapPolicy string) *PercentilesBucketAggregation {
+	p.gapPolicy = gapPolicy
+	return p
+}
+
+// GapInsertZeros inserts zeros for gaps in the series.
+func (p *PercentilesBucketAggregation) GapInsertZeros() *PercentilesBucketAggregation {
+	p.gapPolicy = "insert_zeros"
+	return p
+}
+
+// GapSkip skips gaps in the series.
+func (p *PercentilesBucketAggregation) GapSkip() *PercentilesBucketAggregation {
+	p.gapPolicy = "skip"
+	return p
+}
+
+// SubAggregation adds a sub-aggregation to this aggregation.
+func (p *PercentilesBucketAggregation) SubAggregation(name string, subAggregation Aggregation) *PercentilesBucketAggregation {
+	p.subAggregations[name] = subAggregation
+	return p
+}
+
+// Meta sets the meta data to be included in the aggregation response.
+func (p *PercentilesBucketAggregation) Meta(metaData map[string]interface{}) *PercentilesBucketAggregation {
+	p.meta = metaData
+	return p
+}
+
+// BucketsPath sets the paths to the buckets to use for this pipeline aggregator.
+func (p *PercentilesBucketAggregation) BucketsPath(bucketsPaths ...string) *PercentilesBucketAggregation {
+	p.bucketsPaths = append(p.bucketsPaths, bucketsPaths...)
+	return p
+}
+
+func (p *PercentilesBucketAggregation) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+	params := make(map[string]interface{})
+	source["percentiles_bucket"] = params
+
+	if p.format != "" {
+		params["format"] = p.format
+	}
+	if p.gapPolicy != "" {
+		params["gap_policy"] = p.gapPolicy
+	}
+
+	// Add buckets paths
+	switch len(p.bucketsPaths) {
+	case 0:
+	case 1:
+		params["buckets_path"] = p.bucketsPaths[0]
+	default:
+		params["buckets_path"] = p.bucketsPaths
+	}
+
+	// AggregationBuilder (SubAggregations)
+	if len(p.subAggregations) > 0 {
+		aggsMap := make(map[string]interface{})
+		source["aggregations"] = aggsMap
+		for name, aggregate := range p.subAggregations {
+			src, err := aggregate.Source()
+			if err != nil {
+				return nil, err
+			}
+			aggsMap[name] = src
+		}
+	}
+
+	// Add Meta data if available
+	if len(p.meta) > 0 {
+		source["meta"] = p.meta
+	}
+
+	return source, nil
+}

--- a/search_aggs_pipeline_percentiles_bucket_test.go
+++ b/search_aggs_pipeline_percentiles_bucket_test.go
@@ -1,0 +1,27 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPercentilesBucketAggregation(t *testing.T) {
+	agg := NewPercentilesBucketAggregation().BucketsPath("the_sum").GapPolicy("skip")
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"percentiles_bucket":{"buckets_path":"the_sum","gap_policy":"skip"}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}

--- a/search_aggs_test.go
+++ b/search_aggs_test.go
@@ -3067,6 +3067,34 @@ func TestAggsPipelineDerivative(t *testing.T) {
 	}
 }
 
+func TestAggsPipelinePercentilesBucket(t *testing.T) {
+	s := `{
+	"sales_percentiles": {
+	  "values": {
+        "25.0": 100,
+        "50.0": 200,
+        "75.0": 300
+      }
+    }
+}`
+	aggs := new(Aggregations)
+	err := json.Unmarshal([]byte(s), &aggs)
+	if err != nil {
+		t.Fatalf("expected no error decoding; got: %v", err)
+	}
+
+	agg, found := aggs.PercentilesBucket("sales_percentiles")
+	if !found {
+		t.Fatalf("expected aggregation to be found; got: %v", found)
+	}
+	if agg == nil {
+		t.Fatalf("expected aggregation != nil; got: %v", agg)
+	}
+	if len(agg.Values) != 3 {
+		t.Fatalf("expected aggregation map with three entries; got: %v", agg.Values)
+	}
+}
+
 func TestAggsPipelineStatsBucket(t *testing.T) {
 	s := `{
 	"stats_monthly_sales": {


### PR DESCRIPTION
This PR adds the operations for a Percentiles Bucket aggregation, which is documented at https://www.elastic.co/guide/en/elasticsearch/reference/5.1/search-aggregations-pipeline-percentiles-bucket-aggregation.html.