### PR TITLE
Fix type of Result field for UpdateResponse. Issue #599

### DIFF
--- a/update.go
+++ b/update.go
@@ -313,7 +313,7 @@ type UpdateResponse struct {
 	Id            string      `json:"_id"`
 	Version       int         `json:"_version"`
 	Shards        *shardsInfo `json:"_shards"`
-	Result        bool        `json:"string,omitempty"`
+	Result        string      `json:"result,omitempty"`
 	ForcedRefresh bool        `json:"forced_refresh,omitempty"`
 	GetResult     *GetResult  `json:"get,omitempty"`
 }


### PR DESCRIPTION
According to Elasticsearch source code [1], the Result field should
be represented as a string and its possible values are represented
in Result enum [2].

[1] - https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
[2] - https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java#L66