### PR TITLE
Boost Suggestions by Context

### DIFF
--- a/suggester_completion.go
+++ b/suggester_completion.go
@@ -123,7 +123,7 @@ func (q *CompletionSuggester) Source(includeName bool) (interface{}, error) {
 				ctxq[k] = v
 			}
 		}
-		suggester["context"] = ctxq
+		suggester["contexts"] = ctxq
 	}
 
 	// TODO(oe) Add completion-suggester specific parameters here

--- a/suggester_completion_test.go
+++ b/suggester_completion_test.go
@@ -45,9 +45,8 @@ func TestCompletionSuggesterSourceWithMultipleContexts(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expectedOption1 := `{"song-suggest":{"text":"n","completion":{"contexts":{"artist":[{"context":"Sting"}],"label":[{"context":"BMG"}]},"field":"suggest"}}}`
-	expectedOption2 := `{"song-suggest":{"text":"n","completion":{"contexts":{"label":[{"context":"BMG"}],"artist":[{"context":"Sting"}]},"field":"suggest"}}}`
-	if got != expectedOption1 && got != expectedOption2 {
-		t.Errorf("expected either\n%s\nor\n%s\n,got:\n%s", expectedOption1, expectedOption2, got)
+	expected := `{"song-suggest":{"text":"n","completion":{"contexts":{"artist":[{"context":"Sting"}],"label":[{"context":"BMG"}]},"field":"suggest"}}}`
+	if got != expected {
+		t.Errorf("expected %s\n,got:\n%s", expected, got)
 	}
 }

--- a/suggester_completion_test.go
+++ b/suggester_completion_test.go
@@ -45,8 +45,9 @@ func TestCompletionSuggesterSourceWithMultipleContexts(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"song-suggest":{"text":"n","completion":{"context":{"artist":"Sting","label":"BMG"},"field":"suggest"}}}`
-	if got != expected {
-		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	expectedOption1 := `{"song-suggest":{"text":"n","completion":{"contexts":{"artist":[{"context":"Sting"}],"label":[{"context":"BMG"}]},"field":"suggest"}}}`
+	expectedOption2 := `{"song-suggest":{"text":"n","completion":{"contexts":{"label":[{"context":"BMG"}],"artist":[{"context":"Sting"}]},"field":"suggest"}}}`
+	if got != expectedOption1 && got != expectedOption2 {
+		t.Errorf("expected either\n%s\nor\n%s\n,got:\n%s", expectedOption1, expectedOption2, got)
 	}
 }

--- a/suggester_context_category_test.go
+++ b/suggester_context_category_test.go
@@ -73,7 +73,7 @@ func TestSuggesterCategoryQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"color":"red"}`
+	expected := `{"color":[{"context":"red"}]}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -90,7 +90,43 @@ func TestSuggesterCategoryQueryWithTwoValues(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"color":["red","yellow"]}`
+	expected := `{"color":[{"context":"red"},{"context":"yellow"}]}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestSuggesterCategoryQueryWithBoost(t *testing.T) {
+	q := NewSuggesterCategoryQuery("color", "red")
+	q.ValueWithBoost("yellow", 4)
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"color":[{"context":"red"},{"boost":4,"context":"yellow"}]}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestSuggesterCategoryQueryWithoutBoost(t *testing.T) {
+	q := NewSuggesterCategoryQuery("color", "red")
+	q.Value("yellow")
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"color":[{"context":"red"},{"context":"yellow"}]}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/suggester_context_category_test.go
+++ b/suggester_context_category_test.go
@@ -90,9 +90,10 @@ func TestSuggesterCategoryQueryWithTwoValues(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"color":[{"context":"red"},{"context":"yellow"}]}`
-	if got != expected {
-		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	expectedOption1 := `{"color":[{"context":"red"},{"context":"yellow"}]}`
+	expectedOption2 := `{"color":[{"context":"yellow"},{"context":"red"}]}` // order is irrelevant to the results, and we model the query with a map which has no order guarantees
+	if got != expectedOption1 && got != expectedOption2 {
+		t.Errorf("expected either\n%s\nor\n%s\n,got:\n%s", expectedOption1, expectedOption2, got)
 	}
 }
 
@@ -108,9 +109,10 @@ func TestSuggesterCategoryQueryWithBoost(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"color":[{"context":"red"},{"boost":4,"context":"yellow"}]}`
-	if got != expected {
-		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	expectedOption1 := `{"color":[{"context":"red"},{"boost":4,"context":"yellow"}]}`
+	expectedOption2 := `{"color":[{"boost":4,"context":"yellow"},{"context":"red"}]}`
+	if got != expectedOption1 && got != expectedOption2 {
+		t.Errorf("expected either\n%s\nor\n%s\n,got:\n%s", expectedOption1, expectedOption2, got)
 	}
 }
 
@@ -126,8 +128,9 @@ func TestSuggesterCategoryQueryWithoutBoost(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"color":[{"context":"red"},{"context":"yellow"}]}`
-	if got != expected {
-		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	expectedOption1 := `{"color":[{"context":"red"},{"context":"yellow"}]}`
+	expectedOption2 := `{"color":[{"context":"yellow"},{"context":"red"}]}`
+	if got != expectedOption1 && got != expectedOption2 {
+		t.Errorf("expected either\n%s\nor\n%s\n,got:\n%s", expectedOption1, expectedOption2, got)
 	}
 }

--- a/suggester_context_category_test.go
+++ b/suggester_context_category_test.go
@@ -90,10 +90,9 @@ func TestSuggesterCategoryQueryWithTwoValues(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expectedOption1 := `{"color":[{"context":"red"},{"context":"yellow"}]}`
-	expectedOption2 := `{"color":[{"context":"yellow"},{"context":"red"}]}` // order is irrelevant to the results, and we model the query with a map which has no order guarantees
-	if got != expectedOption1 && got != expectedOption2 {
-		t.Errorf("expected either\n%s\nor\n%s\n,got:\n%s", expectedOption1, expectedOption2, got)
+	expected := `{"color":[{"context":"red"},{"context":"yellow"}]}`
+	if got != expected {
+		t.Errorf("expected %s\n,got:\n%s", expected, got)
 	}
 }
 
@@ -109,10 +108,9 @@ func TestSuggesterCategoryQueryWithBoost(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expectedOption1 := `{"color":[{"context":"red"},{"boost":4,"context":"yellow"}]}`
-	expectedOption2 := `{"color":[{"boost":4,"context":"yellow"},{"context":"red"}]}`
-	if got != expectedOption1 && got != expectedOption2 {
-		t.Errorf("expected either\n%s\nor\n%s\n,got:\n%s", expectedOption1, expectedOption2, got)
+	expected := `{"color":[{"context":"red"},{"boost":4,"context":"yellow"}]}`
+	if got != expected {
+		t.Errorf("expected %s\n,got:\n%s", expected, got)
 	}
 }
 
@@ -128,9 +126,8 @@ func TestSuggesterCategoryQueryWithoutBoost(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expectedOption1 := `{"color":[{"context":"red"},{"context":"yellow"}]}`
-	expectedOption2 := `{"color":[{"context":"yellow"},{"context":"red"}]}`
-	if got != expectedOption1 && got != expectedOption2 {
-		t.Errorf("expected either\n%s\nor\n%s\n,got:\n%s", expectedOption1, expectedOption2, got)
+	expected := `{"color":[{"context":"red"},{"context":"yellow"}]}`
+	if got != expected {
+		t.Errorf("expected %s\n,got:\n%s", expected, got)
 	}
 }


### PR DESCRIPTION
Elasticsearch supports boosting by certain suggester categories - see [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.2/suggester-context.html#_category_query). 

This PR adds support for the boost field, while maintaining backwards compatibility.

**N.B.** The order of contexts is not important to the query, and so I didn't maintain their order in the json output. I didn't want to change the way you did tests (by parsing the json and comparing them), or add any new dependencies, so I simply gave the output two acceptable options. Hope that's ok.