### PR TITLE
Change prefix_len key to prefix_length in suggester options

### DIFF
--- a/suggester_term.go
+++ b/suggester_term.go
@@ -214,7 +214,7 @@ func (q *TermSuggester) Source(includeName bool) (interface{}, error) {
 		suggester["max_term_freq"] = *q.maxTermFreq
 	}
 	if q.prefixLength != nil {
-		suggester["prefix_len"] = *q.prefixLength
+		suggester["prefix_length"] = *q.prefixLength
 	}
 	if q.minWordLength != nil {
 		suggester["min_word_len"] = *q.minWordLength

--- a/suggester_term_test.go
+++ b/suggester_term_test.go
@@ -27,3 +27,23 @@ func TestTermSuggesterSource(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestTermSuggesterWithPrefixLengthSource(t *testing.T) {
+	s := NewTermSuggester("name").
+		Text("n").
+		Field("suggest").
+		PrefixLength(0)
+	src, err := s.Source(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"name":{"text":"n","term":{"field":"suggest","prefix_length":0}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
Hi, 
I'm trying to query ES5.4 term suggester with prefix_lengh option, but I get error from server:
```   
"error": {
      "type": "parsing_exception",
      "reason": "suggester[term] doesn't support field [prefix_len]"
   },
   "status": 400
}
```
as described [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-suggesters-term.html#_other_term_suggest_options) "prefix_len" option name  is deprecated, it should be "prefix_length" for 5.x