### PR TITLE
Use v5 sniffNode logic in v3

### DIFF
--- a/client.go
+++ b/client.go
@@ -847,21 +847,11 @@ func (c *Client) sniffNode(ctx context.Context, url string) []*conn {
 	var info NodesInfoResponse
 	if err := json.NewDecoder(res.Body).Decode(&info); err == nil {
 		if len(info.Nodes) > 0 {
-			switch c.scheme {
-			case "https":
-				for nodeID, node := range info.Nodes {
-					url := c.extractHostname("https", node.HTTPSAddress)
-					if url != "" {
-						if c.snifferCallback(node) {
-							nodes = append(nodes, newConn(nodeID, url))
-						}
-					}
-				}
-			default:
-				for nodeID, node := range info.Nodes {
-					url := c.extractHostname("http", node.HTTPAddress)
-					if url != "" {
-						if c.snifferCallback(node) {
+			for nodeID, node := range info.Nodes {
+				if c.snifferCallback(node) {
+					if node.HTTP != nil && len(node.HTTP.PublishAddress) > 0 {
+						url := c.extractHostname(c.scheme, node.HTTP.PublishAddress)
+						if url != "" {
 							nodes = append(nodes, newConn(nodeID, url))
 						}
 					}


### PR DESCRIPTION
It appears that the logic for sniffing nodes between version 3 and 5 has diverged. I'm not entirely certain if this intentional or not. 

Currently, enabling sniffing in v3 and setting the client's scheme to `https` while querying against a cluster setup with [Search Guard SSL](https://github.com/floragunncom/search-guard-ssl) will produce an empty node list due to the fact that Search Guard will not return a `https_address` key for each node.

Here's a snippet of what a node returns for `GET /_nodes/http` with Search Guard SSL setup:

```
{
  "cluster_name" : "elasticsearch-cluster",
  "nodes" : {
    "m1Mp_vxXRsudaMXvNeKtQg" : {
      "transport_address" : "10.0.0.111:9300",
      "host" : "10.0.0.111",
      "ip" : "10.0.0.111",
      "http_address" : "10.0.0.111:9200",
      "http" : {
        "bound_address" : [ "0.0.0.0:9200" ],
        "publish_address" : "10.0.0.111:9200",
      }
      ...
    }
    ...
  }
}
```


My only concern here is that I'm unaware of how a ES v2.x node behaves with Shield installed to enable SSL... Do you have any insight there?

Happy to take any feedback and adjust accordingly.