### PR TITLE
v2: Let FunctionScoreQuery allow both Query and Filter

### DIFF
--- a/search_queries_fsq.go
+++ b/search_queries_fsq.go
@@ -33,12 +33,10 @@ func NewFunctionScoreQuery() FunctionScoreQuery {
 
 func (q FunctionScoreQuery) Query(query Query) FunctionScoreQuery {
 	q.query = query
-	q.filter = nil
 	return q
 }
 
 func (q FunctionScoreQuery) Filter(filter Filter) FunctionScoreQuery {
-	q.query = nil
 	q.filter = filter
 	return q
 }
@@ -88,7 +86,8 @@ func (q FunctionScoreQuery) Source() interface{} {
 
 	if q.query != nil {
 		query["query"] = q.query.Source()
-	} else if q.filter != nil {
+	}
+	if q.filter != nil {
 		query["filter"] = q.filter.Source()
 	}
 


### PR DESCRIPTION
Previously, FunctionScoreQuery only allowed either Query or Filter to be set,
setting the other to nil. There's no reason to do this, though, as
ElasticSearch allows both to be set.

See the equivalent Java code here:
https://github.com/elastic/elasticsearch/blob/v1.7.6/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java#L85-L88