### PR TITLE
fix problems in search.go:Each when hits have 'nil' _Source field

### DIFF
--- a/search.go
+++ b/search.go
@@ -427,7 +427,8 @@ func (r *SearchResult) TotalHits() int64 {
 
 // Each is a utility function to iterate over all hits. It saves you from
 // checking for nil values. Notice that Each will ignore errors in
-// serializing JSON.
+// serializing JSON and hits with empty/nil _source will get an empty
+// value
 func (r *SearchResult) Each(typ reflect.Type) []interface{} {
 	if r.Hits == nil || r.Hits.Hits == nil || len(r.Hits.Hits) == 0 {
 		return nil
@@ -435,6 +436,10 @@ func (r *SearchResult) Each(typ reflect.Type) []interface{} {
 	var slice []interface{}
 	for _, hit := range r.Hits.Hits {
 		v := reflect.New(typ).Elem()
+		if hit.Source == nil {
+			slice = append(slice, v.Interface())
+			continue
+		}
 		if err := json.Unmarshal(*hit.Source, v.Addr().Interface()); err == nil {
 			slice = append(slice, v.Interface())
 		}

--- a/search_test.go
+++ b/search_test.go
@@ -195,6 +195,51 @@ func TestSearchResultEach(t *testing.T) {
 	}
 }
 
+func TestSearchResultEachNoSource(t *testing.T) {
+	client := setupTestClientAndCreateIndexAndAddDocsNoSource(t)
+
+	all := NewMatchAllQuery()
+	searchResult, err := client.Search().Index(testNoSourceIndexName).Query(all).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Iterate over non-ptr type
+	var aTweet tweet
+	count := 0
+	for _, item := range searchResult.Each(reflect.TypeOf(aTweet)) {
+		count++
+		tw, ok := item.(tweet)
+		if !ok {
+			t.Fatalf("expected hit to be serialized as tweet; got: %v", reflect.ValueOf(item))
+		}
+
+		if tw.User != "" {
+			t.Fatalf("expected no _source hit to be empty tweet; got: %v", reflect.ValueOf(item))
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected to find 2 hits; got: %d", count)
+	}
+
+	// Iterate over ptr-type
+	count = 0
+	var aTweetPtr *tweet
+	for _, item := range searchResult.Each(reflect.TypeOf(aTweetPtr)) {
+		count++
+		tw, ok := item.(*tweet)
+		if !ok {
+			t.Fatalf("expected hit to be serialized as tweet; got: %v", reflect.ValueOf(item))
+		}
+		if tw != nil {
+			t.Fatal("expected hit to be nil")
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected to find 2 hits; got: %d", count)
+	}
+}
+
 func TestSearchSorting(t *testing.T) {
 	client := setupTestClientAndCreateIndex(t)
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -55,6 +55,48 @@ const (
 }
 `
 
+	testNoSourceIndexName = "elastic-nosource-test"
+	testNoSourceMapping   = `
+{
+	"settings":{
+		"number_of_shards":1,
+		"number_of_replicas":0
+	},
+	"mappings":{
+		"doc":{
+			"_source": {
+				"enabled": false
+			},
+			"properties":{
+				"user":{
+					"type":"keyword"
+				},
+				"message":{
+					"type":"text",
+					"store": true,
+					"fielddata": true
+				},
+				"tags":{
+					"type":"keyword"
+				},
+				"location":{
+					"type":"geo_point"
+				},
+				"suggest_field":{
+					"type":"completion",
+					"contexts":[
+						{
+							"name":"user_name",
+							"type":"category"
+						}
+					]
+				}
+			}
+		}
+	}
+}
+`
+
 	testJoinIndex   = "elastic-joins"
 	testJoinMapping = `
 	{
@@ -244,6 +286,7 @@ func setupTestClient(t logger, options ...ClientOptionFunc) (client *Client) {
 	client.DeleteIndex(testIndexName2).Do(context.TODO())
 	client.DeleteIndex(testIndexName3).Do(context.TODO())
 	client.DeleteIndex(testOrderIndex).Do(context.TODO())
+	client.DeleteIndex(testNoSourceIndexName).Do(context.TODO())
 	//client.DeleteIndex(testDoctypeIndex).Do(context.TODO())
 	client.DeleteIndex(testQueryIndex).Do(context.TODO())
 	client.DeleteIndex(testJoinIndex).Do(context.TODO())
@@ -272,6 +315,15 @@ func setupTestClientAndCreateIndex(t logger, options ...ClientOptionFunc) *Clien
 		t.Errorf("expected result to be != nil; got: %v", createIndex2)
 	}
 
+	// Create no source index
+	createNoSourceIndex, err := client.CreateIndex(testNoSourceIndexName).Body(testNoSourceMapping).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createNoSourceIndex == nil {
+		t.Errorf("expected result to be != nil; got: %v", createNoSourceIndex)
+	}
+
 	// Create order index
 	createOrderIndex, err := client.CreateIndex(testOrderIndex).Body(testOrderMapping).Do(context.TODO())
 	if err != nil {
@@ -286,6 +338,31 @@ func setupTestClientAndCreateIndex(t logger, options ...ClientOptionFunc) *Clien
 
 func setupTestClientAndCreateIndexAndLog(t logger, options ...ClientOptionFunc) *Client {
 	return setupTestClientAndCreateIndex(t, SetTraceLog(log.New(os.Stdout, "", 0)))
+}
+
+func setupTestClientAndCreateIndexAndAddDocsNoSource(t logger, options ...ClientOptionFunc) *Client {
+	client := setupTestClientAndCreateIndex(t, options...)
+
+	// Add tweets
+	tweet1 := tweet{User: "olivere", Message: "Welcome to Golang and Elasticsearch."}
+	tweet2 := tweet{User: "olivere", Message: "Another unrelated topic."}
+
+	_, err := client.Index().Index(testNoSourceIndexName).Type("doc").Id("1").BodyJson(&tweet1).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Index().Index(testNoSourceIndexName).Type("doc").Id("2").BodyJson(&tweet2).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Flush
+	_, err = client.Flush().Index(testNoSourceIndexName).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return client
+
 }
 
 func setupTestClientAndCreateIndexAndAddDocs(t logger, options ...ClientOptionFunc) *Client {


### PR DESCRIPTION
_source can be nil in hits in my elastic it seems. This PR proposes to be more resilient to such entries and just skip them.