### PR TITLE
Add custom headers on HTTP requests

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -42,7 +42,7 @@ type BulkService struct {
 	sizeInBytes       int64
 	sizeInBytesCursor int
 
-	headers map[string]string
+	headers map[string][]string
 }
 
 // NewBulkService initializes a new BulkService.
@@ -120,8 +120,8 @@ func (s *BulkService) Pretty(pretty bool) *BulkService {
 }
 
 // Headers adds headers on the http request
-func (s *BulkService) Headers(headers map[string]string) *BulkService {
-	s.headers = headers
+func (s *BulkService) Header(key, value string) *BulkService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/bulk.go
+++ b/bulk.go
@@ -119,7 +119,7 @@ func (s *BulkService) Pretty(pretty bool) *BulkService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *BulkService) Header(key, value string) *BulkService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/bulk.go
+++ b/bulk.go
@@ -41,6 +41,8 @@ type BulkService struct {
 	// estimated bulk size in bytes, up to the request index sizeInBytesCursor
 	sizeInBytes       int64
 	sizeInBytesCursor int
+
+	headers map[string]string
 }
 
 // NewBulkService initializes a new BulkService.
@@ -114,6 +116,12 @@ func (s *BulkService) WaitForActiveShards(waitForActiveShards string) *BulkServi
 // Pretty tells Elasticsearch whether to return a formatted JSON response.
 func (s *BulkService) Pretty(pretty bool) *BulkService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *BulkService) Headers(headers map[string]string) *BulkService {
+	s.headers = headers
 	return s
 }
 
@@ -234,7 +242,7 @@ func (s *BulkService) Do(ctx context.Context) (*BulkResponse, error) {
 	}
 
 	// Get response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/bulk.go
+++ b/bulk.go
@@ -42,7 +42,7 @@ type BulkService struct {
 	sizeInBytes       int64
 	sizeInBytesCursor int
 
-	headers map[string][]string
+	headers headers
 }
 
 // NewBulkService initializes a new BulkService.

--- a/clear_scroll.go
+++ b/clear_scroll.go
@@ -18,7 +18,7 @@ type ClearScrollService struct {
 	client   *Client
 	pretty   bool
 	scrollId []string
-	headers  map[string]string
+	headers  map[string][]string
 }
 
 // NewClearScrollService creates a new ClearScrollService.
@@ -43,8 +43,8 @@ func (s *ClearScrollService) Pretty(pretty bool) *ClearScrollService {
 }
 
 // Headers adds headers on the http request
-func (s *ClearScrollService) Headers(headers map[string]string) *ClearScrollService {
-	s.headers = headers
+func (s *ClearScrollService) Header(key, value string) *ClearScrollService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/clear_scroll.go
+++ b/clear_scroll.go
@@ -18,6 +18,7 @@ type ClearScrollService struct {
 	client   *Client
 	pretty   bool
 	scrollId []string
+	headers  map[string]string
 }
 
 // NewClearScrollService creates a new ClearScrollService.
@@ -38,6 +39,12 @@ func (s *ClearScrollService) ScrollId(scrollIds ...string) *ClearScrollService {
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *ClearScrollService) Pretty(pretty bool) *ClearScrollService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *ClearScrollService) Headers(headers map[string]string) *ClearScrollService {
+	s.headers = headers
 	return s
 }
 
@@ -85,7 +92,7 @@ func (s *ClearScrollService) Do(ctx context.Context) (*ClearScrollResponse, erro
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/clear_scroll.go
+++ b/clear_scroll.go
@@ -42,7 +42,7 @@ func (s *ClearScrollService) Pretty(pretty bool) *ClearScrollService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *ClearScrollService) Header(key, value string) *ClearScrollService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/clear_scroll.go
+++ b/clear_scroll.go
@@ -18,7 +18,7 @@ type ClearScrollService struct {
 	client   *Client
 	pretty   bool
 	scrollId []string
-	headers  map[string][]string
+	headers  headers
 }
 
 // NewClearScrollService creates a new ClearScrollService.

--- a/client.go
+++ b/client.go
@@ -678,8 +678,8 @@ func SetRetrier(retrier Retrier) ClientOptionFunc {
 	}
 }
 
-// SetHeader adds key, value pair to the headers on each HTTP request to Elasticsearch
-func SetHeader(key, value string) ClientOptionFunc {
+// AddHeader adds key, value pair to the headers on each HTTP request to Elasticsearch
+func AddHeader(key, value string) ClientOptionFunc {
 	return func(c *Client) error {
 		c.headers = addHeader(c.headers, key, value)
 		return nil

--- a/client.go
+++ b/client.go
@@ -1175,7 +1175,7 @@ func (c *Client) mustActiveConn() error {
 // Optionally, a list of HTTP error codes to ignore can be passed.
 // This is necessary for services that expect e.g. HTTP status 404 as a
 // valid outcome (Exists, IndicesExists, IndicesTypeExists).
-func (c *Client) PerformRequest(ctx context.Context, method, path string, params url.Values, body interface{}, headers map[string]string, ignoreErrors ...int) (*Response, error) {
+func (c *Client) PerformRequest(ctx context.Context, method, path string, params url.Values, body interface{}, headers map[string][]string, ignoreErrors ...int) (*Response, error) {
 	start := time.Now().UTC()
 
 	c.mu.RLock()

--- a/client.go
+++ b/client.go
@@ -1175,7 +1175,7 @@ func (c *Client) mustActiveConn() error {
 // Optionally, a list of HTTP error codes to ignore can be passed.
 // This is necessary for services that expect e.g. HTTP status 404 as a
 // valid outcome (Exists, IndicesExists, IndicesTypeExists).
-func (c *Client) PerformRequest(ctx context.Context, method, path string, params url.Values, body interface{}, ignoreErrors ...int) (*Response, error) {
+func (c *Client) PerformRequest(ctx context.Context, method, path string, params url.Values, body interface{}, headers map[string]string, ignoreErrors ...int) (*Response, error) {
 	start := time.Now().UTC()
 
 	c.mu.RLock()
@@ -1237,6 +1237,10 @@ func (c *Client) PerformRequest(ctx context.Context, method, path string, params
 
 		if basicAuth {
 			req.SetBasicAuth(basicAuthUsername, basicAuthPassword)
+		}
+
+		if headers != nil {
+			req.SetCustomHeaders(headers)
 		}
 
 		// Set body

--- a/client.go
+++ b/client.go
@@ -111,33 +111,33 @@ type Client struct {
 	conns   []*conn      // all connections
 	cindex  int          // index into conns
 
-	mu                        sync.RWMutex        // guards the next block
-	urls                      []string            // set of URLs passed initially to the client
-	running                   bool                // true if the client's background processes are running
-	errorlog                  Logger              // error log for critical messages
-	infolog                   Logger              // information log for e.g. response times
-	tracelog                  Logger              // trace log for debugging
-	scheme                    string              // http or https
-	healthcheckEnabled        bool                // healthchecks enabled or disabled
-	healthcheckTimeoutStartup time.Duration       // time the healthcheck waits for a response from Elasticsearch on startup
-	healthcheckTimeout        time.Duration       // time the healthcheck waits for a response from Elasticsearch
-	healthcheckInterval       time.Duration       // interval between healthchecks
-	healthcheckStop           chan bool           // notify healthchecker to stop, and notify back
-	snifferEnabled            bool                // sniffer enabled or disabled
-	snifferTimeoutStartup     time.Duration       // time the sniffer waits for a response from nodes info API on startup
-	snifferTimeout            time.Duration       // time the sniffer waits for a response from nodes info API
-	snifferInterval           time.Duration       // interval between sniffing
-	snifferCallback           SnifferCallback     // callback to modify the sniffing decision
-	snifferStop               chan bool           // notify sniffer to stop, and notify back
-	decoder                   Decoder             // used to decode data sent from Elasticsearch
-	basicAuth                 bool                // indicates whether to send HTTP Basic Auth credentials
-	basicAuthUsername         string              // username for HTTP Basic Auth
-	basicAuthPassword         string              // password for HTTP Basic Auth
-	sendGetBodyAs             string              // override for when sending a GET with a body
-	requiredPlugins           []string            // list of required plugins
-	gzipEnabled               bool                // gzip compression enabled or disabled (default)
-	retrier                   Retrier             // strategy for retries
-	headers                   map[string][]string // headers populated on each http request to Elasticsearch
+	mu                        sync.RWMutex    // guards the next block
+	urls                      []string        // set of URLs passed initially to the client
+	running                   bool            // true if the client's background processes are running
+	errorlog                  Logger          // error log for critical messages
+	infolog                   Logger          // information log for e.g. response times
+	tracelog                  Logger          // trace log for debugging
+	scheme                    string          // http or https
+	healthcheckEnabled        bool            // healthchecks enabled or disabled
+	healthcheckTimeoutStartup time.Duration   // time the healthcheck waits for a response from Elasticsearch on startup
+	healthcheckTimeout        time.Duration   // time the healthcheck waits for a response from Elasticsearch
+	healthcheckInterval       time.Duration   // interval between healthchecks
+	healthcheckStop           chan bool       // notify healthchecker to stop, and notify back
+	snifferEnabled            bool            // sniffer enabled or disabled
+	snifferTimeoutStartup     time.Duration   // time the sniffer waits for a response from nodes info API on startup
+	snifferTimeout            time.Duration   // time the sniffer waits for a response from nodes info API
+	snifferInterval           time.Duration   // interval between sniffing
+	snifferCallback           SnifferCallback // callback to modify the sniffing decision
+	snifferStop               chan bool       // notify sniffer to stop, and notify back
+	decoder                   Decoder         // used to decode data sent from Elasticsearch
+	basicAuth                 bool            // indicates whether to send HTTP Basic Auth credentials
+	basicAuthUsername         string          // username for HTTP Basic Auth
+	basicAuthPassword         string          // password for HTTP Basic Auth
+	sendGetBodyAs             string          // override for when sending a GET with a body
+	requiredPlugins           []string        // list of required plugins
+	gzipEnabled               bool            // gzip compression enabled or disabled (default)
+	retrier                   Retrier         // strategy for retries
+	headers                   headers         // headers populated on each http request to Elasticsearch
 }
 
 // NewClient creates a new client to work with Elasticsearch.
@@ -678,7 +678,6 @@ func SetRetrier(retrier Retrier) ClientOptionFunc {
 	}
 }
 
-
 // SetHeader adds key, value pair to the headers on each HTTP request to Elasticsearch
 func SetHeader(key, value string) ClientOptionFunc {
 	return func(c *Client) error {
@@ -1192,7 +1191,7 @@ func (c *Client) mustActiveConn() error {
 // Optionally, a list of HTTP error codes to ignore can be passed.
 // This is necessary for services that expect e.g. HTTP status 404 as a
 // valid outcome (Exists, IndicesExists, IndicesTypeExists).
-func (c *Client) PerformRequest(ctx context.Context, method, path string, params url.Values, body interface{}, headers map[string][]string, ignoreErrors ...int) (*Response, error) {
+func (c *Client) PerformRequest(ctx context.Context, method, path string, params url.Values, body interface{}, headers headers, ignoreErrors ...int) (*Response, error) {
 	start := time.Now().UTC()
 
 	c.mu.RLock()

--- a/client_test.go
+++ b/client_test.go
@@ -873,7 +873,7 @@ func TestPerformRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -895,7 +895,7 @@ func TestPerformRequestWithSimpleClient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -921,7 +921,7 @@ func TestPerformRequestWithLogger(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -960,7 +960,7 @@ func TestPerformRequestWithLoggerAndTracer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -995,7 +995,7 @@ func TestPerformRequestWithTracerOnError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.PerformRequest(context.TODO(), "GET", "/no-such-index", nil, nil)
+	client.PerformRequest(context.TODO(), "GET", "/no-such-index", nil, nil, nil)
 
 	tgot := tw.String()
 	if tgot == "" {
@@ -1019,7 +1019,7 @@ func TestPerformRequestWithCustomLogger(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1082,7 +1082,7 @@ func TestPerformRequestRetryOnHttpError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := client.PerformRequest(context.TODO(), "GET", "/fail", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/fail", nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -1112,7 +1112,7 @@ func TestPerformRequestNoRetryOnValidButUnsuccessfulHttpStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := client.PerformRequest(context.TODO(), "GET", "/fail", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/fail", nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -1141,7 +1141,7 @@ func TestPerformRequestWithSetBodyError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, failingBody{})
+	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, failingBody{}, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -1178,7 +1178,7 @@ func TestPerformRequestWithCancel(t *testing.T) {
 
 	resc := make(chan result, 1)
 	go func() {
-		res, err := client.PerformRequest(ctx, "GET", "/", nil, nil)
+		res, err := client.PerformRequest(ctx, "GET", "/", nil, nil, nil)
 		resc <- result{res: res, err: err}
 	}()
 	select {
@@ -1213,7 +1213,7 @@ func TestPerformRequestWithTimeout(t *testing.T) {
 
 	resc := make(chan result, 1)
 	go func() {
-		res, err := client.PerformRequest(ctx, "GET", "/", nil, nil)
+		res, err := client.PerformRequest(ctx, "GET", "/", nil, nil, nil)
 		resc <- result{res: res, err: err}
 	}()
 	select {
@@ -1261,7 +1261,7 @@ func testPerformRequestWithCompression(t *testing.T, hc *http.Client) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -29,7 +29,7 @@ type ClusterHealthService struct {
 	waitForNodes              string
 	waitForNoRelocatingShards *bool
 	waitForStatus             string
-	headers                   map[string][]string
+	headers                   headers
 }
 
 // NewClusterHealthService creates a new ClusterHealthService.

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -29,7 +29,7 @@ type ClusterHealthService struct {
 	waitForNodes              string
 	waitForNoRelocatingShards *bool
 	waitForStatus             string
-	headers                   map[string]string
+	headers                   map[string][]string
 }
 
 // NewClusterHealthService creates a new ClusterHealthService.
@@ -114,8 +114,8 @@ func (s *ClusterHealthService) Pretty(pretty bool) *ClusterHealthService {
 }
 
 // Headers adds headers on the http request
-func (s *ClusterHealthService) Headers(headers map[string]string) *ClusterHealthService {
-	s.headers = headers
+func (s *ClusterHealthService) Header(key, value string) *ClusterHealthService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -113,7 +113,7 @@ func (s *ClusterHealthService) Pretty(pretty bool) *ClusterHealthService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *ClusterHealthService) Header(key, value string) *ClusterHealthService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/cluster_health.go
+++ b/cluster_health.go
@@ -29,6 +29,7 @@ type ClusterHealthService struct {
 	waitForNodes              string
 	waitForNoRelocatingShards *bool
 	waitForStatus             string
+	headers                   map[string]string
 }
 
 // NewClusterHealthService creates a new ClusterHealthService.
@@ -112,6 +113,12 @@ func (s *ClusterHealthService) Pretty(pretty bool) *ClusterHealthService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *ClusterHealthService) Headers(headers map[string]string) *ClusterHealthService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *ClusterHealthService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -179,7 +186,7 @@ func (s *ClusterHealthService) Do(ctx context.Context) (*ClusterHealthResponse, 
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster_state.go
+++ b/cluster_state.go
@@ -28,7 +28,7 @@ type ClusterStateService struct {
 	ignoreUnavailable *bool
 	local             *bool
 	masterTimeout     string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewClusterStateService creates a new ClusterStateService.
@@ -103,8 +103,8 @@ func (s *ClusterStateService) Pretty(pretty bool) *ClusterStateService {
 }
 
 // Headers adds headers on the http request
-func (s *ClusterStateService) Headers(headers map[string]string) *ClusterStateService {
-	s.headers = headers
+func (s *ClusterStateService) Header(key, value string) *ClusterStateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/cluster_state.go
+++ b/cluster_state.go
@@ -102,7 +102,7 @@ func (s *ClusterStateService) Pretty(pretty bool) *ClusterStateService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *ClusterStateService) Header(key, value string) *ClusterStateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/cluster_state.go
+++ b/cluster_state.go
@@ -28,7 +28,7 @@ type ClusterStateService struct {
 	ignoreUnavailable *bool
 	local             *bool
 	masterTimeout     string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewClusterStateService creates a new ClusterStateService.

--- a/cluster_state.go
+++ b/cluster_state.go
@@ -28,6 +28,7 @@ type ClusterStateService struct {
 	ignoreUnavailable *bool
 	local             *bool
 	masterTimeout     string
+	headers           map[string]string
 }
 
 // NewClusterStateService creates a new ClusterStateService.
@@ -101,6 +102,12 @@ func (s *ClusterStateService) Pretty(pretty bool) *ClusterStateService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *ClusterStateService) Headers(headers map[string]string) *ClusterStateService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *ClusterStateService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -165,7 +172,7 @@ func (s *ClusterStateService) Do(ctx context.Context) (*ClusterStateResponse, er
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster_stats.go
+++ b/cluster_stats.go
@@ -21,7 +21,7 @@ type ClusterStatsService struct {
 	nodeId       []string
 	flatSettings *bool
 	human        *bool
-	headers      map[string]string
+	headers      map[string][]string
 }
 
 // NewClusterStatsService creates a new ClusterStatsService.
@@ -57,8 +57,8 @@ func (s *ClusterStatsService) Pretty(pretty bool) *ClusterStatsService {
 }
 
 // Headers adds headers on the http request
-func (s *ClusterStatsService) Headers(headers map[string]string) *ClusterStatsService {
-	s.headers = headers
+func (s *ClusterStatsService) Header(key, value string) *ClusterStatsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/cluster_stats.go
+++ b/cluster_stats.go
@@ -21,6 +21,7 @@ type ClusterStatsService struct {
 	nodeId       []string
 	flatSettings *bool
 	human        *bool
+	headers      map[string]string
 }
 
 // NewClusterStatsService creates a new ClusterStatsService.
@@ -52,6 +53,12 @@ func (s *ClusterStatsService) Human(human bool) *ClusterStatsService {
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *ClusterStatsService) Pretty(pretty bool) *ClusterStatsService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *ClusterStatsService) Headers(headers map[string]string) *ClusterStatsService {
+	s.headers = headers
 	return s
 }
 
@@ -108,7 +115,7 @@ func (s *ClusterStatsService) Do(ctx context.Context) (*ClusterStatsResponse, er
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster_stats.go
+++ b/cluster_stats.go
@@ -21,7 +21,7 @@ type ClusterStatsService struct {
 	nodeId       []string
 	flatSettings *bool
 	human        *bool
-	headers      map[string][]string
+	headers      headers
 }
 
 // NewClusterStatsService creates a new ClusterStatsService.

--- a/cluster_stats.go
+++ b/cluster_stats.go
@@ -56,7 +56,7 @@ func (s *ClusterStatsService) Pretty(pretty bool) *ClusterStatsService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *ClusterStatsService) Header(key, value string) *ClusterStatsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/count.go
+++ b/count.go
@@ -37,7 +37,7 @@ type CountService struct {
 	routing                string
 	bodyJson               interface{}
 	bodyString             string
-	headers                map[string][]string
+	headers                headers
 }
 
 // NewCountService creates a new CountService.

--- a/count.go
+++ b/count.go
@@ -37,7 +37,7 @@ type CountService struct {
 	routing                string
 	bodyJson               interface{}
 	bodyString             string
-	headers                map[string]string
+	headers                map[string][]string
 }
 
 // NewCountService creates a new CountService.
@@ -181,8 +181,8 @@ func (s *CountService) BodyString(body string) *CountService {
 }
 
 // Headers adds headers on the http request
-func (s *CountService) Headers(headers map[string]string) *CountService {
-	s.headers = headers
+func (s *CountService) Header(key, value string) *CountService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/count.go
+++ b/count.go
@@ -37,6 +37,7 @@ type CountService struct {
 	routing                string
 	bodyJson               interface{}
 	bodyString             string
+	headers                map[string]string
 }
 
 // NewCountService creates a new CountService.
@@ -179,6 +180,12 @@ func (s *CountService) BodyString(body string) *CountService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *CountService) Headers(headers map[string]string) *CountService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *CountService) buildURL() (string, url.Values, error) {
 	var err error
@@ -286,7 +293,7 @@ func (s *CountService) Do(ctx context.Context) (int64, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return 0, err
 	}

--- a/count.go
+++ b/count.go
@@ -180,7 +180,7 @@ func (s *CountService) BodyString(body string) *CountService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *CountService) Header(key, value string) *CountService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/delete.go
+++ b/delete.go
@@ -112,7 +112,7 @@ func (s *DeleteService) Pretty(pretty bool) *DeleteService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *DeleteService) Header(key, value string) *DeleteService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/delete.go
+++ b/delete.go
@@ -32,7 +32,7 @@ type DeleteService struct {
 	waitForActiveShards string
 	parent              string
 	refresh             string
-	headers             map[string][]string
+	headers             headers
 }
 
 // NewDeleteService creates a new DeleteService.

--- a/delete.go
+++ b/delete.go
@@ -32,6 +32,7 @@ type DeleteService struct {
 	waitForActiveShards string
 	parent              string
 	refresh             string
+	headers             map[string]string
 }
 
 // NewDeleteService creates a new DeleteService.
@@ -111,6 +112,12 @@ func (s *DeleteService) Pretty(pretty bool) *DeleteService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *DeleteService) Headers(headers map[string]string) *DeleteService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *DeleteService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -186,7 +193,7 @@ func (s *DeleteService) Do(ctx context.Context) (*DeleteResponse, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil, http.StatusNotFound)
+	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil, s.headers, http.StatusNotFound)
 	if err != nil {
 		return nil, err
 	}

--- a/delete.go
+++ b/delete.go
@@ -32,7 +32,7 @@ type DeleteService struct {
 	waitForActiveShards string
 	parent              string
 	refresh             string
-	headers             map[string]string
+	headers             map[string][]string
 }
 
 // NewDeleteService creates a new DeleteService.
@@ -113,8 +113,8 @@ func (s *DeleteService) Pretty(pretty bool) *DeleteService {
 }
 
 // Headers adds headers on the http request
-func (s *DeleteService) Headers(headers map[string]string) *DeleteService {
-	s.headers = headers
+func (s *DeleteService) Header(key, value string) *DeleteService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/delete_by_query.go
+++ b/delete_by_query.go
@@ -412,7 +412,7 @@ func (s *DeleteByQueryService) Body(body string) *DeleteByQueryService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *DeleteByQueryService) Header(key, value string) *DeleteByQueryService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/delete_by_query.go
+++ b/delete_by_query.go
@@ -62,7 +62,7 @@ type DeleteByQueryService struct {
 	waitForActiveShards    string
 	waitForCompletion      *bool
 	pretty                 bool
-	headers                map[string]string
+	headers                map[string][]string
 }
 
 // NewDeleteByQueryService creates a new DeleteByQueryService.
@@ -413,8 +413,8 @@ func (s *DeleteByQueryService) Body(body string) *DeleteByQueryService {
 }
 
 // Headers adds headers on the http request
-func (s *DeleteByQueryService) Headers(headers map[string]string) *DeleteByQueryService {
-	s.headers = headers
+func (s *DeleteByQueryService) Header(key, value string) *DeleteByQueryService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/delete_by_query.go
+++ b/delete_by_query.go
@@ -62,7 +62,7 @@ type DeleteByQueryService struct {
 	waitForActiveShards    string
 	waitForCompletion      *bool
 	pretty                 bool
-	headers                map[string][]string
+	headers                headers
 }
 
 // NewDeleteByQueryService creates a new DeleteByQueryService.

--- a/delete_by_query.go
+++ b/delete_by_query.go
@@ -62,6 +62,7 @@ type DeleteByQueryService struct {
 	waitForActiveShards    string
 	waitForCompletion      *bool
 	pretty                 bool
+	headers                map[string]string
 }
 
 // NewDeleteByQueryService creates a new DeleteByQueryService.
@@ -411,6 +412,12 @@ func (s *DeleteByQueryService) Body(body string) *DeleteByQueryService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *DeleteByQueryService) Headers(headers map[string]string) *DeleteByQueryService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *DeleteByQueryService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -598,7 +605,7 @@ func (s *DeleteByQueryService) Do(ctx context.Context) (*BulkIndexByScrollRespon
 	}
 
 	// Get response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/delete_template.go
+++ b/delete_template.go
@@ -20,6 +20,7 @@ type DeleteTemplateService struct {
 	id          string
 	version     *int
 	versionType string
+	headers     map[string]string
 }
 
 // NewDeleteTemplateService creates a new DeleteTemplateService.
@@ -44,6 +45,12 @@ func (s *DeleteTemplateService) Version(version int) *DeleteTemplateService {
 // VersionType specifies a version type.
 func (s *DeleteTemplateService) VersionType(versionType string) *DeleteTemplateService {
 	s.versionType = versionType
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *DeleteTemplateService) Headers(headers map[string]string) *DeleteTemplateService {
+	s.headers = headers
 	return s
 }
 
@@ -95,7 +102,7 @@ func (s *DeleteTemplateService) Do(ctx context.Context) (*AcknowledgedResponse, 
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/delete_template.go
+++ b/delete_template.go
@@ -20,7 +20,7 @@ type DeleteTemplateService struct {
 	id          string
 	version     *int
 	versionType string
-	headers     map[string][]string
+	headers     headers
 }
 
 // NewDeleteTemplateService creates a new DeleteTemplateService.

--- a/delete_template.go
+++ b/delete_template.go
@@ -48,7 +48,7 @@ func (s *DeleteTemplateService) VersionType(versionType string) *DeleteTemplateS
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *DeleteTemplateService) Header(key, value string) *DeleteTemplateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/delete_template.go
+++ b/delete_template.go
@@ -20,7 +20,7 @@ type DeleteTemplateService struct {
 	id          string
 	version     *int
 	versionType string
-	headers     map[string]string
+	headers     map[string][]string
 }
 
 // NewDeleteTemplateService creates a new DeleteTemplateService.
@@ -49,8 +49,8 @@ func (s *DeleteTemplateService) VersionType(versionType string) *DeleteTemplateS
 }
 
 // Headers adds headers on the http request
-func (s *DeleteTemplateService) Headers(headers map[string]string) *DeleteTemplateService {
-	s.headers = headers
+func (s *DeleteTemplateService) Header(key, value string) *DeleteTemplateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/exists.go
+++ b/exists.go
@@ -93,7 +93,7 @@ func (s *ExistsService) Pretty(pretty bool) *ExistsService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *ExistsService) Header(key, value string) *ExistsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/exists.go
+++ b/exists.go
@@ -28,7 +28,7 @@ type ExistsService struct {
 	refresh    string
 	routing    string
 	parent     string
-	headers    map[string]string
+	headers    map[string][]string
 }
 
 // NewExistsService creates a new ExistsService.
@@ -94,8 +94,8 @@ func (s *ExistsService) Pretty(pretty bool) *ExistsService {
 }
 
 // Headers adds headers on the http request
-func (s *ExistsService) Headers(headers map[string]string) *ExistsService {
-	s.headers = headers
+func (s *ExistsService) Header(key, value string) *ExistsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/exists.go
+++ b/exists.go
@@ -28,7 +28,7 @@ type ExistsService struct {
 	refresh    string
 	routing    string
 	parent     string
-	headers    map[string][]string
+	headers    headers
 }
 
 // NewExistsService creates a new ExistsService.

--- a/exists.go
+++ b/exists.go
@@ -28,6 +28,7 @@ type ExistsService struct {
 	refresh    string
 	routing    string
 	parent     string
+	headers    map[string]string
 }
 
 // NewExistsService creates a new ExistsService.
@@ -89,6 +90,12 @@ func (s *ExistsService) Parent(parent string) *ExistsService {
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *ExistsService) Pretty(pretty bool) *ExistsService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *ExistsService) Headers(headers map[string]string) *ExistsService {
+	s.headers = headers
 	return s
 }
 
@@ -159,7 +166,7 @@ func (s *ExistsService) Do(ctx context.Context) (bool, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "HEAD", path, params, nil, 404)
+	res, err := s.client.PerformRequest(ctx, "HEAD", path, params, nil, s.headers, 404)
 	if err != nil {
 		return false, err
 	}

--- a/explain.go
+++ b/explain.go
@@ -39,7 +39,7 @@ type ExplainService struct {
 	source                 string
 	bodyJson               interface{}
 	bodyString             string
-	headers                map[string]string
+	headers                map[string][]string
 }
 
 // NewExplainService creates a new ExplainService.
@@ -195,8 +195,8 @@ func (s *ExplainService) BodyString(body string) *ExplainService {
 }
 
 // Headers adds headers on the http request
-func (s *ExplainService) Headers(headers map[string]string) *ExplainService {
-	s.headers = headers
+func (s *ExplainService) Header(key, value string) *ExplainService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/explain.go
+++ b/explain.go
@@ -194,7 +194,7 @@ func (s *ExplainService) BodyString(body string) *ExplainService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *ExplainService) Header(key, value string) *ExplainService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/explain.go
+++ b/explain.go
@@ -39,6 +39,7 @@ type ExplainService struct {
 	source                 string
 	bodyJson               interface{}
 	bodyString             string
+	headers                map[string]string
 }
 
 // NewExplainService creates a new ExplainService.
@@ -193,6 +194,12 @@ func (s *ExplainService) BodyString(body string) *ExplainService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *ExplainService) Headers(headers map[string]string) *ExplainService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *ExplainService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -298,7 +305,7 @@ func (s *ExplainService) Do(ctx context.Context) (*ExplainResponse, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/explain.go
+++ b/explain.go
@@ -39,7 +39,7 @@ type ExplainService struct {
 	source                 string
 	bodyJson               interface{}
 	bodyString             string
-	headers                map[string][]string
+	headers                headers
 }
 
 // NewExplainService creates a new ExplainService.

--- a/field_stats.go
+++ b/field_stats.go
@@ -35,6 +35,7 @@ type FieldStatsService struct {
 	ignoreUnavailable *bool
 	bodyJson          interface{}
 	bodyString        string
+	headers           map[string]string
 }
 
 // NewFieldStatsService creates a new FieldStatsService
@@ -118,6 +119,12 @@ func (s *FieldStatsService) BodyString(body string) *FieldStatsService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *FieldStatsService) Headers(headers map[string]string) *FieldStatsService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *FieldStatsService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -188,7 +195,7 @@ func (s *FieldStatsService) Do(ctx context.Context) (*FieldStatsResponse, error)
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, http.StatusNotFound)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers, http.StatusNotFound)
 	if err != nil {
 		return nil, err
 	}

--- a/field_stats.go
+++ b/field_stats.go
@@ -35,7 +35,7 @@ type FieldStatsService struct {
 	ignoreUnavailable *bool
 	bodyJson          interface{}
 	bodyString        string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewFieldStatsService creates a new FieldStatsService
@@ -120,8 +120,8 @@ func (s *FieldStatsService) BodyString(body string) *FieldStatsService {
 }
 
 // Headers adds headers on the http request
-func (s *FieldStatsService) Headers(headers map[string]string) *FieldStatsService {
-	s.headers = headers
+func (s *FieldStatsService) Header(key, value string) *FieldStatsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/field_stats.go
+++ b/field_stats.go
@@ -119,7 +119,7 @@ func (s *FieldStatsService) BodyString(body string) *FieldStatsService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *FieldStatsService) Header(key, value string) *FieldStatsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/field_stats.go
+++ b/field_stats.go
@@ -35,7 +35,7 @@ type FieldStatsService struct {
 	ignoreUnavailable *bool
 	bodyJson          interface{}
 	bodyString        string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewFieldStatsService creates a new FieldStatsService

--- a/get.go
+++ b/get.go
@@ -35,7 +35,7 @@ type GetService struct {
 	versionType                   string
 	parent                        string
 	ignoreErrorsOnGeneratedFields *bool
-	headers                       map[string]string
+	headers                       map[string][]string
 }
 
 // NewGetService creates a new GetService.
@@ -141,8 +141,8 @@ func (s *GetService) Pretty(pretty bool) *GetService {
 }
 
 // Headers sets headers on the http request
-func (s *GetService) Headers(headers map[string]string) *GetService {
-	s.headers = headers
+func (s *GetService) Header(key, value string) *GetService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/get.go
+++ b/get.go
@@ -35,6 +35,7 @@ type GetService struct {
 	versionType                   string
 	parent                        string
 	ignoreErrorsOnGeneratedFields *bool
+	headers                       map[string]string
 }
 
 // NewGetService creates a new GetService.
@@ -139,6 +140,12 @@ func (s *GetService) Pretty(pretty bool) *GetService {
 	return s
 }
 
+// Headers sets headers on the http request
+func (s *GetService) Headers(headers map[string]string) *GetService {
+	s.headers = headers
+	return s
+}
+
 // Validate checks if the operation is valid.
 func (s *GetService) Validate() error {
 	var invalid []string
@@ -223,7 +230,7 @@ func (s *GetService) Do(ctx context.Context) (*GetResult, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/get.go
+++ b/get.go
@@ -35,7 +35,7 @@ type GetService struct {
 	versionType                   string
 	parent                        string
 	ignoreErrorsOnGeneratedFields *bool
-	headers                       map[string][]string
+	headers                       headers
 }
 
 // NewGetService creates a new GetService.

--- a/get_template.go
+++ b/get_template.go
@@ -20,6 +20,7 @@ type GetTemplateService struct {
 	id          string
 	version     interface{}
 	versionType string
+	headers     map[string]string
 }
 
 // NewGetTemplateService creates a new GetTemplateService.
@@ -44,6 +45,12 @@ func (s *GetTemplateService) Version(version interface{}) *GetTemplateService {
 // VersionType is a specific version type.
 func (s *GetTemplateService) VersionType(versionType string) *GetTemplateService {
 	s.versionType = versionType
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *GetTemplateService) Headers(headers map[string]string) *GetTemplateService {
+	s.headers = headers
 	return s
 }
 
@@ -95,7 +102,7 @@ func (s *GetTemplateService) Do(ctx context.Context) (*GetTemplateResponse, erro
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/get_template.go
+++ b/get_template.go
@@ -20,7 +20,7 @@ type GetTemplateService struct {
 	id          string
 	version     interface{}
 	versionType string
-	headers     map[string][]string
+	headers     headers
 }
 
 // NewGetTemplateService creates a new GetTemplateService.

--- a/get_template.go
+++ b/get_template.go
@@ -20,7 +20,7 @@ type GetTemplateService struct {
 	id          string
 	version     interface{}
 	versionType string
-	headers     map[string]string
+	headers     map[string][]string
 }
 
 // NewGetTemplateService creates a new GetTemplateService.
@@ -49,8 +49,8 @@ func (s *GetTemplateService) VersionType(versionType string) *GetTemplateService
 }
 
 // Headers adds headers on the http request
-func (s *GetTemplateService) Headers(headers map[string]string) *GetTemplateService {
-	s.headers = headers
+func (s *GetTemplateService) Header(key, value string) *GetTemplateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/get_template.go
+++ b/get_template.go
@@ -48,7 +48,7 @@ func (s *GetTemplateService) VersionType(versionType string) *GetTemplateService
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *GetTemplateService) Header(key, value string) *GetTemplateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/headers.go
+++ b/headers.go
@@ -1,5 +1,10 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
 package elastic
 
+// addHeader adds key, value pair to the existing headers map, or creates a new map with that pair if headers was nil
 func addHeader(headers map[string][]string, key string, value string) map[string][]string {
 	if headers == nil {
 		headers = make(map[string][]string)

--- a/headers.go
+++ b/headers.go
@@ -12,11 +12,11 @@ func addHeader(headers map[string][]string, key string, value string) map[string
 
 	var values []string
 	if v, ok := headers[key]; ok {
-		values = v
+		values = append(v, value)
 	} else {
-		values = make([]string, 0)
+		values = []string{value}
 	}
 
-	headers[key] = append(values, value)
+	headers[key] = values
 	return headers
 }

--- a/headers.go
+++ b/headers.go
@@ -4,8 +4,10 @@
 
 package elastic
 
+type headers map[string][]string
+
 // addHeader adds key, value pair to the existing headers map, or creates a new map with that pair if headers was nil
-func addHeader(headers map[string][]string, key string, value string) map[string][]string {
+func addHeader(headers headers, key string, value string) headers {
 	if headers == nil {
 		headers = make(map[string][]string)
 	}

--- a/headers.go
+++ b/headers.go
@@ -1,0 +1,17 @@
+package elastic
+
+func addHeader(headers map[string][]string, key string, value string) map[string][]string {
+	if headers == nil {
+		headers = make(map[string][]string)
+	}
+
+	var values []string
+	if v, ok := headers[key]; ok {
+		values = v
+	} else {
+		values = make([]string, 0)
+	}
+
+	headers[key] = append(values, value)
+	return headers
+}

--- a/headers_test.go
+++ b/headers_test.go
@@ -31,7 +31,7 @@ func TestAddHeadersToNil(t *testing.T) {
 }
 
 func TestAddHeadersToExistingMap(t *testing.T) {
-	newHeaders := addHeader(map[string][]string{"existing": {"other"}}, testKey, testValue)
+	newHeaders := addHeader(headers{"existing": {"other"}}, testKey, testValue)
 
 	l := len(newHeaders)
 	if l != 2 {
@@ -48,7 +48,7 @@ func TestAddHeadersToExistingMap(t *testing.T) {
 }
 
 func TestAddHeadersDuplicatedKey(t *testing.T) {
-	newHeaders := addHeader(map[string][]string{testKey: {"other"}}, testKey, testValue)
+	newHeaders := addHeader(headers{testKey: {"other"}}, testKey, testValue)
 
 	l := len(newHeaders)
 	if l != 1 {

--- a/headers_test.go
+++ b/headers_test.go
@@ -1,0 +1,61 @@
+package elastic
+
+import (
+	"testing"
+)
+
+const (
+	testKey   = "key"
+	testValue = "value"
+)
+
+func TestAddHeadersToNil(t *testing.T) {
+	newHeaders := addHeader(nil, testKey, testValue)
+
+	l := len(newHeaders)
+	if l != 1 {
+		t.Errorf("Expected one item in the headers map, found %d", l)
+	}
+
+	actualVal, ok := newHeaders["key"]
+	if !ok {
+		t.Errorf("Expected key: %s in the map, but not found", testKey)
+	}
+	if len(actualVal) != 1 || actualVal[0] != testValue {
+		t.Errorf("Expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
+	}
+}
+
+func TestAddHeadersToExistingMap(t *testing.T) {
+	newHeaders := addHeader(map[string][]string{"existing": {"other"}}, testKey, testValue)
+
+	l := len(newHeaders)
+	if l != 2 {
+		t.Errorf("Expected two items in the headers map, found %d", l)
+	}
+
+	actualVal, ok := newHeaders["key"]
+	if !ok {
+		t.Errorf("Expected key: %s in the map, but not found", testKey)
+	}
+	if len(actualVal) != 1 || actualVal[0] != testValue {
+		t.Errorf("Expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
+	}
+}
+
+func TestAddHeadersDuplicatedKey(t *testing.T) {
+	newHeaders := addHeader(map[string][]string{testKey: {"other"}}, testKey, testValue)
+
+	l := len(newHeaders)
+	if l != 1 {
+		t.Errorf("Expected one item in the headers map, found %d", l)
+	}
+
+	actualVal, ok := newHeaders["key"]
+	if !ok {
+		t.Errorf("Expected key: %s in the map, but not found", testKey)
+	}
+	if len(actualVal) != 2 || actualVal[1] != testValue {
+		t.Errorf("Expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
+	}
+}

--- a/headers_test.go
+++ b/headers_test.go
@@ -1,3 +1,7 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
 package elastic
 
 import (
@@ -14,15 +18,15 @@ func TestAddHeadersToNil(t *testing.T) {
 
 	l := len(newHeaders)
 	if l != 1 {
-		t.Errorf("Expected one item in the headers map, found %d", l)
+		t.Errorf("expected one item in the headers map, found %d", l)
 	}
 
 	actualVal, ok := newHeaders["key"]
 	if !ok {
-		t.Errorf("Expected key: %s in the map, but not found", testKey)
+		t.Errorf("expected key: %s in the map, but not found", testKey)
 	}
 	if len(actualVal) != 1 || actualVal[0] != testValue {
-		t.Errorf("Expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
+		t.Errorf("expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
 	}
 }
 
@@ -31,15 +35,15 @@ func TestAddHeadersToExistingMap(t *testing.T) {
 
 	l := len(newHeaders)
 	if l != 2 {
-		t.Errorf("Expected two items in the headers map, found %d", l)
+		t.Errorf("expected two items in the headers map, found %d", l)
 	}
 
 	actualVal, ok := newHeaders["key"]
 	if !ok {
-		t.Errorf("Expected key: %s in the map, but not found", testKey)
+		t.Errorf("expected key: %s in the map, but not found", testKey)
 	}
 	if len(actualVal) != 1 || actualVal[0] != testValue {
-		t.Errorf("Expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
+		t.Errorf("expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
 	}
 }
 
@@ -48,14 +52,14 @@ func TestAddHeadersDuplicatedKey(t *testing.T) {
 
 	l := len(newHeaders)
 	if l != 1 {
-		t.Errorf("Expected one item in the headers map, found %d", l)
+		t.Errorf("expected one item in the headers map, found %d", l)
 	}
 
 	actualVal, ok := newHeaders["key"]
 	if !ok {
-		t.Errorf("Expected key: %s in the map, but not found", testKey)
+		t.Errorf("expected key: %s in the map, but not found", testKey)
 	}
 	if len(actualVal) != 2 || actualVal[1] != testValue {
-		t.Errorf("Expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
+		t.Errorf("expected value: %s associated with the key: %s, but found: %s", testValue, testKey, actualVal)
 	}
 }

--- a/index.go
+++ b/index.go
@@ -36,7 +36,7 @@ type IndexService struct {
 	pipeline            string
 	bodyJson            interface{}
 	bodyString          string
-	headers             map[string]string
+	headers             map[string][]string
 }
 
 // NewIndexService creates a new IndexService.
@@ -159,8 +159,8 @@ func (s *IndexService) BodyString(body string) *IndexService {
 }
 
 // Headers adds headers on the http request
-func (s *IndexService) Headers(headers map[string]string) *IndexService {
-	s.headers = headers
+func (s *IndexService) Header(key, value string) *IndexService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/index.go
+++ b/index.go
@@ -36,6 +36,7 @@ type IndexService struct {
 	pipeline            string
 	bodyJson            interface{}
 	bodyString          string
+	headers             map[string]string
 }
 
 // NewIndexService creates a new IndexService.
@@ -157,6 +158,12 @@ func (s *IndexService) BodyString(body string) *IndexService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *IndexService) Headers(headers map[string]string) *IndexService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *IndexService) buildURL() (string, string, url.Values, error) {
 	var err error
@@ -264,7 +271,7 @@ func (s *IndexService) Do(ctx context.Context) (*IndexResponse, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, method, path, params, body)
+	res, err := s.client.PerformRequest(ctx, method, path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/index.go
+++ b/index.go
@@ -36,7 +36,7 @@ type IndexService struct {
 	pipeline            string
 	bodyJson            interface{}
 	bodyString          string
-	headers             map[string][]string
+	headers             headers
 }
 
 // NewIndexService creates a new IndexService.

--- a/index.go
+++ b/index.go
@@ -158,7 +158,7 @@ func (s *IndexService) BodyString(body string) *IndexService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndexService) Header(key, value string) *IndexService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_analyze.go
+++ b/indices_analyze.go
@@ -26,6 +26,7 @@ type IndicesAnalyzeService struct {
 	preferLocal *bool
 	bodyJson    interface{}
 	bodyString  string
+	headers     map[string]string
 }
 
 // NewIndicesAnalyzeService creates a new IndicesAnalyzeService.
@@ -132,6 +133,12 @@ func (s *IndicesAnalyzeService) BodyString(body string) *IndicesAnalyzeService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *IndicesAnalyzeService) Headers(headers map[string]string) *IndicesAnalyzeService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *IndicesAnalyzeService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -189,7 +196,7 @@ func (s *IndicesAnalyzeService) Do(ctx context.Context) (*IndicesAnalyzeResponse
 		body = s.request
 	}
 
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_analyze.go
+++ b/indices_analyze.go
@@ -133,7 +133,7 @@ func (s *IndicesAnalyzeService) BodyString(body string) *IndicesAnalyzeService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesAnalyzeService) Header(key, value string) *IndicesAnalyzeService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_analyze.go
+++ b/indices_analyze.go
@@ -26,7 +26,7 @@ type IndicesAnalyzeService struct {
 	preferLocal *bool
 	bodyJson    interface{}
 	bodyString  string
-	headers     map[string][]string
+	headers     headers
 }
 
 // NewIndicesAnalyzeService creates a new IndicesAnalyzeService.

--- a/indices_analyze.go
+++ b/indices_analyze.go
@@ -26,7 +26,7 @@ type IndicesAnalyzeService struct {
 	preferLocal *bool
 	bodyJson    interface{}
 	bodyString  string
-	headers     map[string]string
+	headers     map[string][]string
 }
 
 // NewIndicesAnalyzeService creates a new IndicesAnalyzeService.
@@ -134,8 +134,8 @@ func (s *IndicesAnalyzeService) BodyString(body string) *IndicesAnalyzeService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesAnalyzeService) Headers(headers map[string]string) *IndicesAnalyzeService {
-	s.headers = headers
+func (s *IndicesAnalyzeService) Header(key, value string) *IndicesAnalyzeService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_close.go
+++ b/indices_close.go
@@ -25,6 +25,7 @@ type IndicesCloseService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
+	headers           map[string]string
 }
 
 // NewIndicesCloseService creates and initializes a new IndicesCloseService.
@@ -74,6 +75,12 @@ func (s *IndicesCloseService) ExpandWildcards(expandWildcards string) *IndicesCl
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesCloseService) Pretty(pretty bool) *IndicesCloseService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesCloseService) Headers(headers map[string]string) *IndicesCloseService {
+	s.headers = headers
 	return s
 }
 
@@ -134,7 +141,7 @@ func (s *IndicesCloseService) Do(ctx context.Context) (*IndicesCloseResponse, er
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_close.go
+++ b/indices_close.go
@@ -78,7 +78,7 @@ func (s *IndicesCloseService) Pretty(pretty bool) *IndicesCloseService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesCloseService) Header(key, value string) *IndicesCloseService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_close.go
+++ b/indices_close.go
@@ -25,7 +25,7 @@ type IndicesCloseService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewIndicesCloseService creates and initializes a new IndicesCloseService.
@@ -79,8 +79,8 @@ func (s *IndicesCloseService) Pretty(pretty bool) *IndicesCloseService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesCloseService) Headers(headers map[string]string) *IndicesCloseService {
-	s.headers = headers
+func (s *IndicesCloseService) Header(key, value string) *IndicesCloseService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_close.go
+++ b/indices_close.go
@@ -25,7 +25,7 @@ type IndicesCloseService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewIndicesCloseService creates and initializes a new IndicesCloseService.

--- a/indices_create.go
+++ b/indices_create.go
@@ -24,6 +24,7 @@ type IndicesCreateService struct {
 	masterTimeout string
 	bodyJson      interface{}
 	bodyString    string
+	headers       map[string]string
 }
 
 // NewIndicesCreateService returns a new IndicesCreateService.
@@ -75,6 +76,12 @@ func (b *IndicesCreateService) Pretty(pretty bool) *IndicesCreateService {
 	return b
 }
 
+// Headers adds headers on the http request
+func (s *IndicesCreateService) Headers(headers map[string]string) *IndicesCreateService {
+	s.headers = headers
+	return s
+}
+
 // Do executes the operation.
 func (b *IndicesCreateService) Do(ctx context.Context) (*IndicesCreateResult, error) {
 	if b.index == "" {
@@ -109,7 +116,7 @@ func (b *IndicesCreateService) Do(ctx context.Context) (*IndicesCreateResult, er
 	}
 
 	// Get response
-	res, err := b.client.PerformRequest(ctx, "PUT", path, params, body)
+	res, err := b.client.PerformRequest(ctx, "PUT", path, params, body, b.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_create.go
+++ b/indices_create.go
@@ -76,7 +76,7 @@ func (b *IndicesCreateService) Pretty(pretty bool) *IndicesCreateService {
 	return b
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesCreateService) Header(key, value string) *IndicesCreateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_create.go
+++ b/indices_create.go
@@ -24,7 +24,7 @@ type IndicesCreateService struct {
 	masterTimeout string
 	bodyJson      interface{}
 	bodyString    string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewIndicesCreateService returns a new IndicesCreateService.
@@ -77,8 +77,8 @@ func (b *IndicesCreateService) Pretty(pretty bool) *IndicesCreateService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesCreateService) Headers(headers map[string]string) *IndicesCreateService {
-	s.headers = headers
+func (s *IndicesCreateService) Header(key, value string) *IndicesCreateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_create.go
+++ b/indices_create.go
@@ -24,7 +24,7 @@ type IndicesCreateService struct {
 	masterTimeout string
 	bodyJson      interface{}
 	bodyString    string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewIndicesCreateService returns a new IndicesCreateService.

--- a/indices_delete.go
+++ b/indices_delete.go
@@ -59,7 +59,7 @@ func (s *IndicesDeleteService) Pretty(pretty bool) *IndicesDeleteService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesDeleteService) Header(key, value string) *IndicesDeleteService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_delete.go
+++ b/indices_delete.go
@@ -23,7 +23,7 @@ type IndicesDeleteService struct {
 	index         []string
 	timeout       string
 	masterTimeout string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewIndicesDeleteService creates and initializes a new IndicesDeleteService.

--- a/indices_delete.go
+++ b/indices_delete.go
@@ -23,6 +23,7 @@ type IndicesDeleteService struct {
 	index         []string
 	timeout       string
 	masterTimeout string
+	headers       map[string]string
 }
 
 // NewIndicesDeleteService creates and initializes a new IndicesDeleteService.
@@ -55,6 +56,12 @@ func (s *IndicesDeleteService) MasterTimeout(masterTimeout string) *IndicesDelet
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesDeleteService) Pretty(pretty bool) *IndicesDeleteService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesDeleteService) Headers(headers map[string]string) *IndicesDeleteService {
+	s.headers = headers
 	return s
 }
 
@@ -108,7 +115,7 @@ func (s *IndicesDeleteService) Do(ctx context.Context) (*IndicesDeleteResponse, 
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_delete.go
+++ b/indices_delete.go
@@ -23,7 +23,7 @@ type IndicesDeleteService struct {
 	index         []string
 	timeout       string
 	masterTimeout string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewIndicesDeleteService creates and initializes a new IndicesDeleteService.
@@ -60,8 +60,8 @@ func (s *IndicesDeleteService) Pretty(pretty bool) *IndicesDeleteService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesDeleteService) Headers(headers map[string]string) *IndicesDeleteService {
-	s.headers = headers
+func (s *IndicesDeleteService) Header(key, value string) *IndicesDeleteService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_delete_template.go
+++ b/indices_delete_template.go
@@ -20,7 +20,7 @@ type IndicesDeleteTemplateService struct {
 	name          string
 	timeout       string
 	masterTimeout string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewIndicesDeleteTemplateService creates a new IndicesDeleteTemplateService.

--- a/indices_delete_template.go
+++ b/indices_delete_template.go
@@ -20,7 +20,7 @@ type IndicesDeleteTemplateService struct {
 	name          string
 	timeout       string
 	masterTimeout string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewIndicesDeleteTemplateService creates a new IndicesDeleteTemplateService.
@@ -55,8 +55,8 @@ func (s *IndicesDeleteTemplateService) Pretty(pretty bool) *IndicesDeleteTemplat
 }
 
 // Headers adds headers on the http request
-func (s *IndicesDeleteTemplateService) Headers(headers map[string]string) *IndicesDeleteTemplateService {
-	s.headers = headers
+func (s *IndicesDeleteTemplateService) Header(key, value string) *IndicesDeleteTemplateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_delete_template.go
+++ b/indices_delete_template.go
@@ -54,7 +54,7 @@ func (s *IndicesDeleteTemplateService) Pretty(pretty bool) *IndicesDeleteTemplat
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesDeleteTemplateService) Header(key, value string) *IndicesDeleteTemplateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_delete_template.go
+++ b/indices_delete_template.go
@@ -20,6 +20,7 @@ type IndicesDeleteTemplateService struct {
 	name          string
 	timeout       string
 	masterTimeout string
+	headers       map[string]string
 }
 
 // NewIndicesDeleteTemplateService creates a new IndicesDeleteTemplateService.
@@ -50,6 +51,12 @@ func (s *IndicesDeleteTemplateService) MasterTimeout(masterTimeout string) *Indi
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesDeleteTemplateService) Pretty(pretty bool) *IndicesDeleteTemplateService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesDeleteTemplateService) Headers(headers map[string]string) *IndicesDeleteTemplateService {
+	s.headers = headers
 	return s
 }
 
@@ -103,7 +110,7 @@ func (s *IndicesDeleteTemplateService) Do(ctx context.Context) (*IndicesDeleteTe
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_exists.go
+++ b/indices_exists.go
@@ -26,7 +26,7 @@ type IndicesExistsService struct {
 	allowNoIndices    *bool
 	expandWildcards   string
 	local             *bool
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewIndicesExistsService creates and initializes a new IndicesExistsService.
@@ -79,8 +79,8 @@ func (s *IndicesExistsService) Pretty(pretty bool) *IndicesExistsService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesExistsService) Headers(headers map[string]string) *IndicesExistsService {
-	s.headers = headers
+func (s *IndicesExistsService) Header(key, value string) *IndicesExistsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_exists.go
+++ b/indices_exists.go
@@ -78,7 +78,7 @@ func (s *IndicesExistsService) Pretty(pretty bool) *IndicesExistsService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesExistsService) Header(key, value string) *IndicesExistsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_exists.go
+++ b/indices_exists.go
@@ -26,6 +26,7 @@ type IndicesExistsService struct {
 	allowNoIndices    *bool
 	expandWildcards   string
 	local             *bool
+	headers           map[string]string
 }
 
 // NewIndicesExistsService creates and initializes a new IndicesExistsService.
@@ -74,6 +75,12 @@ func (s *IndicesExistsService) IgnoreUnavailable(ignoreUnavailable bool) *Indice
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesExistsService) Pretty(pretty bool) *IndicesExistsService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesExistsService) Headers(headers map[string]string) *IndicesExistsService {
+	s.headers = headers
 	return s
 }
 
@@ -133,7 +140,7 @@ func (s *IndicesExistsService) Do(ctx context.Context) (bool, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "HEAD", path, params, nil, 404)
+	res, err := s.client.PerformRequest(ctx, "HEAD", path, params, nil, s.headers, 404)
 	if err != nil {
 		return false, err
 	}

--- a/indices_exists.go
+++ b/indices_exists.go
@@ -26,7 +26,7 @@ type IndicesExistsService struct {
 	allowNoIndices    *bool
 	expandWildcards   string
 	local             *bool
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewIndicesExistsService creates and initializes a new IndicesExistsService.

--- a/indices_exists_template.go
+++ b/indices_exists_template.go
@@ -21,7 +21,7 @@ type IndicesExistsTemplateService struct {
 	pretty  bool
 	name    string
 	local   *bool
-	headers map[string]string
+	headers map[string][]string
 }
 
 // NewIndicesExistsTemplateService creates a new IndicesExistsTemplateService.
@@ -51,8 +51,8 @@ func (s *IndicesExistsTemplateService) Pretty(pretty bool) *IndicesExistsTemplat
 }
 
 // Headers adds headers on the http request
-func (s *IndicesExistsTemplateService) Headers(headers map[string]string) *IndicesExistsTemplateService {
-	s.headers = headers
+func (s *IndicesExistsTemplateService) Header(key, value string) *IndicesExistsTemplateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_exists_template.go
+++ b/indices_exists_template.go
@@ -50,7 +50,7 @@ func (s *IndicesExistsTemplateService) Pretty(pretty bool) *IndicesExistsTemplat
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesExistsTemplateService) Header(key, value string) *IndicesExistsTemplateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_exists_template.go
+++ b/indices_exists_template.go
@@ -21,7 +21,7 @@ type IndicesExistsTemplateService struct {
 	pretty  bool
 	name    string
 	local   *bool
-	headers map[string][]string
+	headers headers
 }
 
 // NewIndicesExistsTemplateService creates a new IndicesExistsTemplateService.

--- a/indices_exists_template.go
+++ b/indices_exists_template.go
@@ -17,10 +17,11 @@ import (
 // See http://www.elastic.co/guide/en/elasticsearch/reference/5.2/indices-templates.html#indices-templates-exists
 // for documentation.
 type IndicesExistsTemplateService struct {
-	client *Client
-	pretty bool
-	name   string
-	local  *bool
+	client  *Client
+	pretty  bool
+	name    string
+	local   *bool
+	headers map[string]string
 }
 
 // NewIndicesExistsTemplateService creates a new IndicesExistsTemplateService.
@@ -46,6 +47,12 @@ func (s *IndicesExistsTemplateService) Local(local bool) *IndicesExistsTemplateS
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesExistsTemplateService) Pretty(pretty bool) *IndicesExistsTemplateService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesExistsTemplateService) Headers(headers map[string]string) *IndicesExistsTemplateService {
+	s.headers = headers
 	return s
 }
 
@@ -96,7 +103,7 @@ func (s *IndicesExistsTemplateService) Do(ctx context.Context) (bool, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "HEAD", path, params, nil, 404)
+	res, err := s.client.PerformRequest(ctx, "HEAD", path, params, nil, s.headers, 404)
 	if err != nil {
 		return false, err
 	}

--- a/indices_exists_type.go
+++ b/indices_exists_type.go
@@ -84,7 +84,7 @@ func (s *IndicesExistsTypeService) Pretty(pretty bool) *IndicesExistsTypeService
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesExistsTypeService) Header(key, value string) *IndicesExistsTypeService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_exists_type.go
+++ b/indices_exists_type.go
@@ -27,6 +27,7 @@ type IndicesExistsTypeService struct {
 	local             *bool
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
+	headers           map[string]string
 }
 
 // NewIndicesExistsTypeService creates a new IndicesExistsTypeService.
@@ -80,6 +81,12 @@ func (s *IndicesExistsTypeService) Local(local bool) *IndicesExistsTypeService {
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesExistsTypeService) Pretty(pretty bool) *IndicesExistsTypeService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesExistsTypeService) Headers(headers map[string]string) *IndicesExistsTypeService {
+	s.headers = headers
 	return s
 }
 
@@ -143,7 +150,7 @@ func (s *IndicesExistsTypeService) Do(ctx context.Context) (bool, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "HEAD", path, params, nil, 404)
+	res, err := s.client.PerformRequest(ctx, "HEAD", path, params, nil, s.headers, 404)
 	if err != nil {
 		return false, err
 	}

--- a/indices_exists_type.go
+++ b/indices_exists_type.go
@@ -27,7 +27,7 @@ type IndicesExistsTypeService struct {
 	local             *bool
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewIndicesExistsTypeService creates a new IndicesExistsTypeService.
@@ -85,8 +85,8 @@ func (s *IndicesExistsTypeService) Pretty(pretty bool) *IndicesExistsTypeService
 }
 
 // Headers adds headers on the http request
-func (s *IndicesExistsTypeService) Headers(headers map[string]string) *IndicesExistsTypeService {
-	s.headers = headers
+func (s *IndicesExistsTypeService) Header(key, value string) *IndicesExistsTypeService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_exists_type.go
+++ b/indices_exists_type.go
@@ -27,7 +27,7 @@ type IndicesExistsTypeService struct {
 	local             *bool
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewIndicesExistsTypeService creates a new IndicesExistsTypeService.

--- a/indices_flush.go
+++ b/indices_flush.go
@@ -91,7 +91,7 @@ func (s *IndicesFlushService) Pretty(pretty bool) *IndicesFlushService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesFlushService) Header(key, value string) *IndicesFlushService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_flush.go
+++ b/indices_flush.go
@@ -28,7 +28,7 @@ type IndicesFlushService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewIndicesFlushService creates a new IndicesFlushService.

--- a/indices_flush.go
+++ b/indices_flush.go
@@ -28,6 +28,7 @@ type IndicesFlushService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
+	headers           map[string]string
 }
 
 // NewIndicesFlushService creates a new IndicesFlushService.
@@ -90,6 +91,12 @@ func (s *IndicesFlushService) Pretty(pretty bool) *IndicesFlushService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *IndicesFlushService) Headers(headers map[string]string) *IndicesFlushService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *IndicesFlushService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -149,7 +156,7 @@ func (s *IndicesFlushService) Do(ctx context.Context) (*IndicesFlushResponse, er
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_flush.go
+++ b/indices_flush.go
@@ -28,7 +28,7 @@ type IndicesFlushService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewIndicesFlushService creates a new IndicesFlushService.
@@ -92,8 +92,8 @@ func (s *IndicesFlushService) Pretty(pretty bool) *IndicesFlushService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesFlushService) Headers(headers map[string]string) *IndicesFlushService {
-	s.headers = headers
+func (s *IndicesFlushService) Header(key, value string) *IndicesFlushService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_forcemerge.go
+++ b/indices_forcemerge.go
@@ -31,6 +31,7 @@ type IndicesForcemergeService struct {
 	maxNumSegments     interface{}
 	onlyExpungeDeletes *bool
 	operationThreading interface{}
+	headers            map[string]string
 }
 
 // NewIndicesForcemergeService creates a new IndicesForcemergeService.
@@ -105,6 +106,12 @@ func (s *IndicesForcemergeService) Pretty(pretty bool) *IndicesForcemergeService
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *IndicesForcemergeService) Headers(headers map[string]string) *IndicesForcemergeService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *IndicesForcemergeService) buildURL() (string, url.Values, error) {
 	var err error
@@ -170,7 +177,7 @@ func (s *IndicesForcemergeService) Do(ctx context.Context) (*IndicesForcemergeRe
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_forcemerge.go
+++ b/indices_forcemerge.go
@@ -106,7 +106,7 @@ func (s *IndicesForcemergeService) Pretty(pretty bool) *IndicesForcemergeService
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesForcemergeService) Header(key, value string) *IndicesForcemergeService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_forcemerge.go
+++ b/indices_forcemerge.go
@@ -31,7 +31,7 @@ type IndicesForcemergeService struct {
 	maxNumSegments     interface{}
 	onlyExpungeDeletes *bool
 	operationThreading interface{}
-	headers            map[string]string
+	headers            map[string][]string
 }
 
 // NewIndicesForcemergeService creates a new IndicesForcemergeService.
@@ -107,8 +107,8 @@ func (s *IndicesForcemergeService) Pretty(pretty bool) *IndicesForcemergeService
 }
 
 // Headers adds headers on the http request
-func (s *IndicesForcemergeService) Headers(headers map[string]string) *IndicesForcemergeService {
-	s.headers = headers
+func (s *IndicesForcemergeService) Header(key, value string) *IndicesForcemergeService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_forcemerge.go
+++ b/indices_forcemerge.go
@@ -31,7 +31,7 @@ type IndicesForcemergeService struct {
 	maxNumSegments     interface{}
 	onlyExpungeDeletes *bool
 	operationThreading interface{}
-	headers            map[string][]string
+	headers            headers
 }
 
 // NewIndicesForcemergeService creates a new IndicesForcemergeService.

--- a/indices_get.go
+++ b/indices_get.go
@@ -28,7 +28,7 @@ type IndicesGetService struct {
 	expandWildcards   string
 	flatSettings      *bool
 	human             *bool
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewIndicesGetService creates a new IndicesGetService.
@@ -102,8 +102,8 @@ func (s *IndicesGetService) Pretty(pretty bool) *IndicesGetService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesGetService) Headers(headers map[string]string) *IndicesGetService {
-	s.headers = headers
+func (s *IndicesGetService) Header(key, value string) *IndicesGetService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_get.go
+++ b/indices_get.go
@@ -28,6 +28,7 @@ type IndicesGetService struct {
 	expandWildcards   string
 	flatSettings      *bool
 	human             *bool
+	headers           map[string]string
 }
 
 // NewIndicesGetService creates a new IndicesGetService.
@@ -97,6 +98,12 @@ func (s *IndicesGetService) Human(human bool) *IndicesGetService {
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesGetService) Pretty(pretty bool) *IndicesGetService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesGetService) Headers(headers map[string]string) *IndicesGetService {
+	s.headers = headers
 	return s
 }
 
@@ -180,7 +187,7 @@ func (s *IndicesGetService) Do(ctx context.Context) (map[string]*IndicesGetRespo
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_get.go
+++ b/indices_get.go
@@ -101,7 +101,7 @@ func (s *IndicesGetService) Pretty(pretty bool) *IndicesGetService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesGetService) Header(key, value string) *IndicesGetService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_get.go
+++ b/indices_get.go
@@ -28,7 +28,7 @@ type IndicesGetService struct {
 	expandWildcards   string
 	flatSettings      *bool
 	human             *bool
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewIndicesGetService creates a new IndicesGetService.

--- a/indices_get_aliases.go
+++ b/indices_get_aliases.go
@@ -19,7 +19,7 @@ type AliasesService struct {
 	client  *Client
 	index   []string
 	pretty  bool
-	headers map[string][]string
+	headers headers
 }
 
 // NewAliasesService instantiates a new AliasesService.

--- a/indices_get_aliases.go
+++ b/indices_get_aliases.go
@@ -19,7 +19,7 @@ type AliasesService struct {
 	client  *Client
 	index   []string
 	pretty  bool
-	headers map[string]string
+	headers map[string][]string
 }
 
 // NewAliasesService instantiates a new AliasesService.
@@ -37,8 +37,8 @@ func (s *AliasesService) Pretty(pretty bool) *AliasesService {
 }
 
 // Headers adds headers on the http request
-func (s *AliasesService) Headers(headers map[string]string) *AliasesService {
-	s.headers = headers
+func (s *AliasesService) Header(key, value string) *AliasesService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_get_aliases.go
+++ b/indices_get_aliases.go
@@ -36,7 +36,7 @@ func (s *AliasesService) Pretty(pretty bool) *AliasesService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *AliasesService) Header(key, value string) *AliasesService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_get_aliases.go
+++ b/indices_get_aliases.go
@@ -16,9 +16,10 @@ import (
 // AliasesService returns the aliases associated with one or more indices.
 // See http://www.elastic.co/guide/en/elasticsearch/reference/5.2/indices-aliases.html.
 type AliasesService struct {
-	client *Client
-	index  []string
-	pretty bool
+	client  *Client
+	index   []string
+	pretty  bool
+	headers map[string]string
 }
 
 // NewAliasesService instantiates a new AliasesService.
@@ -32,6 +33,12 @@ func NewAliasesService(client *Client) *AliasesService {
 // Pretty asks Elasticsearch to indent the returned JSON.
 func (s *AliasesService) Pretty(pretty bool) *AliasesService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *AliasesService) Headers(headers map[string]string) *AliasesService {
+	s.headers = headers
 	return s
 }
 
@@ -72,7 +79,7 @@ func (s *AliasesService) Do(ctx context.Context) (*AliasesResult, error) {
 	}
 
 	// Get response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_get_field_mapping.go
+++ b/indices_get_field_mapping.go
@@ -28,7 +28,7 @@ type IndicesGetFieldMappingService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewGetFieldMappingService is an alias for NewIndicesGetFieldMappingService.

--- a/indices_get_field_mapping.go
+++ b/indices_get_field_mapping.go
@@ -28,7 +28,7 @@ type IndicesGetFieldMappingService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewGetFieldMappingService is an alias for NewIndicesGetFieldMappingService.
@@ -98,8 +98,8 @@ func (s *IndicesGetFieldMappingService) Pretty(pretty bool) *IndicesGetFieldMapp
 }
 
 // Headers adds headers on the http request
-func (s *IndicesGetFieldMappingService) Headers(headers map[string]string) *IndicesGetFieldMappingService {
-	s.headers = headers
+func (s *IndicesGetFieldMappingService) Header(key, value string) *IndicesGetFieldMappingService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_get_field_mapping.go
+++ b/indices_get_field_mapping.go
@@ -97,7 +97,7 @@ func (s *IndicesGetFieldMappingService) Pretty(pretty bool) *IndicesGetFieldMapp
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesGetFieldMappingService) Header(key, value string) *IndicesGetFieldMappingService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_get_field_mapping.go
+++ b/indices_get_field_mapping.go
@@ -28,6 +28,7 @@ type IndicesGetFieldMappingService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
+	headers           map[string]string
 }
 
 // NewGetFieldMappingService is an alias for NewIndicesGetFieldMappingService.
@@ -93,6 +94,12 @@ func (s *IndicesGetFieldMappingService) IgnoreUnavailable(ignoreUnavailable bool
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesGetFieldMappingService) Pretty(pretty bool) *IndicesGetFieldMappingService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesGetFieldMappingService) Headers(headers map[string]string) *IndicesGetFieldMappingService {
+	s.headers = headers
 	return s
 }
 
@@ -170,7 +177,7 @@ func (s *IndicesGetFieldMappingService) Do(ctx context.Context) (map[string]inte
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_get_mapping.go
+++ b/indices_get_mapping.go
@@ -27,7 +27,7 @@ type IndicesGetMappingService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewGetMappingService is an alias for NewIndicesGetMappingService.
@@ -93,8 +93,8 @@ func (s *IndicesGetMappingService) Pretty(pretty bool) *IndicesGetMappingService
 }
 
 // Headers adds headers on the http request
-func (s *IndicesGetMappingService) Headers(headers map[string]string) *IndicesGetMappingService {
-	s.headers = headers
+func (s *IndicesGetMappingService) Header(key, value string) *IndicesGetMappingService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_get_mapping.go
+++ b/indices_get_mapping.go
@@ -92,7 +92,7 @@ func (s *IndicesGetMappingService) Pretty(pretty bool) *IndicesGetMappingService
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesGetMappingService) Header(key, value string) *IndicesGetMappingService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_get_mapping.go
+++ b/indices_get_mapping.go
@@ -27,7 +27,7 @@ type IndicesGetMappingService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewGetMappingService is an alias for NewIndicesGetMappingService.

--- a/indices_get_mapping.go
+++ b/indices_get_mapping.go
@@ -27,6 +27,7 @@ type IndicesGetMappingService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
+	headers           map[string]string
 }
 
 // NewGetMappingService is an alias for NewIndicesGetMappingService.
@@ -88,6 +89,12 @@ func (s *IndicesGetMappingService) IgnoreUnavailable(ignoreUnavailable bool) *In
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesGetMappingService) Pretty(pretty bool) *IndicesGetMappingService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesGetMappingService) Headers(headers map[string]string) *IndicesGetMappingService {
+	s.headers = headers
 	return s
 }
 
@@ -156,7 +163,7 @@ func (s *IndicesGetMappingService) Do(ctx context.Context) (map[string]interface
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_get_settings.go
+++ b/indices_get_settings.go
@@ -95,7 +95,7 @@ func (s *IndicesGetSettingsService) Pretty(pretty bool) *IndicesGetSettingsServi
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesGetSettingsService) Header(key, value string) *IndicesGetSettingsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_get_settings.go
+++ b/indices_get_settings.go
@@ -28,7 +28,7 @@ type IndicesGetSettingsService struct {
 	expandWildcards   string
 	flatSettings      *bool
 	local             *bool
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewIndicesGetSettingsService creates a new IndicesGetSettingsService.

--- a/indices_get_settings.go
+++ b/indices_get_settings.go
@@ -28,7 +28,7 @@ type IndicesGetSettingsService struct {
 	expandWildcards   string
 	flatSettings      *bool
 	local             *bool
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewIndicesGetSettingsService creates a new IndicesGetSettingsService.
@@ -96,8 +96,8 @@ func (s *IndicesGetSettingsService) Pretty(pretty bool) *IndicesGetSettingsServi
 }
 
 // Headers adds headers on the http request
-func (s *IndicesGetSettingsService) Headers(headers map[string]string) *IndicesGetSettingsService {
-	s.headers = headers
+func (s *IndicesGetSettingsService) Header(key, value string) *IndicesGetSettingsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_get_settings.go
+++ b/indices_get_settings.go
@@ -28,6 +28,7 @@ type IndicesGetSettingsService struct {
 	expandWildcards   string
 	flatSettings      *bool
 	local             *bool
+	headers           map[string]string
 }
 
 // NewIndicesGetSettingsService creates a new IndicesGetSettingsService.
@@ -91,6 +92,12 @@ func (s *IndicesGetSettingsService) Local(local bool) *IndicesGetSettingsService
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesGetSettingsService) Pretty(pretty bool) *IndicesGetSettingsService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesGetSettingsService) Headers(headers map[string]string) *IndicesGetSettingsService {
+	s.headers = headers
 	return s
 }
 
@@ -164,7 +171,7 @@ func (s *IndicesGetSettingsService) Do(ctx context.Context) (map[string]*Indices
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_get_template.go
+++ b/indices_get_template.go
@@ -57,7 +57,7 @@ func (s *IndicesGetTemplateService) Pretty(pretty bool) *IndicesGetTemplateServi
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesGetTemplateService) Header(key, value string) *IndicesGetTemplateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_get_template.go
+++ b/indices_get_template.go
@@ -21,7 +21,7 @@ type IndicesGetTemplateService struct {
 	name         []string
 	flatSettings *bool
 	local        *bool
-	headers      map[string]string
+	headers      map[string][]string
 }
 
 // NewIndicesGetTemplateService creates a new IndicesGetTemplateService.
@@ -58,8 +58,8 @@ func (s *IndicesGetTemplateService) Pretty(pretty bool) *IndicesGetTemplateServi
 }
 
 // Headers adds headers on the http request
-func (s *IndicesGetTemplateService) Headers(headers map[string]string) *IndicesGetTemplateService {
-	s.headers = headers
+func (s *IndicesGetTemplateService) Header(key, value string) *IndicesGetTemplateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_get_template.go
+++ b/indices_get_template.go
@@ -21,6 +21,7 @@ type IndicesGetTemplateService struct {
 	name         []string
 	flatSettings *bool
 	local        *bool
+	headers      map[string]string
 }
 
 // NewIndicesGetTemplateService creates a new IndicesGetTemplateService.
@@ -53,6 +54,12 @@ func (s *IndicesGetTemplateService) Local(local bool) *IndicesGetTemplateService
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesGetTemplateService) Pretty(pretty bool) *IndicesGetTemplateService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesGetTemplateService) Headers(headers map[string]string) *IndicesGetTemplateService {
+	s.headers = headers
 	return s
 }
 
@@ -105,7 +112,7 @@ func (s *IndicesGetTemplateService) Do(ctx context.Context) (map[string]*Indices
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_get_template.go
+++ b/indices_get_template.go
@@ -21,7 +21,7 @@ type IndicesGetTemplateService struct {
 	name         []string
 	flatSettings *bool
 	local        *bool
-	headers      map[string][]string
+	headers      headers
 }
 
 // NewIndicesGetTemplateService creates a new IndicesGetTemplateService.

--- a/indices_open.go
+++ b/indices_open.go
@@ -25,6 +25,7 @@ type IndicesOpenService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
+	headers           map[string]string
 }
 
 // NewIndicesOpenService creates and initializes a new IndicesOpenService.
@@ -75,6 +76,12 @@ func (s *IndicesOpenService) ExpandWildcards(expandWildcards string) *IndicesOpe
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IndicesOpenService) Pretty(pretty bool) *IndicesOpenService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesOpenService) Headers(headers map[string]string) *IndicesOpenService {
+	s.headers = headers
 	return s
 }
 
@@ -138,7 +145,7 @@ func (s *IndicesOpenService) Do(ctx context.Context) (*IndicesOpenResponse, erro
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_open.go
+++ b/indices_open.go
@@ -25,7 +25,7 @@ type IndicesOpenService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewIndicesOpenService creates and initializes a new IndicesOpenService.
@@ -80,8 +80,8 @@ func (s *IndicesOpenService) Pretty(pretty bool) *IndicesOpenService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesOpenService) Headers(headers map[string]string) *IndicesOpenService {
-	s.headers = headers
+func (s *IndicesOpenService) Header(key, value string) *IndicesOpenService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_open.go
+++ b/indices_open.go
@@ -25,7 +25,7 @@ type IndicesOpenService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewIndicesOpenService creates and initializes a new IndicesOpenService.

--- a/indices_open.go
+++ b/indices_open.go
@@ -79,7 +79,7 @@ func (s *IndicesOpenService) Pretty(pretty bool) *IndicesOpenService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesOpenService) Header(key, value string) *IndicesOpenService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_put_alias.go
+++ b/indices_put_alias.go
@@ -243,7 +243,7 @@ func (s *AliasService) Action(action ...AliasAction) *AliasService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *AliasService) Header(key, value string) *AliasService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_put_alias.go
+++ b/indices_put_alias.go
@@ -198,7 +198,7 @@ type AliasService struct {
 	client  *Client
 	actions []AliasAction
 	pretty  bool
-	headers map[string]string
+	headers map[string][]string
 }
 
 // NewAliasService implements a service to manage aliases.
@@ -244,8 +244,8 @@ func (s *AliasService) Action(action ...AliasAction) *AliasService {
 }
 
 // Headers adds headers on the http request
-func (s *AliasService) Headers(headers map[string]string) *AliasService {
-	s.headers = headers
+func (s *AliasService) Header(key, value string) *AliasService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_put_alias.go
+++ b/indices_put_alias.go
@@ -198,7 +198,7 @@ type AliasService struct {
 	client  *Client
 	actions []AliasAction
 	pretty  bool
-	headers map[string][]string
+	headers headers
 }
 
 // NewAliasService implements a service to manage aliases.

--- a/indices_put_alias.go
+++ b/indices_put_alias.go
@@ -198,6 +198,7 @@ type AliasService struct {
 	client  *Client
 	actions []AliasAction
 	pretty  bool
+	headers map[string]string
 }
 
 // NewAliasService implements a service to manage aliases.
@@ -242,6 +243,12 @@ func (s *AliasService) Action(action ...AliasAction) *AliasService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *AliasService) Headers(headers map[string]string) *AliasService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *AliasService) buildURL() (string, url.Values, error) {
 	path := "/_aliases"
@@ -274,7 +281,7 @@ func (s *AliasService) Do(ctx context.Context) (*AliasResult, error) {
 	body["actions"] = actions
 
 	// Get response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_put_mapping.go
+++ b/indices_put_mapping.go
@@ -31,6 +31,7 @@ type IndicesPutMappingService struct {
 	timeout           string
 	bodyJson          map[string]interface{}
 	bodyString        string
+	headers           map[string]string
 }
 
 // NewPutMappingService is an alias for NewIndicesPutMappingService.
@@ -119,6 +120,12 @@ func (s *IndicesPutMappingService) BodyString(mapping string) *IndicesPutMapping
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *IndicesPutMappingService) Headers(headers map[string]string) *IndicesPutMappingService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *IndicesPutMappingService) buildURL() (string, url.Values, error) {
 	var err error
@@ -202,7 +209,7 @@ func (s *IndicesPutMappingService) Do(ctx context.Context) (*PutMappingResponse,
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_put_mapping.go
+++ b/indices_put_mapping.go
@@ -120,7 +120,7 @@ func (s *IndicesPutMappingService) BodyString(mapping string) *IndicesPutMapping
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesPutMappingService) Header(key, value string) *IndicesPutMappingService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_put_mapping.go
+++ b/indices_put_mapping.go
@@ -31,7 +31,7 @@ type IndicesPutMappingService struct {
 	timeout           string
 	bodyJson          map[string]interface{}
 	bodyString        string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewPutMappingService is an alias for NewIndicesPutMappingService.

--- a/indices_put_mapping.go
+++ b/indices_put_mapping.go
@@ -31,7 +31,7 @@ type IndicesPutMappingService struct {
 	timeout           string
 	bodyJson          map[string]interface{}
 	bodyString        string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewPutMappingService is an alias for NewIndicesPutMappingService.
@@ -121,8 +121,8 @@ func (s *IndicesPutMappingService) BodyString(mapping string) *IndicesPutMapping
 }
 
 // Headers adds headers on the http request
-func (s *IndicesPutMappingService) Headers(headers map[string]string) *IndicesPutMappingService {
-	s.headers = headers
+func (s *IndicesPutMappingService) Header(key, value string) *IndicesPutMappingService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_put_settings.go
+++ b/indices_put_settings.go
@@ -99,7 +99,7 @@ func (s *IndicesPutSettingsService) BodyString(body string) *IndicesPutSettingsS
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesPutSettingsService) Header(key, value string) *IndicesPutSettingsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_put_settings.go
+++ b/indices_put_settings.go
@@ -29,6 +29,7 @@ type IndicesPutSettingsService struct {
 	masterTimeout     string
 	bodyJson          interface{}
 	bodyString        string
+	headers           map[string]string
 }
 
 // NewIndicesPutSettingsService creates a new IndicesPutSettingsService.
@@ -95,6 +96,12 @@ func (s *IndicesPutSettingsService) BodyJson(body interface{}) *IndicesPutSettin
 // BodyString is documented as: The index settings to be updated.
 func (s *IndicesPutSettingsService) BodyString(body string) *IndicesPutSettingsService {
 	s.bodyString = body
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesPutSettingsService) Headers(headers map[string]string) *IndicesPutSettingsService {
+	s.headers = headers
 	return s
 }
 
@@ -165,7 +172,7 @@ func (s *IndicesPutSettingsService) Do(ctx context.Context) (*IndicesPutSettings
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_put_settings.go
+++ b/indices_put_settings.go
@@ -29,7 +29,7 @@ type IndicesPutSettingsService struct {
 	masterTimeout     string
 	bodyJson          interface{}
 	bodyString        string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewIndicesPutSettingsService creates a new IndicesPutSettingsService.
@@ -100,8 +100,8 @@ func (s *IndicesPutSettingsService) BodyString(body string) *IndicesPutSettingsS
 }
 
 // Headers adds headers on the http request
-func (s *IndicesPutSettingsService) Headers(headers map[string]string) *IndicesPutSettingsService {
-	s.headers = headers
+func (s *IndicesPutSettingsService) Header(key, value string) *IndicesPutSettingsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_put_settings.go
+++ b/indices_put_settings.go
@@ -29,7 +29,7 @@ type IndicesPutSettingsService struct {
 	masterTimeout     string
 	bodyJson          interface{}
 	bodyString        string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewIndicesPutSettingsService creates a new IndicesPutSettingsService.

--- a/indices_put_template.go
+++ b/indices_put_template.go
@@ -27,7 +27,7 @@ type IndicesPutTemplateService struct {
 	flatSettings  *bool
 	bodyJson      interface{}
 	bodyString    string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewIndicesPutTemplateService creates a new IndicesPutTemplateService.
@@ -107,8 +107,8 @@ func (s *IndicesPutTemplateService) BodyString(body string) *IndicesPutTemplateS
 }
 
 // Headers adds headers on the http request
-func (s *IndicesPutTemplateService) Headers(headers map[string]string) *IndicesPutTemplateService {
-	s.headers = headers
+func (s *IndicesPutTemplateService) Header(key, value string) *IndicesPutTemplateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_put_template.go
+++ b/indices_put_template.go
@@ -106,7 +106,7 @@ func (s *IndicesPutTemplateService) BodyString(body string) *IndicesPutTemplateS
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesPutTemplateService) Header(key, value string) *IndicesPutTemplateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_put_template.go
+++ b/indices_put_template.go
@@ -27,7 +27,7 @@ type IndicesPutTemplateService struct {
 	flatSettings  *bool
 	bodyJson      interface{}
 	bodyString    string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewIndicesPutTemplateService creates a new IndicesPutTemplateService.

--- a/indices_put_template.go
+++ b/indices_put_template.go
@@ -27,6 +27,7 @@ type IndicesPutTemplateService struct {
 	flatSettings  *bool
 	bodyJson      interface{}
 	bodyString    string
+	headers       map[string]string
 }
 
 // NewIndicesPutTemplateService creates a new IndicesPutTemplateService.
@@ -102,6 +103,12 @@ func (s *IndicesPutTemplateService) BodyJson(body interface{}) *IndicesPutTempla
 // BodyString is documented as: The template definition.
 func (s *IndicesPutTemplateService) BodyString(body string) *IndicesPutTemplateService {
 	s.bodyString = body
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesPutTemplateService) Headers(headers map[string]string) *IndicesPutTemplateService {
+	s.headers = headers
 	return s
 }
 
@@ -181,7 +188,7 @@ func (s *IndicesPutTemplateService) Do(ctx context.Context) (*IndicesPutTemplate
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_refresh.go
+++ b/indices_refresh.go
@@ -20,7 +20,7 @@ type RefreshService struct {
 	index   []string
 	force   *bool
 	pretty  bool
-	headers map[string]string
+	headers map[string][]string
 }
 
 // NewRefreshService creates a new instance of RefreshService.
@@ -50,8 +50,8 @@ func (s *RefreshService) Pretty(pretty bool) *RefreshService {
 }
 
 // Headers adds headers on the http request
-func (s *RefreshService) Headers(headers map[string]string) *RefreshService {
-	s.headers = headers
+func (s *RefreshService) Header(key, value string) *RefreshService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_refresh.go
+++ b/indices_refresh.go
@@ -16,10 +16,11 @@ import (
 // RefreshService explicitly refreshes one or more indices.
 // See https://www.elastic.co/guide/en/elasticsearch/reference/5.2/indices-refresh.html.
 type RefreshService struct {
-	client *Client
-	index  []string
-	force  *bool
-	pretty bool
+	client  *Client
+	index   []string
+	force   *bool
+	pretty  bool
+	headers map[string]string
 }
 
 // NewRefreshService creates a new instance of RefreshService.
@@ -45,6 +46,12 @@ func (s *RefreshService) Force(force bool) *RefreshService {
 // Pretty asks Elasticsearch to return indented JSON.
 func (s *RefreshService) Pretty(pretty bool) *RefreshService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *RefreshService) Headers(headers map[string]string) *RefreshService {
+	s.headers = headers
 	return s
 }
 
@@ -83,7 +90,7 @@ func (s *RefreshService) Do(ctx context.Context) (*RefreshResult, error) {
 	}
 
 	// Get response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_refresh.go
+++ b/indices_refresh.go
@@ -49,7 +49,7 @@ func (s *RefreshService) Pretty(pretty bool) *RefreshService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *RefreshService) Header(key, value string) *RefreshService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_refresh.go
+++ b/indices_refresh.go
@@ -20,7 +20,7 @@ type RefreshService struct {
 	index   []string
 	force   *bool
 	pretty  bool
-	headers map[string][]string
+	headers headers
 }
 
 // NewRefreshService creates a new instance of RefreshService.

--- a/indices_rollover.go
+++ b/indices_rollover.go
@@ -32,7 +32,7 @@ type IndicesRolloverService struct {
 	mappings            map[string]interface{}
 	bodyJson            interface{}
 	bodyString          string
-	headers             map[string][]string
+	headers             headers
 }
 
 // NewIndicesRolloverService creates a new IndicesRolloverService.

--- a/indices_rollover.go
+++ b/indices_rollover.go
@@ -152,7 +152,7 @@ func (s *IndicesRolloverService) BodyString(body string) *IndicesRolloverService
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesRolloverService) Header(key, value string) *IndicesRolloverService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_rollover.go
+++ b/indices_rollover.go
@@ -32,6 +32,7 @@ type IndicesRolloverService struct {
 	mappings            map[string]interface{}
 	bodyJson            interface{}
 	bodyString          string
+	headers             map[string]string
 }
 
 // NewIndicesRolloverService creates a new IndicesRolloverService.
@@ -151,6 +152,12 @@ func (s *IndicesRolloverService) BodyString(body string) *IndicesRolloverService
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *IndicesRolloverService) Headers(headers map[string]string) *IndicesRolloverService {
+	s.headers = headers
+	return s
+}
+
 // getBody returns the body of the request, if not explicitly set via
 // BodyJson or BodyString.
 func (s *IndicesRolloverService) getBody() interface{} {
@@ -242,7 +249,7 @@ func (s *IndicesRolloverService) Do(ctx context.Context) (*IndicesRolloverRespon
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_rollover.go
+++ b/indices_rollover.go
@@ -32,7 +32,7 @@ type IndicesRolloverService struct {
 	mappings            map[string]interface{}
 	bodyJson            interface{}
 	bodyString          string
-	headers             map[string]string
+	headers             map[string][]string
 }
 
 // NewIndicesRolloverService creates a new IndicesRolloverService.
@@ -153,8 +153,8 @@ func (s *IndicesRolloverService) BodyString(body string) *IndicesRolloverService
 }
 
 // Headers adds headers on the http request
-func (s *IndicesRolloverService) Headers(headers map[string]string) *IndicesRolloverService {
-	s.headers = headers
+func (s *IndicesRolloverService) Header(key, value string) *IndicesRolloverService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_shrink.go
+++ b/indices_shrink.go
@@ -28,7 +28,7 @@ type IndicesShrinkService struct {
 	waitForActiveShards string
 	bodyJson            interface{}
 	bodyString          string
-	headers             map[string]string
+	headers             map[string][]string
 }
 
 // NewIndicesShrinkService creates a new IndicesShrinkService.
@@ -90,8 +90,8 @@ func (s *IndicesShrinkService) BodyString(body string) *IndicesShrinkService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesShrinkService) Headers(headers map[string]string) *IndicesShrinkService {
-	s.headers = headers
+func (s *IndicesShrinkService) Header(key, value string) *IndicesShrinkService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_shrink.go
+++ b/indices_shrink.go
@@ -28,7 +28,7 @@ type IndicesShrinkService struct {
 	waitForActiveShards string
 	bodyJson            interface{}
 	bodyString          string
-	headers             map[string][]string
+	headers             headers
 }
 
 // NewIndicesShrinkService creates a new IndicesShrinkService.

--- a/indices_shrink.go
+++ b/indices_shrink.go
@@ -28,6 +28,7 @@ type IndicesShrinkService struct {
 	waitForActiveShards string
 	bodyJson            interface{}
 	bodyString          string
+	headers             map[string]string
 }
 
 // NewIndicesShrinkService creates a new IndicesShrinkService.
@@ -85,6 +86,12 @@ func (s *IndicesShrinkService) BodyJson(body interface{}) *IndicesShrinkService 
 // defined as a string to send as the request body.
 func (s *IndicesShrinkService) BodyString(body string) *IndicesShrinkService {
 	s.bodyString = body
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IndicesShrinkService) Headers(headers map[string]string) *IndicesShrinkService {
+	s.headers = headers
 	return s
 }
 
@@ -153,7 +160,7 @@ func (s *IndicesShrinkService) Do(ctx context.Context) (*IndicesShrinkResponse, 
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_shrink.go
+++ b/indices_shrink.go
@@ -89,7 +89,7 @@ func (s *IndicesShrinkService) BodyString(body string) *IndicesShrinkService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesShrinkService) Header(key, value string) *IndicesShrinkService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/indices_stats.go
+++ b/indices_stats.go
@@ -27,7 +27,7 @@ type IndicesStatsService struct {
 	fields           []string
 	groups           []string
 	human            *bool
-	headers          map[string][]string
+	headers          headers
 }
 
 // NewIndicesStatsService creates a new IndicesStatsService.

--- a/indices_stats.go
+++ b/indices_stats.go
@@ -27,7 +27,7 @@ type IndicesStatsService struct {
 	fields           []string
 	groups           []string
 	human            *bool
-	headers          map[string]string
+	headers          map[string][]string
 }
 
 // NewIndicesStatsService creates a new IndicesStatsService.
@@ -110,8 +110,8 @@ func (s *IndicesStatsService) Pretty(pretty bool) *IndicesStatsService {
 }
 
 // Headers adds headers on the http request
-func (s *IndicesStatsService) Headers(headers map[string]string) *IndicesStatsService {
-	s.headers = headers
+func (s *IndicesStatsService) Header(key, value string) *IndicesStatsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/indices_stats.go
+++ b/indices_stats.go
@@ -27,6 +27,7 @@ type IndicesStatsService struct {
 	fields           []string
 	groups           []string
 	human            *bool
+	headers          map[string]string
 }
 
 // NewIndicesStatsService creates a new IndicesStatsService.
@@ -108,6 +109,12 @@ func (s *IndicesStatsService) Pretty(pretty bool) *IndicesStatsService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *IndicesStatsService) Headers(headers map[string]string) *IndicesStatsService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *IndicesStatsService) buildURL() (string, url.Values, error) {
 	var err error
@@ -180,7 +187,7 @@ func (s *IndicesStatsService) Do(ctx context.Context) (*IndicesStatsResponse, er
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/indices_stats.go
+++ b/indices_stats.go
@@ -109,7 +109,7 @@ func (s *IndicesStatsService) Pretty(pretty bool) *IndicesStatsService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IndicesStatsService) Header(key, value string) *IndicesStatsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/ingest_delete_pipeline.go
+++ b/ingest_delete_pipeline.go
@@ -55,7 +55,7 @@ func (s *IngestDeletePipelineService) Pretty(pretty bool) *IngestDeletePipelineS
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IngestDeletePipelineService) Header(key, value string) *IngestDeletePipelineService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/ingest_delete_pipeline.go
+++ b/ingest_delete_pipeline.go
@@ -21,7 +21,7 @@ type IngestDeletePipelineService struct {
 	id            string
 	masterTimeout string
 	timeout       string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewIngestDeletePipelineService creates a new IngestDeletePipelineService.
@@ -56,8 +56,8 @@ func (s *IngestDeletePipelineService) Pretty(pretty bool) *IngestDeletePipelineS
 }
 
 // Headers adds headers on the http request
-func (s *IngestDeletePipelineService) Headers(headers map[string]string) *IngestDeletePipelineService {
-	s.headers = headers
+func (s *IngestDeletePipelineService) Header(key, value string) *IngestDeletePipelineService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/ingest_delete_pipeline.go
+++ b/ingest_delete_pipeline.go
@@ -21,6 +21,7 @@ type IngestDeletePipelineService struct {
 	id            string
 	masterTimeout string
 	timeout       string
+	headers       map[string]string
 }
 
 // NewIngestDeletePipelineService creates a new IngestDeletePipelineService.
@@ -51,6 +52,12 @@ func (s *IngestDeletePipelineService) Timeout(timeout string) *IngestDeletePipel
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IngestDeletePipelineService) Pretty(pretty bool) *IngestDeletePipelineService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IngestDeletePipelineService) Headers(headers map[string]string) *IngestDeletePipelineService {
+	s.headers = headers
 	return s
 }
 
@@ -104,7 +111,7 @@ func (s *IngestDeletePipelineService) Do(ctx context.Context) (*IngestDeletePipe
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/ingest_delete_pipeline.go
+++ b/ingest_delete_pipeline.go
@@ -21,7 +21,7 @@ type IngestDeletePipelineService struct {
 	id            string
 	masterTimeout string
 	timeout       string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewIngestDeletePipelineService creates a new IngestDeletePipelineService.

--- a/ingest_get_pipeline.go
+++ b/ingest_get_pipeline.go
@@ -21,6 +21,7 @@ type IngestGetPipelineService struct {
 	pretty        bool
 	id            []string
 	masterTimeout string
+	headers       map[string]string
 }
 
 // NewIngestGetPipelineService creates a new IngestGetPipelineService.
@@ -45,6 +46,12 @@ func (s *IngestGetPipelineService) MasterTimeout(masterTimeout string) *IngestGe
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *IngestGetPipelineService) Pretty(pretty bool) *IngestGetPipelineService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IngestGetPipelineService) Headers(headers map[string]string) *IngestGetPipelineService {
+	s.headers = headers
 	return s
 }
 
@@ -95,7 +102,7 @@ func (s *IngestGetPipelineService) Do(ctx context.Context) (IngestGetPipelineRes
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/ingest_get_pipeline.go
+++ b/ingest_get_pipeline.go
@@ -21,7 +21,7 @@ type IngestGetPipelineService struct {
 	pretty        bool
 	id            []string
 	masterTimeout string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewIngestGetPipelineService creates a new IngestGetPipelineService.

--- a/ingest_get_pipeline.go
+++ b/ingest_get_pipeline.go
@@ -49,7 +49,7 @@ func (s *IngestGetPipelineService) Pretty(pretty bool) *IngestGetPipelineService
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IngestGetPipelineService) Header(key, value string) *IngestGetPipelineService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/ingest_get_pipeline.go
+++ b/ingest_get_pipeline.go
@@ -21,7 +21,7 @@ type IngestGetPipelineService struct {
 	pretty        bool
 	id            []string
 	masterTimeout string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewIngestGetPipelineService creates a new IngestGetPipelineService.
@@ -50,8 +50,8 @@ func (s *IngestGetPipelineService) Pretty(pretty bool) *IngestGetPipelineService
 }
 
 // Headers adds headers on the http request
-func (s *IngestGetPipelineService) Headers(headers map[string]string) *IngestGetPipelineService {
-	s.headers = headers
+func (s *IngestGetPipelineService) Header(key, value string) *IngestGetPipelineService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/ingest_put_pipeline.go
+++ b/ingest_put_pipeline.go
@@ -25,7 +25,7 @@ type IngestPutPipelineService struct {
 	timeout       string
 	bodyJson      interface{}
 	bodyString    string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewIngestPutPipelineService creates a new IngestPutPipelineService.
@@ -73,8 +73,8 @@ func (s *IngestPutPipelineService) BodyString(body string) *IngestPutPipelineSer
 }
 
 // Headers adds headers on the http request
-func (s *IngestPutPipelineService) Headers(headers map[string]string) *IngestPutPipelineService {
-	s.headers = headers
+func (s *IngestPutPipelineService) Header(key, value string) *IngestPutPipelineService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/ingest_put_pipeline.go
+++ b/ingest_put_pipeline.go
@@ -25,6 +25,7 @@ type IngestPutPipelineService struct {
 	timeout       string
 	bodyJson      interface{}
 	bodyString    string
+	headers       map[string]string
 }
 
 // NewIngestPutPipelineService creates a new IngestPutPipelineService.
@@ -68,6 +69,12 @@ func (s *IngestPutPipelineService) BodyJson(body interface{}) *IngestPutPipeline
 // BodyString is the ingest definition, specified as a string.
 func (s *IngestPutPipelineService) BodyString(body string) *IngestPutPipelineService {
 	s.bodyString = body
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IngestPutPipelineService) Headers(headers map[string]string) *IngestPutPipelineService {
+	s.headers = headers
 	return s
 }
 
@@ -132,7 +139,7 @@ func (s *IngestPutPipelineService) Do(ctx context.Context) (*IngestPutPipelineRe
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/ingest_put_pipeline.go
+++ b/ingest_put_pipeline.go
@@ -72,7 +72,7 @@ func (s *IngestPutPipelineService) BodyString(body string) *IngestPutPipelineSer
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IngestPutPipelineService) Header(key, value string) *IngestPutPipelineService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/ingest_put_pipeline.go
+++ b/ingest_put_pipeline.go
@@ -25,7 +25,7 @@ type IngestPutPipelineService struct {
 	timeout       string
 	bodyJson      interface{}
 	bodyString    string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewIngestPutPipelineService creates a new IngestPutPipelineService.

--- a/ingest_simulate_pipeline.go
+++ b/ingest_simulate_pipeline.go
@@ -66,7 +66,7 @@ func (s *IngestSimulatePipelineService) BodyString(body string) *IngestSimulateP
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *IngestSimulatePipelineService) Header(key, value string) *IngestSimulatePipelineService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/ingest_simulate_pipeline.go
+++ b/ingest_simulate_pipeline.go
@@ -25,7 +25,7 @@ type IngestSimulatePipelineService struct {
 	verbose    *bool
 	bodyJson   interface{}
 	bodyString string
-	headers    map[string][]string
+	headers    headers
 }
 
 // NewIngestSimulatePipelineService creates a new IngestSimulatePipeline.

--- a/ingest_simulate_pipeline.go
+++ b/ingest_simulate_pipeline.go
@@ -25,6 +25,7 @@ type IngestSimulatePipelineService struct {
 	verbose    *bool
 	bodyJson   interface{}
 	bodyString string
+	headers    map[string]string
 }
 
 // NewIngestSimulatePipelineService creates a new IngestSimulatePipeline.
@@ -62,6 +63,12 @@ func (s *IngestSimulatePipelineService) BodyJson(body interface{}) *IngestSimula
 // BodyString is the simulate definition, defined as a string.
 func (s *IngestSimulatePipelineService) BodyString(body string) *IngestSimulatePipelineService {
 	s.bodyString = body
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *IngestSimulatePipelineService) Headers(headers map[string]string) *IngestSimulatePipelineService {
+	s.headers = headers
 	return s
 }
 
@@ -127,7 +134,7 @@ func (s *IngestSimulatePipelineService) Do(ctx context.Context) (*IngestSimulate
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/ingest_simulate_pipeline.go
+++ b/ingest_simulate_pipeline.go
@@ -25,7 +25,7 @@ type IngestSimulatePipelineService struct {
 	verbose    *bool
 	bodyJson   interface{}
 	bodyString string
-	headers    map[string]string
+	headers    map[string][]string
 }
 
 // NewIngestSimulatePipelineService creates a new IngestSimulatePipeline.
@@ -67,8 +67,8 @@ func (s *IngestSimulatePipelineService) BodyString(body string) *IngestSimulateP
 }
 
 // Headers adds headers on the http request
-func (s *IngestSimulatePipelineService) Headers(headers map[string]string) *IngestSimulatePipelineService {
-	s.headers = headers
+func (s *IngestSimulatePipelineService) Header(key, value string) *IngestSimulatePipelineService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/mget.go
+++ b/mget.go
@@ -27,6 +27,7 @@ type MgetService struct {
 	routing      string
 	storedFields []string
 	items        []*MultiGetItem
+	headers      map[string]string
 }
 
 // NewMgetService initializes a new Multi GET API request call.
@@ -95,6 +96,12 @@ func (s *MgetService) Source() (interface{}, error) {
 	return source, nil
 }
 
+// Headers adds headers on the http request
+func (s *MgetService) Headers(headers map[string]string) *MgetService {
+	s.headers = headers
+	return s
+}
+
 // Do executes the request.
 func (s *MgetService) Do(ctx context.Context) (*MgetResponse, error) {
 	// Build url
@@ -124,7 +131,7 @@ func (s *MgetService) Do(ctx context.Context) (*MgetResponse, error) {
 	}
 
 	// Get response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/mget.go
+++ b/mget.go
@@ -27,7 +27,7 @@ type MgetService struct {
 	routing      string
 	storedFields []string
 	items        []*MultiGetItem
-	headers      map[string]string
+	headers      map[string][]string
 }
 
 // NewMgetService initializes a new Multi GET API request call.
@@ -97,8 +97,8 @@ func (s *MgetService) Source() (interface{}, error) {
 }
 
 // Headers adds headers on the http request
-func (s *MgetService) Headers(headers map[string]string) *MgetService {
-	s.headers = headers
+func (s *MgetService) Header(key, value string) *MgetService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/mget.go
+++ b/mget.go
@@ -96,7 +96,7 @@ func (s *MgetService) Source() (interface{}, error) {
 	return source, nil
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *MgetService) Header(key, value string) *MgetService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/mget.go
+++ b/mget.go
@@ -27,7 +27,7 @@ type MgetService struct {
 	routing      string
 	storedFields []string
 	items        []*MultiGetItem
-	headers      map[string][]string
+	headers      headers
 }
 
 // NewMgetService initializes a new Multi GET API request call.

--- a/msearch.go
+++ b/msearch.go
@@ -20,7 +20,7 @@ type MultiSearchService struct {
 	pretty     bool
 	routing    string
 	preference string
-	headers    map[string][]string
+	headers    headers
 }
 
 func NewMultiSearchService(client *Client) *MultiSearchService {

--- a/msearch.go
+++ b/msearch.go
@@ -20,6 +20,7 @@ type MultiSearchService struct {
 	pretty     bool
 	routing    string
 	preference string
+	headers    map[string]string
 }
 
 func NewMultiSearchService(client *Client) *MultiSearchService {
@@ -43,6 +44,12 @@ func (s *MultiSearchService) Index(indices ...string) *MultiSearchService {
 
 func (s *MultiSearchService) Pretty(pretty bool) *MultiSearchService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *MultiSearchService) Headers(headers map[string]string) *MultiSearchService {
+	s.headers = headers
 	return s
 }
 
@@ -78,7 +85,7 @@ func (s *MultiSearchService) Do(ctx context.Context) (*MultiSearchResult, error)
 	body := strings.Join(lines, "\n") + "\n" // Don't forget trailing \n
 
 	// Get response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/msearch.go
+++ b/msearch.go
@@ -20,7 +20,7 @@ type MultiSearchService struct {
 	pretty     bool
 	routing    string
 	preference string
-	headers    map[string]string
+	headers    map[string][]string
 }
 
 func NewMultiSearchService(client *Client) *MultiSearchService {
@@ -48,8 +48,8 @@ func (s *MultiSearchService) Pretty(pretty bool) *MultiSearchService {
 }
 
 // Headers adds headers on the http request
-func (s *MultiSearchService) Headers(headers map[string]string) *MultiSearchService {
-	s.headers = headers
+func (s *MultiSearchService) Header(key, value string) *MultiSearchService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/msearch.go
+++ b/msearch.go
@@ -47,7 +47,7 @@ func (s *MultiSearchService) Pretty(pretty bool) *MultiSearchService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *MultiSearchService) Header(key, value string) *MultiSearchService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/mtermvectors.go
+++ b/mtermvectors.go
@@ -175,7 +175,7 @@ func (s *MultiTermvectorService) Source() interface{} {
 	return source
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *MultiTermvectorService) Header(key, value string) *MultiTermvectorService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/mtermvectors.go
+++ b/mtermvectors.go
@@ -41,7 +41,7 @@ type MultiTermvectorService struct {
 	bodyJson        interface{}
 	bodyString      string
 	docs            []*MultiTermvectorItem
-	headers         map[string]string
+	headers         map[string][]string
 }
 
 // NewMultiTermvectorService creates a new MultiTermvectorService.
@@ -176,8 +176,8 @@ func (s *MultiTermvectorService) Source() interface{} {
 }
 
 // Headers adds headers on the http request
-func (s *MultiTermvectorService) Headers(headers map[string]string) *MultiTermvectorService {
-	s.headers = headers
+func (s *MultiTermvectorService) Header(key, value string) *MultiTermvectorService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/mtermvectors.go
+++ b/mtermvectors.go
@@ -41,7 +41,7 @@ type MultiTermvectorService struct {
 	bodyJson        interface{}
 	bodyString      string
 	docs            []*MultiTermvectorItem
-	headers         map[string][]string
+	headers         headers
 }
 
 // NewMultiTermvectorService creates a new MultiTermvectorService.

--- a/mtermvectors.go
+++ b/mtermvectors.go
@@ -41,6 +41,7 @@ type MultiTermvectorService struct {
 	bodyJson        interface{}
 	bodyString      string
 	docs            []*MultiTermvectorItem
+	headers         map[string]string
 }
 
 // NewMultiTermvectorService creates a new MultiTermvectorService.
@@ -174,6 +175,12 @@ func (s *MultiTermvectorService) Source() interface{} {
 	return source
 }
 
+// Headers adds headers on the http request
+func (s *MultiTermvectorService) Headers(headers map[string]string) *MultiTermvectorService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *MultiTermvectorService) buildURL() (string, url.Values, error) {
 	var path string
@@ -278,7 +285,7 @@ func (s *MultiTermvectorService) Do(ctx context.Context) (*MultiTermvectorRespon
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/nodes_info.go
+++ b/nodes_info.go
@@ -24,7 +24,7 @@ type NodesInfoService struct {
 	metric       []string
 	flatSettings *bool
 	human        *bool
-	headers      map[string]string
+	headers      map[string][]string
 }
 
 // NewNodesInfoService creates a new NodesInfoService.
@@ -71,8 +71,8 @@ func (s *NodesInfoService) Pretty(pretty bool) *NodesInfoService {
 }
 
 // Headers adds headers on the http request
-func (s *NodesInfoService) Headers(headers map[string]string) *NodesInfoService {
-	s.headers = headers
+func (s *NodesInfoService) Header(key, value string) *NodesInfoService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/nodes_info.go
+++ b/nodes_info.go
@@ -70,7 +70,7 @@ func (s *NodesInfoService) Pretty(pretty bool) *NodesInfoService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *NodesInfoService) Header(key, value string) *NodesInfoService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/nodes_info.go
+++ b/nodes_info.go
@@ -24,7 +24,7 @@ type NodesInfoService struct {
 	metric       []string
 	flatSettings *bool
 	human        *bool
-	headers      map[string][]string
+	headers      headers
 }
 
 // NewNodesInfoService creates a new NodesInfoService.

--- a/nodes_info.go
+++ b/nodes_info.go
@@ -24,6 +24,7 @@ type NodesInfoService struct {
 	metric       []string
 	flatSettings *bool
 	human        *bool
+	headers      map[string]string
 }
 
 // NewNodesInfoService creates a new NodesInfoService.
@@ -66,6 +67,12 @@ func (s *NodesInfoService) Human(human bool) *NodesInfoService {
 // Pretty indicates whether to indent the returned JSON.
 func (s *NodesInfoService) Pretty(pretty bool) *NodesInfoService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *NodesInfoService) Headers(headers map[string]string) *NodesInfoService {
+	s.headers = headers
 	return s
 }
 
@@ -113,7 +120,7 @@ func (s *NodesInfoService) Do(ctx context.Context) (*NodesInfoResponse, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/nodes_stats.go
+++ b/nodes_stats.go
@@ -31,7 +31,7 @@ type NodesStatsService struct {
 	level            string
 	timeout          string
 	types            []string
-	headers          map[string]string
+	headers          map[string][]string
 }
 
 // NewNodesStatsService creates a new NodesStatsService.
@@ -119,8 +119,8 @@ func (s *NodesStatsService) Pretty(pretty bool) *NodesStatsService {
 }
 
 // Headers adds headers on the http request
-func (s *NodesStatsService) Headers(headers map[string]string) *NodesStatsService {
-	s.headers = headers
+func (s *NodesStatsService) Header(key, value string) *NodesStatsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/nodes_stats.go
+++ b/nodes_stats.go
@@ -31,6 +31,7 @@ type NodesStatsService struct {
 	level            string
 	timeout          string
 	types            []string
+	headers          map[string]string
 }
 
 // NewNodesStatsService creates a new NodesStatsService.
@@ -114,6 +115,12 @@ func (s *NodesStatsService) Types(types ...string) *NodesStatsService {
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *NodesStatsService) Pretty(pretty bool) *NodesStatsService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *NodesStatsService) Headers(headers map[string]string) *NodesStatsService {
+	s.headers = headers
 	return s
 }
 
@@ -213,7 +220,7 @@ func (s *NodesStatsService) Do(ctx context.Context) (*NodesStatsResponse, error)
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/nodes_stats.go
+++ b/nodes_stats.go
@@ -31,7 +31,7 @@ type NodesStatsService struct {
 	level            string
 	timeout          string
 	types            []string
-	headers          map[string][]string
+	headers          headers
 }
 
 // NewNodesStatsService creates a new NodesStatsService.

--- a/nodes_stats.go
+++ b/nodes_stats.go
@@ -118,7 +118,7 @@ func (s *NodesStatsService) Pretty(pretty bool) *NodesStatsService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *NodesStatsService) Header(key, value string) *NodesStatsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/ping.go
+++ b/ping.go
@@ -77,6 +77,7 @@ func (s *PingService) Do(ctx context.Context) (*PingResult, int, error) {
 	basicAuth := s.client.basicAuth
 	basicAuthUsername := s.client.basicAuthUsername
 	basicAuthPassword := s.client.basicAuthPassword
+	headers := s.client.headers
 	s.client.mu.RUnlock()
 
 	url_ := s.url + "/"
@@ -107,6 +108,9 @@ func (s *PingService) Do(ctx context.Context) (*PingResult, int, error) {
 
 	if basicAuth {
 		req.SetBasicAuth(basicAuthUsername, basicAuthPassword)
+	}
+	if headers != nil {
+		req.SetCustomHeaders(headers)
 	}
 
 	res, err := s.client.c.Do((*http.Request)(req).WithContext(ctx))

--- a/put_template.go
+++ b/put_template.go
@@ -24,7 +24,7 @@ type PutTemplateService struct {
 	versionType string
 	bodyJson    interface{}
 	bodyString  string
-	headers     map[string][]string
+	headers     headers
 }
 
 // NewPutTemplateService creates a new PutTemplateService.

--- a/put_template.go
+++ b/put_template.go
@@ -24,6 +24,7 @@ type PutTemplateService struct {
 	versionType string
 	bodyJson    interface{}
 	bodyString  string
+	headers     map[string]string
 }
 
 // NewPutTemplateService creates a new PutTemplateService.
@@ -66,6 +67,12 @@ func (s *PutTemplateService) BodyJson(body interface{}) *PutTemplateService {
 // BodyString is the document as a string.
 func (s *PutTemplateService) BodyString(body string) *PutTemplateService {
 	s.bodyString = body
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *PutTemplateService) Headers(headers map[string]string) *PutTemplateService {
+	s.headers = headers
 	return s
 }
 
@@ -131,7 +138,7 @@ func (s *PutTemplateService) Do(ctx context.Context) (*AcknowledgedResponse, err
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/put_template.go
+++ b/put_template.go
@@ -24,7 +24,7 @@ type PutTemplateService struct {
 	versionType string
 	bodyJson    interface{}
 	bodyString  string
-	headers     map[string]string
+	headers     map[string][]string
 }
 
 // NewPutTemplateService creates a new PutTemplateService.
@@ -71,8 +71,8 @@ func (s *PutTemplateService) BodyString(body string) *PutTemplateService {
 }
 
 // Headers adds headers on the http request
-func (s *PutTemplateService) Headers(headers map[string]string) *PutTemplateService {
-	s.headers = headers
+func (s *PutTemplateService) Header(key, value string) *PutTemplateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/put_template.go
+++ b/put_template.go
@@ -70,7 +70,7 @@ func (s *PutTemplateService) BodyString(body string) *PutTemplateService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *PutTemplateService) Header(key, value string) *PutTemplateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/reindex.go
+++ b/reindex.go
@@ -26,7 +26,7 @@ type ReindexService struct {
 	conflicts           string
 	size                *int
 	script              *Script
-	headers             map[string][]string
+	headers             headers
 }
 
 // NewReindexService creates a new ReindexService.

--- a/reindex.go
+++ b/reindex.go
@@ -26,6 +26,7 @@ type ReindexService struct {
 	conflicts           string
 	size                *int
 	script              *Script
+	headers             map[string]string
 }
 
 // NewReindexService creates a new ReindexService.
@@ -160,6 +161,12 @@ func (s *ReindexService) Body(body interface{}) *ReindexService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *ReindexService) Headers(headers map[string]string) *ReindexService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *ReindexService) buildURL() (string, url.Values, error) {
 	// Build URL path
@@ -267,7 +274,7 @@ func (s *ReindexService) Do(ctx context.Context) (*BulkIndexByScrollResponse, er
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +316,7 @@ func (s *ReindexService) DoAsync(ctx context.Context) (*StartTaskResult, error) 
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/reindex.go
+++ b/reindex.go
@@ -26,7 +26,7 @@ type ReindexService struct {
 	conflicts           string
 	size                *int
 	script              *Script
-	headers             map[string]string
+	headers             map[string][]string
 }
 
 // NewReindexService creates a new ReindexService.
@@ -162,8 +162,8 @@ func (s *ReindexService) Body(body interface{}) *ReindexService {
 }
 
 // Headers adds headers on the http request
-func (s *ReindexService) Headers(headers map[string]string) *ReindexService {
-	s.headers = headers
+func (s *ReindexService) Header(key, value string) *ReindexService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/reindex.go
+++ b/reindex.go
@@ -161,7 +161,7 @@ func (s *ReindexService) Body(body interface{}) *ReindexService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *ReindexService) Header(key, value string) *ReindexService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/request.go
+++ b/request.go
@@ -31,7 +31,7 @@ func NewRequest(method, url string) (*Request, error) {
 }
 
 // SetCustomHeaders adds the key, value pairs to the header
-func (r *Request) SetCustomHeaders(headers map[string][]string) {
+func (r *Request) SetCustomHeaders(headers headers) {
 	for k, v := range headers {
 		for _, el := range v {
 			r.Header.Add(k, el)

--- a/request.go
+++ b/request.go
@@ -30,6 +30,13 @@ func NewRequest(method, url string) (*Request, error) {
 	return (*Request)(req), nil
 }
 
+// SetCustomHeaders adds the key, value pairs to the header
+func (r *Request) SetCustomHeaders(headers map[string]string) {
+	for k, v := range headers {
+		r.Header.Add(k, v)
+	}
+}
+
 // SetBasicAuth wraps http.Request's SetBasicAuth.
 func (r *Request) SetBasicAuth(username, password string) {
 	((*http.Request)(r)).SetBasicAuth(username, password)

--- a/request.go
+++ b/request.go
@@ -31,9 +31,11 @@ func NewRequest(method, url string) (*Request, error) {
 }
 
 // SetCustomHeaders adds the key, value pairs to the header
-func (r *Request) SetCustomHeaders(headers map[string]string) {
+func (r *Request) SetCustomHeaders(headers map[string][]string) {
 	for k, v := range headers {
-		r.Header.Add(k, v)
+		for _, el := range v {
+			r.Header.Add(k, el)
+		}
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -8,6 +8,22 @@ import "testing"
 
 var testReq *Request // used as a temporary variable to avoid compiler optimizations in tests/benchmarks
 
+func BenchmarkRequestSetCustomHeader(b *testing.B) {
+	req, err := NewRequest("GET", "/")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		body := `{"query":{"match_all":{}}}`
+		err = req.SetBody(body, false)
+		req.SetCustomHeaders(map[string]string{"header1": "custom"})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	testReq = req
+}
+
 func BenchmarkRequestSetBodyString(b *testing.B) {
 	req, err := NewRequest("GET", "/")
 	if err != nil {

--- a/request_test.go
+++ b/request_test.go
@@ -16,7 +16,7 @@ func BenchmarkRequestSetCustomHeader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		body := `{"query":{"match_all":{}}}`
 		err = req.SetBody(body, false)
-		req.SetCustomHeaders(map[string][]string{"header1": {"custom"}})
+		req.SetCustomHeaders(headers{"header1": {"custom"}})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/request_test.go
+++ b/request_test.go
@@ -16,7 +16,7 @@ func BenchmarkRequestSetCustomHeader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		body := `{"query":{"match_all":{}}}`
 		err = req.SetBody(body, false)
-		req.SetCustomHeaders(map[string]string{"header1": "custom"})
+		req.SetCustomHeaders(map[string][]string{"header1": {"custom"}})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -65,7 +65,7 @@ func TestRetrier(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := client.PerformRequest(context.TODO(), "GET", "/fail", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/fail", nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -107,7 +107,7 @@ func TestRetrierWithError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := client.PerformRequest(context.TODO(), "GET", "/fail", nil, nil)
+	res, err := client.PerformRequest(context.TODO(), "GET", "/fail", nil, nil, nil)
 	if err != kaboom {
 		t.Fatalf("expected %v, got %v", kaboom, err)
 	}

--- a/scroll.go
+++ b/scroll.go
@@ -39,7 +39,7 @@ type ScrollService struct {
 	mu       sync.RWMutex
 	scrollId string
 
-	headers map[string]string
+	headers map[string][]string
 }
 
 // NewScrollService initializes and returns a new ScrollService.
@@ -230,8 +230,8 @@ func (s *ScrollService) ScrollId(scrollId string) *ScrollService {
 }
 
 // Headers adds headers on the http request
-func (s *ScrollService) Headers(headers map[string]string) *ScrollService {
-	s.headers = headers
+func (s *ScrollService) Header(key, value string) *ScrollService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/scroll.go
+++ b/scroll.go
@@ -39,7 +39,7 @@ type ScrollService struct {
 	mu       sync.RWMutex
 	scrollId string
 
-	headers map[string][]string
+	headers headers
 }
 
 // NewScrollService initializes and returns a new ScrollService.

--- a/scroll.go
+++ b/scroll.go
@@ -38,6 +38,8 @@ type ScrollService struct {
 
 	mu       sync.RWMutex
 	scrollId string
+
+	headers map[string]string
 }
 
 // NewScrollService initializes and returns a new ScrollService.
@@ -227,6 +229,12 @@ func (s *ScrollService) ScrollId(scrollId string) *ScrollService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *ScrollService) Headers(headers map[string]string) *ScrollService {
+	s.headers = headers
+	return s
+}
+
 // Do returns the next search result. It will return io.EOF as error if there
 // are no more search results.
 func (s *ScrollService) Do(ctx context.Context) (*SearchResult, error) {
@@ -258,7 +266,7 @@ func (s *ScrollService) Clear(ctx context.Context) error {
 		ScrollId: []string{scrollId},
 	}
 
-	_, err := s.client.PerformRequest(ctx, "DELETE", path, params, body)
+	_, err := s.client.PerformRequest(ctx, "DELETE", path, params, body, s.headers)
 	if err != nil {
 		return err
 	}
@@ -283,7 +291,7 @@ func (s *ScrollService) first(ctx context.Context) (*SearchResult, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +405,7 @@ func (s *ScrollService) next(ctx context.Context) (*SearchResult, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/scroll.go
+++ b/scroll.go
@@ -229,7 +229,7 @@ func (s *ScrollService) ScrollId(scrollId string) *ScrollService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *ScrollService) Header(key, value string) *ScrollService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/search.go
+++ b/search.go
@@ -31,7 +31,7 @@ type SearchService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewSearchService creates a new service for searching in Elasticsearch.

--- a/search.go
+++ b/search.go
@@ -31,7 +31,7 @@ type SearchService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewSearchService creates a new service for searching in Elasticsearch.
@@ -301,8 +301,8 @@ func (s *SearchService) ExpandWildcards(expandWildcards string) *SearchService {
 }
 
 // Headers adds headers on the http request
-func (s *SearchService) Headers(headers map[string]string) *SearchService {
-	s.headers = headers
+func (s *SearchService) Header(key, value string) *SearchService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/search.go
+++ b/search.go
@@ -31,6 +31,7 @@ type SearchService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
+	headers           map[string]string
 }
 
 // NewSearchService creates a new service for searching in Elasticsearch.
@@ -299,6 +300,12 @@ func (s *SearchService) ExpandWildcards(expandWildcards string) *SearchService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *SearchService) Headers(headers map[string]string) *SearchService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *SearchService) buildURL() (string, url.Values, error) {
 	var err error
@@ -385,7 +392,7 @@ func (s *SearchService) Do(ctx context.Context) (*SearchResult, error) {
 		}
 		body = src
 	}
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/search.go
+++ b/search.go
@@ -300,7 +300,7 @@ func (s *SearchService) ExpandWildcards(expandWildcards string) *SearchService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *SearchService) Header(key, value string) *SearchService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/snapshot_create.go
+++ b/snapshot_create.go
@@ -24,7 +24,7 @@ type SnapshotCreateService struct {
 	waitForCompletion *bool
 	bodyJson          interface{}
 	bodyString        string
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewSnapshotCreateService creates a new SnapshotCreateService.

--- a/snapshot_create.go
+++ b/snapshot_create.go
@@ -76,7 +76,7 @@ func (s *SnapshotCreateService) BodyString(body string) *SnapshotCreateService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *SnapshotCreateService) Header(key, value string) *SnapshotCreateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/snapshot_create.go
+++ b/snapshot_create.go
@@ -24,7 +24,7 @@ type SnapshotCreateService struct {
 	waitForCompletion *bool
 	bodyJson          interface{}
 	bodyString        string
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewSnapshotCreateService creates a new SnapshotCreateService.
@@ -77,8 +77,8 @@ func (s *SnapshotCreateService) BodyString(body string) *SnapshotCreateService {
 }
 
 // Headers adds headers on the http request
-func (s *SnapshotCreateService) Headers(headers map[string]string) *SnapshotCreateService {
-	s.headers = headers
+func (s *SnapshotCreateService) Header(key, value string) *SnapshotCreateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/snapshot_create.go
+++ b/snapshot_create.go
@@ -24,6 +24,7 @@ type SnapshotCreateService struct {
 	waitForCompletion *bool
 	bodyJson          interface{}
 	bodyString        string
+	headers           map[string]string
 }
 
 // NewSnapshotCreateService creates a new SnapshotCreateService.
@@ -72,6 +73,12 @@ func (s *SnapshotCreateService) BodyJson(body interface{}) *SnapshotCreateServic
 // BodyString is documented as: The snapshot definition.
 func (s *SnapshotCreateService) BodyString(body string) *SnapshotCreateService {
 	s.bodyString = body
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *SnapshotCreateService) Headers(headers map[string]string) *SnapshotCreateService {
+	s.headers = headers
 	return s
 }
 
@@ -137,7 +144,7 @@ func (s *SnapshotCreateService) Do(ctx context.Context) (*SnapshotCreateResponse
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot_create_repository.go
+++ b/snapshot_create_repository.go
@@ -27,7 +27,7 @@ type SnapshotCreateRepositoryService struct {
 	settings      map[string]interface{}
 	bodyJson      interface{}
 	bodyString    string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewSnapshotCreateRepositoryService creates a new SnapshotCreateRepositoryService.
@@ -101,8 +101,8 @@ func (s *SnapshotCreateRepositoryService) BodyString(body string) *SnapshotCreat
 }
 
 // Headers adds headers on the http request
-func (s *SnapshotCreateRepositoryService) Headers(headers map[string]string) *SnapshotCreateRepositoryService {
-	s.headers = headers
+func (s *SnapshotCreateRepositoryService) Header(key, value string) *SnapshotCreateRepositoryService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/snapshot_create_repository.go
+++ b/snapshot_create_repository.go
@@ -100,7 +100,7 @@ func (s *SnapshotCreateRepositoryService) BodyString(body string) *SnapshotCreat
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *SnapshotCreateRepositoryService) Header(key, value string) *SnapshotCreateRepositoryService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/snapshot_create_repository.go
+++ b/snapshot_create_repository.go
@@ -27,7 +27,7 @@ type SnapshotCreateRepositoryService struct {
 	settings      map[string]interface{}
 	bodyJson      interface{}
 	bodyString    string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewSnapshotCreateRepositoryService creates a new SnapshotCreateRepositoryService.

--- a/snapshot_create_repository.go
+++ b/snapshot_create_repository.go
@@ -27,6 +27,7 @@ type SnapshotCreateRepositoryService struct {
 	settings      map[string]interface{}
 	bodyJson      interface{}
 	bodyString    string
+	headers       map[string]string
 }
 
 // NewSnapshotCreateRepositoryService creates a new SnapshotCreateRepositoryService.
@@ -96,6 +97,12 @@ func (s *SnapshotCreateRepositoryService) BodyJson(body interface{}) *SnapshotCr
 // BodyString is documented as: The repository definition.
 func (s *SnapshotCreateRepositoryService) BodyString(body string) *SnapshotCreateRepositoryService {
 	s.bodyString = body
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *SnapshotCreateRepositoryService) Headers(headers map[string]string) *SnapshotCreateRepositoryService {
+	s.headers = headers
 	return s
 }
 
@@ -179,7 +186,7 @@ func (s *SnapshotCreateRepositoryService) Do(ctx context.Context) (*SnapshotCrea
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "PUT", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot_delete_repository.go
+++ b/snapshot_delete_repository.go
@@ -23,7 +23,7 @@ type SnapshotDeleteRepositoryService struct {
 	repository    []string
 	masterTimeout string
 	timeout       string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewSnapshotDeleteRepositoryService creates a new SnapshotDeleteRepositoryService.
@@ -59,8 +59,8 @@ func (s *SnapshotDeleteRepositoryService) Pretty(pretty bool) *SnapshotDeleteRep
 }
 
 // Headers adds headers on the http request
-func (s *SnapshotDeleteRepositoryService) Headers(headers map[string]string) *SnapshotDeleteRepositoryService {
-	s.headers = headers
+func (s *SnapshotDeleteRepositoryService) Header(key, value string) *SnapshotDeleteRepositoryService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/snapshot_delete_repository.go
+++ b/snapshot_delete_repository.go
@@ -58,7 +58,7 @@ func (s *SnapshotDeleteRepositoryService) Pretty(pretty bool) *SnapshotDeleteRep
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *SnapshotDeleteRepositoryService) Header(key, value string) *SnapshotDeleteRepositoryService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/snapshot_delete_repository.go
+++ b/snapshot_delete_repository.go
@@ -23,7 +23,7 @@ type SnapshotDeleteRepositoryService struct {
 	repository    []string
 	masterTimeout string
 	timeout       string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewSnapshotDeleteRepositoryService creates a new SnapshotDeleteRepositoryService.

--- a/snapshot_delete_repository.go
+++ b/snapshot_delete_repository.go
@@ -23,6 +23,7 @@ type SnapshotDeleteRepositoryService struct {
 	repository    []string
 	masterTimeout string
 	timeout       string
+	headers       map[string]string
 }
 
 // NewSnapshotDeleteRepositoryService creates a new SnapshotDeleteRepositoryService.
@@ -54,6 +55,12 @@ func (s *SnapshotDeleteRepositoryService) Timeout(timeout string) *SnapshotDelet
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *SnapshotDeleteRepositoryService) Pretty(pretty bool) *SnapshotDeleteRepositoryService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *SnapshotDeleteRepositoryService) Headers(headers map[string]string) *SnapshotDeleteRepositoryService {
+	s.headers = headers
 	return s
 }
 
@@ -107,7 +114,7 @@ func (s *SnapshotDeleteRepositoryService) Do(ctx context.Context) (*SnapshotDele
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "DELETE", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot_get_repository.go
+++ b/snapshot_get_repository.go
@@ -23,7 +23,7 @@ type SnapshotGetRepositoryService struct {
 	repository    []string
 	local         *bool
 	masterTimeout string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewSnapshotGetRepositoryService creates a new SnapshotGetRepositoryService.
@@ -59,8 +59,8 @@ func (s *SnapshotGetRepositoryService) Pretty(pretty bool) *SnapshotGetRepositor
 }
 
 // Headers adds headers on the http request
-func (s *SnapshotGetRepositoryService) Headers(headers map[string]string) *SnapshotGetRepositoryService {
-	s.headers = headers
+func (s *SnapshotGetRepositoryService) Header(key, value string) *SnapshotGetRepositoryService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/snapshot_get_repository.go
+++ b/snapshot_get_repository.go
@@ -58,7 +58,7 @@ func (s *SnapshotGetRepositoryService) Pretty(pretty bool) *SnapshotGetRepositor
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *SnapshotGetRepositoryService) Header(key, value string) *SnapshotGetRepositoryService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/snapshot_get_repository.go
+++ b/snapshot_get_repository.go
@@ -23,6 +23,7 @@ type SnapshotGetRepositoryService struct {
 	repository    []string
 	local         *bool
 	masterTimeout string
+	headers       map[string]string
 }
 
 // NewSnapshotGetRepositoryService creates a new SnapshotGetRepositoryService.
@@ -54,6 +55,12 @@ func (s *SnapshotGetRepositoryService) MasterTimeout(masterTimeout string) *Snap
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *SnapshotGetRepositoryService) Pretty(pretty bool) *SnapshotGetRepositoryService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *SnapshotGetRepositoryService) Headers(headers map[string]string) *SnapshotGetRepositoryService {
+	s.headers = headers
 	return s
 }
 
@@ -106,7 +113,7 @@ func (s *SnapshotGetRepositoryService) Do(ctx context.Context) (SnapshotGetRepos
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot_get_repository.go
+++ b/snapshot_get_repository.go
@@ -23,7 +23,7 @@ type SnapshotGetRepositoryService struct {
 	repository    []string
 	local         *bool
 	masterTimeout string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewSnapshotGetRepositoryService creates a new SnapshotGetRepositoryService.

--- a/snapshot_verify_repository.go
+++ b/snapshot_verify_repository.go
@@ -22,6 +22,7 @@ type SnapshotVerifyRepositoryService struct {
 	repository    string
 	masterTimeout string
 	timeout       string
+	headers       map[string]string
 }
 
 // NewSnapshotVerifyRepositoryService creates a new SnapshotVerifyRepositoryService.
@@ -52,6 +53,12 @@ func (s *SnapshotVerifyRepositoryService) Timeout(timeout string) *SnapshotVerif
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *SnapshotVerifyRepositoryService) Pretty(pretty bool) *SnapshotVerifyRepositoryService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *SnapshotVerifyRepositoryService) Headers(headers map[string]string) *SnapshotVerifyRepositoryService {
+	s.headers = headers
 	return s
 }
 
@@ -105,7 +112,7 @@ func (s *SnapshotVerifyRepositoryService) Do(ctx context.Context) (*SnapshotVeri
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot_verify_repository.go
+++ b/snapshot_verify_repository.go
@@ -22,7 +22,7 @@ type SnapshotVerifyRepositoryService struct {
 	repository    string
 	masterTimeout string
 	timeout       string
-	headers       map[string][]string
+	headers       headers
 }
 
 // NewSnapshotVerifyRepositoryService creates a new SnapshotVerifyRepositoryService.

--- a/snapshot_verify_repository.go
+++ b/snapshot_verify_repository.go
@@ -22,7 +22,7 @@ type SnapshotVerifyRepositoryService struct {
 	repository    string
 	masterTimeout string
 	timeout       string
-	headers       map[string]string
+	headers       map[string][]string
 }
 
 // NewSnapshotVerifyRepositoryService creates a new SnapshotVerifyRepositoryService.
@@ -57,8 +57,8 @@ func (s *SnapshotVerifyRepositoryService) Pretty(pretty bool) *SnapshotVerifyRep
 }
 
 // Headers adds headers on the http request
-func (s *SnapshotVerifyRepositoryService) Headers(headers map[string]string) *SnapshotVerifyRepositoryService {
-	s.headers = headers
+func (s *SnapshotVerifyRepositoryService) Header(key, value string) *SnapshotVerifyRepositoryService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/snapshot_verify_repository.go
+++ b/snapshot_verify_repository.go
@@ -56,7 +56,7 @@ func (s *SnapshotVerifyRepositoryService) Pretty(pretty bool) *SnapshotVerifyRep
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *SnapshotVerifyRepositoryService) Header(key, value string) *SnapshotVerifyRepositoryService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/suggest.go
+++ b/suggest.go
@@ -65,7 +65,7 @@ func (s *SuggestService) Suggester(suggester Suggester) *SuggestService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *SuggestService) Header(key, value string) *SuggestService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/suggest.go
+++ b/suggest.go
@@ -23,7 +23,7 @@ type SuggestService struct {
 	preference string
 	index      []string
 	suggesters []Suggester
-	headers    map[string]string
+	headers    map[string][]string
 }
 
 // NewSuggestService creates a new instance of SuggestService.
@@ -66,8 +66,8 @@ func (s *SuggestService) Suggester(suggester Suggester) *SuggestService {
 }
 
 // Headers adds headers on the http request
-func (s *SuggestService) Headers(headers map[string]string) *SuggestService {
-	s.headers = headers
+func (s *SuggestService) Header(key, value string) *SuggestService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/suggest.go
+++ b/suggest.go
@@ -23,6 +23,7 @@ type SuggestService struct {
 	preference string
 	index      []string
 	suggesters []Suggester
+	headers    map[string]string
 }
 
 // NewSuggestService creates a new instance of SuggestService.
@@ -61,6 +62,12 @@ func (s *SuggestService) Preference(preference string) *SuggestService {
 // Suggester adds a suggester to the request.
 func (s *SuggestService) Suggester(suggester Suggester) *SuggestService {
 	s.suggesters = append(s.suggesters, suggester)
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *SuggestService) Headers(headers map[string]string) *SuggestService {
+	s.headers = headers
 	return s
 }
 
@@ -112,7 +119,7 @@ func (s *SuggestService) Do(ctx context.Context) (SuggestResult, error) {
 	}
 
 	// Get response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/suggest.go
+++ b/suggest.go
@@ -23,7 +23,7 @@ type SuggestService struct {
 	preference string
 	index      []string
 	suggesters []Suggester
-	headers    map[string][]string
+	headers    headers
 }
 
 // NewSuggestService creates a new instance of SuggestService.

--- a/tasks_cancel.go
+++ b/tasks_cancel.go
@@ -77,7 +77,7 @@ func (s *TasksCancelService) Pretty(pretty bool) *TasksCancelService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *TasksCancelService) Header(key, value string) *TasksCancelService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/tasks_cancel.go
+++ b/tasks_cancel.go
@@ -26,6 +26,7 @@ type TasksCancelService struct {
 	nodeId     []string
 	parentNode string
 	parentTask *int64
+	headers    map[string]string
 }
 
 // NewTasksCancelService creates a new TasksCancelService.
@@ -73,6 +74,12 @@ func (s *TasksCancelService) ParentTask(parentTask int64) *TasksCancelService {
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *TasksCancelService) Pretty(pretty bool) *TasksCancelService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *TasksCancelService) Headers(headers map[string]string) *TasksCancelService {
+	s.headers = headers
 	return s
 }
 
@@ -131,7 +138,7 @@ func (s *TasksCancelService) Do(ctx context.Context) (*TasksListResponse, error)
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks_cancel.go
+++ b/tasks_cancel.go
@@ -26,7 +26,7 @@ type TasksCancelService struct {
 	nodeId     []string
 	parentNode string
 	parentTask *int64
-	headers    map[string]string
+	headers    map[string][]string
 }
 
 // NewTasksCancelService creates a new TasksCancelService.
@@ -78,8 +78,8 @@ func (s *TasksCancelService) Pretty(pretty bool) *TasksCancelService {
 }
 
 // Headers adds headers on the http request
-func (s *TasksCancelService) Headers(headers map[string]string) *TasksCancelService {
-	s.headers = headers
+func (s *TasksCancelService) Header(key, value string) *TasksCancelService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/tasks_cancel.go
+++ b/tasks_cancel.go
@@ -26,7 +26,7 @@ type TasksCancelService struct {
 	nodeId     []string
 	parentNode string
 	parentTask *int64
-	headers    map[string][]string
+	headers    headers
 }
 
 // NewTasksCancelService creates a new TasksCancelService.

--- a/tasks_get_task.go
+++ b/tasks_get_task.go
@@ -17,7 +17,7 @@ type TasksGetTaskService struct {
 	pretty            bool
 	taskId            string
 	waitForCompletion *bool
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewTasksGetTaskService creates a new TasksGetTaskService.
@@ -47,8 +47,8 @@ func (s *TasksGetTaskService) Pretty(pretty bool) *TasksGetTaskService {
 }
 
 // Headers adds headers on the http request
-func (s *TasksGetTaskService) Headers(headers map[string]string) *TasksGetTaskService {
-	s.headers = headers
+func (s *TasksGetTaskService) Header(key, value string) *TasksGetTaskService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/tasks_get_task.go
+++ b/tasks_get_task.go
@@ -17,6 +17,7 @@ type TasksGetTaskService struct {
 	pretty            bool
 	taskId            string
 	waitForCompletion *bool
+	headers           map[string]string
 }
 
 // NewTasksGetTaskService creates a new TasksGetTaskService.
@@ -42,6 +43,12 @@ func (s *TasksGetTaskService) WaitForCompletion(waitForCompletion bool) *TasksGe
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *TasksGetTaskService) Pretty(pretty bool) *TasksGetTaskService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *TasksGetTaskService) Headers(headers map[string]string) *TasksGetTaskService {
+	s.headers = headers
 	return s
 }
 
@@ -85,7 +92,7 @@ func (s *TasksGetTaskService) Do(ctx context.Context) (*TasksGetTaskResponse, er
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks_get_task.go
+++ b/tasks_get_task.go
@@ -17,7 +17,7 @@ type TasksGetTaskService struct {
 	pretty            bool
 	taskId            string
 	waitForCompletion *bool
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewTasksGetTaskService creates a new TasksGetTaskService.

--- a/tasks_get_task.go
+++ b/tasks_get_task.go
@@ -46,7 +46,7 @@ func (s *TasksGetTaskService) Pretty(pretty bool) *TasksGetTaskService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *TasksGetTaskService) Header(key, value string) *TasksGetTaskService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/tasks_list.go
+++ b/tasks_list.go
@@ -28,7 +28,7 @@ type TasksListService struct {
 	parentNode        string
 	parentTask        *int64
 	waitForCompletion *bool
-	headers           map[string]string
+	headers           map[string][]string
 }
 
 // NewTasksListService creates a new TasksListService.
@@ -93,8 +93,8 @@ func (s *TasksListService) Pretty(pretty bool) *TasksListService {
 }
 
 // Headers adds headers on the http request
-func (s *TasksListService) Headers(headers map[string]string) *TasksListService {
-	s.headers = headers
+func (s *TasksListService) Header(key, value string) *TasksListService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/tasks_list.go
+++ b/tasks_list.go
@@ -28,6 +28,7 @@ type TasksListService struct {
 	parentNode        string
 	parentTask        *int64
 	waitForCompletion *bool
+	headers           map[string]string
 }
 
 // NewTasksListService creates a new TasksListService.
@@ -88,6 +89,12 @@ func (s *TasksListService) WaitForCompletion(waitForCompletion bool) *TasksListS
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *TasksListService) Pretty(pretty bool) *TasksListService {
 	s.pretty = pretty
+	return s
+}
+
+// Headers adds headers on the http request
+func (s *TasksListService) Headers(headers map[string]string) *TasksListService {
+	s.headers = headers
 	return s
 }
 
@@ -156,7 +163,7 @@ func (s *TasksListService) Do(ctx context.Context) (*TasksListResponse, error) {
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, nil, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks_list.go
+++ b/tasks_list.go
@@ -92,7 +92,7 @@ func (s *TasksListService) Pretty(pretty bool) *TasksListService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *TasksListService) Header(key, value string) *TasksListService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/tasks_list.go
+++ b/tasks_list.go
@@ -28,7 +28,7 @@ type TasksListService struct {
 	parentNode        string
 	parentTask        *int64
 	waitForCompletion *bool
-	headers           map[string][]string
+	headers           headers
 }
 
 // NewTasksListService creates a new TasksListService.

--- a/termvectors.go
+++ b/termvectors.go
@@ -43,7 +43,7 @@ type TermvectorsService struct {
 	versionType      string
 	bodyJson         interface{}
 	bodyString       string
-	headers          map[string]string
+	headers          map[string][]string
 }
 
 // NewTermvectorsService creates a new TermvectorsService.
@@ -195,8 +195,8 @@ func (s *TermvectorsService) BodyString(body string) *TermvectorsService {
 }
 
 // Headers adds headers on the http request
-func (s *TermvectorsService) Headers(headers map[string]string) *TermvectorsService {
-	s.headers = headers
+func (s *TermvectorsService) Header(key, value string) *TermvectorsService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/termvectors.go
+++ b/termvectors.go
@@ -194,7 +194,7 @@ func (s *TermvectorsService) BodyString(body string) *TermvectorsService {
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *TermvectorsService) Header(key, value string) *TermvectorsService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/termvectors.go
+++ b/termvectors.go
@@ -43,6 +43,7 @@ type TermvectorsService struct {
 	versionType      string
 	bodyJson         interface{}
 	bodyString       string
+	headers          map[string]string
 }
 
 // NewTermvectorsService creates a new TermvectorsService.
@@ -193,6 +194,12 @@ func (s *TermvectorsService) BodyString(body string) *TermvectorsService {
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *TermvectorsService) Headers(headers map[string]string) *TermvectorsService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *TermvectorsService) buildURL() (string, url.Values, error) {
 	var pathParam = map[string]string{
@@ -316,7 +323,7 @@ func (s *TermvectorsService) Do(ctx context.Context) (*TermvectorsResponse, erro
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "GET", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "GET", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/termvectors.go
+++ b/termvectors.go
@@ -43,7 +43,7 @@ type TermvectorsService struct {
 	versionType      string
 	bodyJson         interface{}
 	bodyString       string
-	headers          map[string][]string
+	headers          headers
 }
 
 // NewTermvectorsService creates a new TermvectorsService.

--- a/update.go
+++ b/update.go
@@ -174,7 +174,7 @@ func (b *UpdateService) Pretty(pretty bool) *UpdateService {
 	return b
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *UpdateService) Header(key, value string) *UpdateService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/update.go
+++ b/update.go
@@ -38,6 +38,7 @@ type UpdateService struct {
 	doc                 interface{}
 	timeout             string
 	pretty              bool
+	headers             map[string]string
 }
 
 // NewUpdateService creates the service to update documents in Elasticsearch.
@@ -173,6 +174,12 @@ func (b *UpdateService) Pretty(pretty bool) *UpdateService {
 	return b
 }
 
+// Headers adds headers on the http request
+func (s *UpdateService) Headers(headers map[string]string) *UpdateService {
+	s.headers = headers
+	return s
+}
+
 // FetchSource asks Elasticsearch to return the updated _source in the response.
 func (s *UpdateService) FetchSource(fetchSource bool) *UpdateService {
 	if s.fsc == nil {
@@ -293,7 +300,7 @@ func (b *UpdateService) Do(ctx context.Context) (*UpdateResponse, error) {
 	}
 
 	// Get response
-	res, err := b.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := b.client.PerformRequest(ctx, "POST", path, params, body, b.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/update.go
+++ b/update.go
@@ -38,7 +38,7 @@ type UpdateService struct {
 	doc                 interface{}
 	timeout             string
 	pretty              bool
-	headers             map[string][]string
+	headers             headers
 }
 
 // NewUpdateService creates the service to update documents in Elasticsearch.

--- a/update.go
+++ b/update.go
@@ -38,7 +38,7 @@ type UpdateService struct {
 	doc                 interface{}
 	timeout             string
 	pretty              bool
-	headers             map[string]string
+	headers             map[string][]string
 }
 
 // NewUpdateService creates the service to update documents in Elasticsearch.
@@ -175,8 +175,8 @@ func (b *UpdateService) Pretty(pretty bool) *UpdateService {
 }
 
 // Headers adds headers on the http request
-func (s *UpdateService) Headers(headers map[string]string) *UpdateService {
-	s.headers = headers
+func (s *UpdateService) Header(key, value string) *UpdateService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/update_by_query.go
+++ b/update_by_query.go
@@ -426,7 +426,7 @@ func (s *UpdateByQueryService) WaitForCompletion(waitForCompletion bool) *Update
 	return s
 }
 
-// Headers adds headers on the http request
+// Header adds key, value pair to the header on the http request
 func (s *UpdateByQueryService) Header(key, value string) *UpdateByQueryService {
 	s.headers = addHeader(s.headers, key, value)
 	return s

--- a/update_by_query.go
+++ b/update_by_query.go
@@ -65,7 +65,7 @@ type UpdateByQueryService struct {
 	versionType            *bool
 	waitForActiveShards    string
 	waitForCompletion      *bool
-	headers                map[string][]string
+	headers                headers
 }
 
 // NewUpdateByQueryService creates a new UpdateByQueryService.

--- a/update_by_query.go
+++ b/update_by_query.go
@@ -65,7 +65,7 @@ type UpdateByQueryService struct {
 	versionType            *bool
 	waitForActiveShards    string
 	waitForCompletion      *bool
-	headers                map[string]string
+	headers                map[string][]string
 }
 
 // NewUpdateByQueryService creates a new UpdateByQueryService.
@@ -427,8 +427,8 @@ func (s *UpdateByQueryService) WaitForCompletion(waitForCompletion bool) *Update
 }
 
 // Headers adds headers on the http request
-func (s *UpdateByQueryService) Headers(headers map[string]string) *UpdateByQueryService {
-	s.headers = headers
+func (s *UpdateByQueryService) Header(key, value string) *UpdateByQueryService {
+	s.headers = addHeader(s.headers, key, value)
 	return s
 }
 

--- a/update_by_query.go
+++ b/update_by_query.go
@@ -65,6 +65,7 @@ type UpdateByQueryService struct {
 	versionType            *bool
 	waitForActiveShards    string
 	waitForCompletion      *bool
+	headers                map[string]string
 }
 
 // NewUpdateByQueryService creates a new UpdateByQueryService.
@@ -425,6 +426,12 @@ func (s *UpdateByQueryService) WaitForCompletion(waitForCompletion bool) *Update
 	return s
 }
 
+// Headers adds headers on the http request
+func (s *UpdateByQueryService) Headers(headers map[string]string) *UpdateByQueryService {
+	s.headers = headers
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *UpdateByQueryService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -636,7 +643,7 @@ func (s *UpdateByQueryService) Do(ctx context.Context) (*BulkIndexByScrollRespon
 	}
 
 	// Get HTTP response
-	res, err := s.client.PerformRequest(ctx, "POST", path, params, body)
+	res, err := s.client.PerformRequest(ctx, "POST", path, params, body, s.headers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is to provide a mechanism to set custom headers on all HTTP requests to elastic search.
There are two levels where this can be done:
- set custom headers on the client, in which case they would be populated on all http requests (including healthcheck, ping etc) - this could be useful eg. when you use a custom authorization mechanism
- set custom headers on each http request explicitly - this could be useful eg. for auditing 