### PR TITLE
Add Snapshot Create API

### DIFF
--- a/client.go
+++ b/client.go
@@ -1629,11 +1629,15 @@ func (c *Client) TasksList() *TasksListService {
 
 // -- Snapshot and Restore --
 
-// TODO Snapshot Create
 // TODO Snapshot Delete
 // TODO Snapshot Get
 // TODO Snapshot Restore
 // TODO Snapshot Status
+
+// SnapshotCreate creates a snapshot.
+func (c *Client) SnapshotCreate(repository string, snapshot string) *SnapshotCreateService {
+	return NewSnapshotCreateService(c).Repository(repository).Snapshot(snapshot)
+}
 
 // SnapshotCreateRepository creates or updates a snapshot repository.
 func (c *Client) SnapshotCreateRepository(repository string) *SnapshotCreateRepositoryService {

--- a/snapshot_create.go
+++ b/snapshot_create.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/olivere/elastic/uritemplates"
+	"gopkg.in/olivere/elastic.v5/uritemplates"
 )
 
 // SnapshotCreateService is documented at https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html.
@@ -150,6 +150,16 @@ func (s *SnapshotCreateService) Do(ctx context.Context) (*SnapshotCreateResponse
 	return ret, nil
 }
 
+// SnapshotShardFailure stores information about failures that occurred during shard snapshotting process.
+type SnapshotShardFailure struct {
+	Index     string `json:"index"`
+	IndexUUID string `json:"index_uuid"`
+	ShardID   int    `json:"shard_id"`
+	Reason    string `json:"reason"`
+	NodeID    string `json:"node_id"`
+	Status    string `json:"status"`
+}
+
 // SnapshotCreateResponse is the response of SnapshotCreateService.Do.
 type SnapshotCreateResponse struct {
 	// Accepted indicates whether the request was accepted by elasticsearch.
@@ -158,22 +168,19 @@ type SnapshotCreateResponse struct {
 
 	// Snapshot is available when waitForCompletion is true.
 	Snapshot *struct {
-		Snapshot          string        `json:"snapshot"`
-		UUID              string        `json:"uuid"`
-		VersionID         int           `json:"version_id"`
-		Version           string        `json:"version"`
-		Indices           []string      `json:"indices"`
-		State             string        `json:"state"`
-		StartTime         time.Time     `json:"start_time"`
-		StartTimeInMillis int64         `json:"start_time_in_millis"`
-		EndTime           time.Time     `json:"end_time"`
-		EndTimeInMillis   int64         `json:"end_time_in_millis"`
-		DurationInMillis  int           `json:"duration_in_millis"`
-		Failures          []interface{} `json:"failures"`
-		Shards            struct {
-			Total      int `json:"total"`
-			Failed     int `json:"failed"`
-			Successful int `json:"successful"`
-		} `json:"shards"`
+		Snapshot          string                 `json:"snapshot"`
+		UUID              string                 `json:"uuid"`
+		VersionID         int                    `json:"version_id"`
+		Version           string                 `json:"version"`
+		Indices           []string               `json:"indices"`
+		State             string                 `json:"state"`
+		Reason            string                 `json:"reason"`
+		StartTime         time.Time              `json:"start_time"`
+		StartTimeInMillis int64                  `json:"start_time_in_millis"`
+		EndTime           time.Time              `json:"end_time"`
+		EndTimeInMillis   int64                  `json:"end_time_in_millis"`
+		DurationInMillis  int64                  `json:"duration_in_millis"`
+		Failures          []SnapshotShardFailure `json:"failures"`
+		Shards            shardsInfo             `json:"shards"`
 	} `json:"snapshot"`
 }

--- a/snapshot_create.go
+++ b/snapshot_create.go
@@ -1,0 +1,179 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/olivere/elastic/uritemplates"
+)
+
+// SnapshotCreateService is documented at https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html.
+type SnapshotCreateService struct {
+	client            *Client
+	pretty            bool
+	repository        string
+	snapshot          string
+	masterTimeout     string
+	waitForCompletion *bool
+	bodyJson          interface{}
+	bodyString        string
+}
+
+// NewSnapshotCreateService creates a new SnapshotCreateService.
+func NewSnapshotCreateService(client *Client) *SnapshotCreateService {
+	return &SnapshotCreateService{
+		client: client,
+	}
+}
+
+// Repository is the repository name.
+func (s *SnapshotCreateService) Repository(repository string) *SnapshotCreateService {
+	s.repository = repository
+	return s
+}
+
+// Snapshot is the snapshot name.
+func (s *SnapshotCreateService) Snapshot(snapshot string) *SnapshotCreateService {
+	s.snapshot = snapshot
+	return s
+}
+
+// MasterTimeout is documented as: Explicit operation timeout for connection to master node.
+func (s *SnapshotCreateService) MasterTimeout(masterTimeout string) *SnapshotCreateService {
+	s.masterTimeout = masterTimeout
+	return s
+}
+
+// WaitForCompletion is documented as: Should this request wait until the operation has completed before returning.
+func (s *SnapshotCreateService) WaitForCompletion(waitForCompletion bool) *SnapshotCreateService {
+	s.waitForCompletion = &waitForCompletion
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *SnapshotCreateService) Pretty(pretty bool) *SnapshotCreateService {
+	s.pretty = pretty
+	return s
+}
+
+// BodyJson is documented as: The snapshot definition.
+func (s *SnapshotCreateService) BodyJson(body interface{}) *SnapshotCreateService {
+	s.bodyJson = body
+	return s
+}
+
+// BodyString is documented as: The snapshot definition.
+func (s *SnapshotCreateService) BodyString(body string) *SnapshotCreateService {
+	s.bodyString = body
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *SnapshotCreateService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_snapshot/{repository}/{snapshot}", map[string]string{
+		"snapshot":   s.snapshot,
+		"repository": s.repository,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "1")
+	}
+	if s.masterTimeout != "" {
+		params.Set("master_timeout", s.masterTimeout)
+	}
+	if s.waitForCompletion != nil {
+		params.Set("wait_for_completion", fmt.Sprintf("%v", *s.waitForCompletion))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *SnapshotCreateService) Validate() error {
+	var invalid []string
+	if s.repository == "" {
+		invalid = append(invalid, "Repository")
+	}
+	if s.snapshot == "" {
+		invalid = append(invalid, "Snapshot")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *SnapshotCreateService) Do(ctx context.Context) (*SnapshotCreateResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup HTTP request body
+	var body interface{}
+	if s.bodyJson != nil {
+		body = s.bodyJson
+	} else {
+		body = s.bodyString
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(SnapshotCreateResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// SnapshotCreateResponse is the response of SnapshotCreateService.Do.
+type SnapshotCreateResponse struct {
+	// Accepted indicates whether the request was accepted by elasticsearch.
+	// It's available when waitForCompletion is false.
+	Accepted *bool `json:"accepted"`
+
+	// Snapshot is available when waitForCompletion is true.
+	Snapshot *struct {
+		Snapshot          string        `json:"snapshot"`
+		UUID              string        `json:"uuid"`
+		VersionID         int           `json:"version_id"`
+		Version           string        `json:"version"`
+		Indices           []string      `json:"indices"`
+		State             string        `json:"state"`
+		StartTime         time.Time     `json:"start_time"`
+		StartTimeInMillis int64         `json:"start_time_in_millis"`
+		EndTime           time.Time     `json:"end_time"`
+		EndTimeInMillis   int64         `json:"end_time_in_millis"`
+		DurationInMillis  int           `json:"duration_in_millis"`
+		Failures          []interface{} `json:"failures"`
+		Shards            struct {
+			Total      int `json:"total"`
+			Failed     int `json:"failed"`
+			Successful int `json:"successful"`
+		} `json:"shards"`
+	} `json:"snapshot"`
+}

--- a/snapshot_create_test.go
+++ b/snapshot_create_test.go
@@ -1,0 +1,63 @@
+package elastic
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestSnapshotValidate(t *testing.T) {
+	var client *Client
+
+	err := NewSnapshotCreateService(client).Validate()
+	got := err.Error()
+	expected := "missing required fields: [Repository Snapshot]"
+	if got != expected {
+		t.Errorf("expected %q; got: %q", expected, got)
+	}
+}
+
+func TestSnapshotPutURL(t *testing.T) {
+	client := setupTestClient(t)
+
+	tests := []struct {
+		Repository        string
+		Snapshot          string
+		Pretty            bool
+		MasterTimeout     string
+		WaitForCompletion bool
+		ExpectedPath      string
+		ExpectedParams    url.Values
+	}{
+		{
+			Repository:        "repo",
+			Snapshot:          "snapshot_of_sunday",
+			Pretty:            true,
+			MasterTimeout:     "60s",
+			WaitForCompletion: true,
+			ExpectedPath:      "/_snapshot/repo/snapshot_of_sunday",
+			ExpectedParams: url.Values{
+				"pretty":              []string{"1"},
+				"master_timeout":      []string{"60s"},
+				"wait_for_completion": []string{"true"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		path, params, err := client.SnapshotCreate(test.Repository, test.Snapshot).
+			Pretty(test.Pretty).
+			MasterTimeout(test.MasterTimeout).
+			WaitForCompletion(test.WaitForCompletion).
+			buildURL()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if path != test.ExpectedPath {
+			t.Errorf("expected %q; got: %q", test.ExpectedPath, path)
+		}
+		if !reflect.DeepEqual(params, test.ExpectedParams) {
+			t.Errorf("expected %q; got: %q", test.ExpectedParams, params)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for Elasticsearch's [snapshot create API](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html).

Example program:
```go
package main

import (
	"context"
	"log"
	"os"
	"time"

	elastic "gopkg.in/olivere/elastic.v5"
)

func main() {
	client, err := elastic.NewClient()
	if err != nil {
		panic(err)
	}

	// create snapshot repo
	repo := elastic.
		NewSnapshotCreateRepositoryService(client).
		Repository("repo1").
		BodyJson(map[string]interface{}{
			"type": "fs",
			"settings": map[string]interface{}{
				"location": "/tmp/elasticsearch",
			},
		})

	repoResponse, err := repo.Do(context.TODO())
	if err != nil {
		panic(err)
	}

	if !repoResponse.Acknowledged {
		panic("could not ack repository create")
	}

	// create snapshot
	service := elastic.
		NewSnapshotCreateService(client).
		Repository("repo1").
		Snapshot(time.Now().Format("2006-01-02-15-04-05")).
		WaitForCompletion(true).
		BodyJson(map[string]interface{}{
			"indices":              "website",
			"ignore_unavailable":   false,
			"include_global_state": true,
		})

	response, err := service.Do(context.TODO())
	if err != nil {
		panic(err)
	}

	if response.Snapshot.State != "SUCCESS" {
		panic("elasticsearch snapshot state != SUCCESS: " + response.Snapshot.State)
	}
}
```