### PR TITLE
Add in boundary_scanner to highlighter

### DIFF
--- a/highlight.go
+++ b/highlight.go
@@ -20,6 +20,7 @@ type Highlight struct {
 	requireFieldMatch     *bool
 	boundaryMaxScan       *int
 	boundaryChars         *string
+	boundaryScannerType   *string
 	highlighterType       *string
 	fragmenter            *string
 	highlightQuery        Query
@@ -103,6 +104,11 @@ func (hl *Highlight) BoundaryChars(boundaryChars string) *Highlight {
 	return hl
 }
 
+func (hl *Highlight) BoundaryScannerType(boundaryScannerType string) *Highlight {
+	hl.boundaryScannerType = &boundaryScannerType
+	return hl
+}
+
 func (hl *Highlight) HighlighterType(highlighterType string) *Highlight {
 	hl.highlighterType = &highlighterType
 	return hl
@@ -177,6 +183,9 @@ func (hl *Highlight) Source() (interface{}, error) {
 	}
 	if hl.boundaryChars != nil {
 		source["boundary_chars"] = *hl.boundaryChars
+	}
+	if hl.boundaryScannerType != nil {
+		source["boundary_scanner"] = *hl.boundaryScannerType
 	}
 	if hl.highlighterType != nil {
 		source["type"] = *hl.highlighterType

--- a/highlight_test.go
+++ b/highlight_test.go
@@ -134,6 +134,23 @@ func TestHighlightWithBoundaryChars(t *testing.T) {
 	}
 }
 
+func TestHighlightWithBoundaryScannerType(t *testing.T) {
+	builder := NewHighlight().BoundaryScannerType("word")
+	src, err := builder.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"boundary_scanner":"word"}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
 func TestHighlightWithTermQuery(t *testing.T) {
 	client := setupTestClientAndCreateIndex(t)
 


### PR DESCRIPTION
This adds in the boundary_scanner option to the elastic.Highlighter
object.  I based my changes off of release-branch.v5 for selfish
reasons; I need this feature for an Elasticsearch 5.6.4 cluster.

Java API:
https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SearchContextHighlight.java#L277
Elasticsearch docs:
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html#highlighting-settings