### PR TITLE
Add support for context suggesters

### DIFF
--- a/search_suggester_test.go
+++ b/search_suggester_test.go
@@ -238,3 +238,109 @@ func TestCompletionSuggester(t *testing.T) {
 		t.Errorf("expected Text = 'Golang'; got %s", myOption.Text)
 	}
 }
+
+func TestContextSuggester(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t) // , SetTraceLog(log.New(os.Stdout, "", 0)))
+
+	// TODO make a nice way of creating tweets, as currently the context fields are unsupported as part of the suggestion fields
+	tweet1 := `
+	{
+		"user":"olivere",
+		"message":"Welcome to Golang and Elasticsearch.",
+		"retweets":0,
+		"created":"0001-01-01T00:00:00Z",
+		"suggest_field":{
+			"input":[
+			"Golang",
+			"Elasticsearch"
+			],
+			"contexts":{
+				"user_name": ["olivere"]
+			}
+		}
+	}
+	`
+	tweet2 := `
+	{
+		"user":"sandrae",
+		"message":"I like golfing",
+		"retweets":0,
+		"created":"0001-01-01T00:00:00Z",
+		"suggest_field":{
+			"input":[
+			"Golfing"
+			],
+			"contexts":{
+				"user_name": ["sandrae"]
+			}
+		}
+	}
+	`
+
+	// Add all documents
+	_, err := client.Index().Index(testIndexName).Type("tweet").Id("1").BodyString(tweet1).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Index().Index(testIndexName).Type("tweet").Id("2").BodyString(tweet2).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Flush().Index(testIndexName).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	suggesterName := "my-suggestions"
+	cs := NewContextSuggester(suggesterName)
+	cs = cs.Prefix("Gol")
+	cs = cs.Field("suggest_field")
+	cs = cs.ContextQueries(
+		NewSuggesterCategoryQuery("user_name", "olivere"),
+	)
+
+	searchResult, err := client.Search().
+		Index(testIndexName).
+		Suggester(cs).
+		Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if searchResult.Suggest == nil {
+		t.Errorf("expected SearchResult.Suggest != nil; got nil")
+	}
+	mySuggestions, found := searchResult.Suggest[suggesterName]
+	if !found {
+		t.Errorf("expected to find SearchResult.Suggest[%s]; got false", suggesterName)
+	}
+	if mySuggestions == nil {
+		t.Errorf("expected SearchResult.Suggest[%s] != nil; got nil", suggesterName)
+	}
+
+	// sandra's tweet is not returned because of the user_name context
+	if len(mySuggestions) != 1 {
+		t.Errorf("expected 1 suggestion; got %d", len(mySuggestions))
+	}
+	mySuggestion := mySuggestions[0]
+	if mySuggestion.Text != "Gol" {
+		t.Errorf("expected Text = 'Gol'; got %s", mySuggestion.Text)
+	}
+	if mySuggestion.Offset != 0 {
+		t.Errorf("expected Offset = %d; got %d", 0, mySuggestion.Offset)
+	}
+	if mySuggestion.Length != 3 {
+		t.Errorf("expected Length = %d; got %d", 3, mySuggestion.Length)
+	}
+	if len(mySuggestion.Options) != 1 {
+		t.Errorf("expected 1 option; got %d", len(mySuggestion.Options))
+	}
+	myOption := mySuggestion.Options[0]
+	if myOption.Text != "Golang" {
+		t.Errorf("expected Text = 'Golang'; got %s", myOption.Text)
+	}
+	if myOption.Id != "1" {
+		t.Errorf("expected Id = '1'; got %s", myOption.Id)
+	}
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -45,7 +45,13 @@ const (
 					"type":"geo_point"
 				},
 				"suggest_field":{
-					"type":"completion"
+					"type":"completion",
+					"contexts":[
+					{
+						"name":"user_name",
+						"type":"category"
+					}
+					]
 				}
 			}
 		},

--- a/suggester_context.go
+++ b/suggester_context.go
@@ -4,8 +4,121 @@
 
 package elastic
 
+import "errors"
+
 // SuggesterContextQuery is used to define context information within
 // a suggestion request.
 type SuggesterContextQuery interface {
 	Source() (interface{}, error)
+}
+
+// ContextSuggester is a fast suggester for e.g. type-ahead completion that supports filtering and boosting based on contexts.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/suggester-context.html
+// for more details.
+type ContextSuggester struct {
+	Suggester
+	name           string
+	prefix         string
+	field          string
+	size           *int
+	contextQueries []SuggesterContextQuery
+}
+
+// Creates a new context suggester.
+func NewContextSuggester(name string) *ContextSuggester {
+	return &ContextSuggester{
+		name:           name,
+		contextQueries: make([]SuggesterContextQuery, 0),
+	}
+}
+
+func (q *ContextSuggester) Name() string {
+	return q.name
+}
+
+func (q *ContextSuggester) Prefix(prefix string) *ContextSuggester {
+	q.prefix = prefix
+	return q
+}
+
+func (q *ContextSuggester) Field(field string) *ContextSuggester {
+	q.field = field
+	return q
+}
+
+func (q *ContextSuggester) Size(size int) *ContextSuggester {
+	q.size = &size
+	return q
+}
+
+func (q *ContextSuggester) ContextQuery(query SuggesterContextQuery) *ContextSuggester {
+	q.contextQueries = append(q.contextQueries, query)
+	return q
+}
+
+func (q *ContextSuggester) ContextQueries(queries ...SuggesterContextQuery) *ContextSuggester {
+	q.contextQueries = append(q.contextQueries, queries...)
+	return q
+}
+
+// contextSuggesterRequest is necessary because the order in which
+// the JSON elements are routed to Elasticsearch is relevant.
+// We got into trouble when using plain maps because the text element
+// needs to go before the completion element.
+type contextSuggesterRequest struct {
+	Prefix     string      `json:"prefix"`
+	Completion interface{} `json:"completion"`
+}
+
+// Creates the source for the context suggester.
+func (q *ContextSuggester) Source(includeName bool) (interface{}, error) {
+	cs := &contextSuggesterRequest{}
+
+	if q.prefix != "" {
+		cs.Prefix = q.prefix
+	}
+
+	suggester := make(map[string]interface{})
+	cs.Completion = suggester
+
+	if q.field != "" {
+		suggester["field"] = q.field
+	}
+	if q.size != nil {
+		suggester["size"] = *q.size
+	}
+	switch len(q.contextQueries) {
+	case 0:
+	case 1:
+		src, err := q.contextQueries[0].Source()
+		if err != nil {
+			return nil, err
+		}
+		suggester["context"] = src
+	default:
+		ctxq := make(map[string]interface{})
+		for _, query := range q.contextQueries {
+			src, err := query.Source()
+			if err != nil {
+				return nil, err
+			}
+			// Merge the dictionary into ctxq
+			m, ok := src.(map[string]interface{})
+			if !ok {
+				return nil, errors.New("elastic: context query is not a map")
+			}
+			for k, v := range m {
+				ctxq[k] = v
+			}
+		}
+		suggester["contexts"] = ctxq
+	}
+
+	if !includeName {
+		return cs, nil
+	}
+
+	source := make(map[string]interface{})
+	source[q.name] = cs
+	return source, nil
 }

--- a/suggester_context_test.go
+++ b/suggester_context_test.go
@@ -1,0 +1,51 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestContextSuggesterSource(t *testing.T) {
+	s := NewContextSuggester("place_suggestion").
+		Prefix("tim").
+		Field("suggest")
+	src, err := s.Source(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"place_suggestion":{"prefix":"tim","completion":{"field":"suggest"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestContextSuggesterSourceWithMultipleContexts(t *testing.T) {
+	s := NewContextSuggester("place_suggestion").
+		Prefix("tim").
+		Field("suggest").
+		ContextQueries(
+			NewSuggesterCategoryQuery("place_type", "cafe", "restaurants"),
+		)
+	src, err := s.Source(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"place_suggestion":{"prefix":"tim","completion":{"context":{"place_type":[{"context":"cafe"},{"context":"restaurants"}]},"field":"suggest"}}}`
+	if got != expected {
+		t.Errorf("expected %s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
Elasticsearch has 4 types of suggesters, however only 3 are currently supported by elastic. This PR adds support for the fourth type of suggester, [context suggesters](https://www.elastic.co/guide/en/elasticsearch/reference/current/suggester-context.html). This fixes #561. 