### PR TITLE
Don't ignore error while doing startup check

### DIFF
--- a/client.go
+++ b/client.go
@@ -1104,6 +1104,8 @@ func (c *Client) startupHealthcheck(timeout time.Duration) error {
 			res, err := cl.Do(req)
 			if err == nil && res != nil && res.StatusCode >= 200 && res.StatusCode < 300 {
 				return nil
+			} else if err != nil {
+				return err
 			}
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
Error is checked for if it is nil in Client#startupHealthcheck, but not for if the error actually contains an error.

Fixes #625 and will likely give a better message for basic auth failures as well

This code:
```
package main

import (
	"log"
	"os"

	"gopkg.in/olivere/elastic.v5"
)

func main() {
	host := os.Getenv("ELS_HOST")
	user := os.Getenv("ELS_USER")
	pass := os.Getenv("ELS_PASS")

	_, err := elastic.NewClient(
		elastic.SetURL(host),
		elastic.SetSniff(false),
		elastic.SetBasicAuth(user, pass),
	)
	if err != nil {
		log.Fatalf("could no create elastic client to %q: %v", host, err.Error())
	}
}
```

and this Dockerfile
```
FROM bitnami/minideb
#RUN install_packages ca-certificates
ADD elastic ./
CMD ["./elastic"]
```

showcase the difference this PR makes.

e.g

Instead of receiving the message 
```
health check timeout: no Elasticsearch node available
```
on client creation, we will now receive [in the case where the underlying system has no ca-certificates]
```
Head https://domain.net: x509: failed to load system roots and no roots provided
```

which will be nice for UX when debugging issues.