### PR TITLE
[v*] Healthcheck goroutine leaks

### DIFF
--- a/client.go
+++ b/client.go
@@ -995,7 +995,7 @@ func (c *Client) healthcheck(timeout time.Duration, force bool) {
 			if basicAuth {
 				req.SetBasicAuth(basicAuthUsername, basicAuthPassword)
 			}
-			res, err := c.c.Do((*http.Request)(req))
+			res, err := c.c.Do((*http.Request)(req).WithContext(ctx))
 			if res != nil {
 				status = res.StatusCode
 				if res.Body != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1141,11 +1141,11 @@ func TestRoutineLeaks(t *testing.T) {
 			},
 		},
 	}
-	defer leaktest.Check(t)()
-	cli.healthcheck(time.Second, true)
+	defer leaktest.CheckTimeout(t, time.Second*2)()
+	cli.healthcheck(time.Millisecond*500, true)
 
-	<-time.After(time.Second * 2)
-	srv.Close()
+	<-time.After(time.Second)
+	lis.Close()
 	if !reqCanceled {
 		t.Fatal("Request wasn't canceled")
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1144,9 +1144,8 @@ func TestRoutineLeaks(t *testing.T) {
 	defer leaktest.Check(t)()
 	cli.healthcheck(time.Second, true)
 
-	to, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	defer cancel()
-	srv.Shutdown(to)
+	<-time.After(time.Second * 2)
+	srv.Close()
 	if !reqCanceled {
 		t.Fatal("Request wasn't canceled")
 	}


### PR DESCRIPTION
Hi! This PR fixes goroutine leaks caused by healthcheck not using ctx properly.
I've managed to reproduce it via tests.