### PR TITLE
add terminate_after to params

### DIFF
--- a/count.go
+++ b/count.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"gopkg.in/olivere/elastic.v5/uritemplates"
@@ -35,6 +36,7 @@ type CountService struct {
 	q                      string
 	query                  Query
 	routing                string
+	terminateAfter         *int
 	bodyJson               interface{}
 	bodyString             string
 }
@@ -158,6 +160,12 @@ func (s *CountService) Routing(routing string) *CountService {
 	return s
 }
 
+// TerminateAfter specifies the maximum count for each shard
+func (s *CountService) TerminateAfter(terminateAfter int) *CountService {
+	s.terminateAfter = &terminateAfter
+	return s
+}
+
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *CountService) Pretty(pretty bool) *CountService {
 	s.pretty = pretty
@@ -247,6 +255,9 @@ func (s *CountService) buildURL() (string, url.Values, error) {
 	}
 	if s.routing != "" {
 		params.Set("routing", s.routing)
+	}
+	if s.terminateAfter != nil {
+		params.Set("terminate_after", strconv.Itoa(*s.terminateAfter))
 	}
 	return path, params, nil
 }


### PR DESCRIPTION
Add support for terminate_after, as specified in 

https://www.elastic.co/guide/en/elasticsearch/reference/5.4/search-count.html