### PR TITLE
Add remove index alias action

### DIFF
--- a/indices_put_alias.go
+++ b/indices_put_alias.go
@@ -189,6 +189,39 @@ func (a *AliasRemoveAction) Source() (interface{}, error) {
 	return src, nil
 }
 
+// AliasRemoveIndexAction is an action to remove an index during an alias
+// operation.
+type AliasRemoveIndexAction struct {
+	index string // index name
+}
+
+// NewAliasRemoveIndexAction returns an action to remove an index.
+func NewAliasRemoveIndexAction(index string) *AliasRemoveIndexAction {
+	return &AliasRemoveIndexAction{
+		index: index,
+	}
+}
+
+// Validate checks if the operation is valid.
+func (a *AliasRemoveIndexAction) Validate() error {
+	if a.index == "" {
+		return fmt.Errorf("missing required field: index")
+	}
+	return nil
+}
+
+// Source returns the JSON-serializable data.
+func (a *AliasRemoveIndexAction) Source() (interface{}, error) {
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
+	src := make(map[string]interface{})
+	act := make(map[string]interface{})
+	src["remove_index"] = act
+	act["index"] = a.index
+	return src, nil
+}
+
 // -- Service --
 
 // AliasService enables users to add or remove an alias.

--- a/indices_put_alias_test.go
+++ b/indices_put_alias_test.go
@@ -220,3 +220,41 @@ func TestAliasRemoveAction(t *testing.T) {
 		}
 	}
 }
+
+func TestAliasRemoveIndexAction(t *testing.T) {
+	var tests = []struct {
+		Action   *AliasRemoveIndexAction
+		Expected string
+		Invalid  bool
+	}{
+		{
+			Action:  NewAliasRemoveIndexAction(""),
+			Invalid: true,
+		},
+		{
+			Action:   NewAliasRemoveIndexAction("index1"),
+			Expected: `{"remove_index":{"index":"index1"}}`,
+		},
+	}
+
+	for i, tt := range tests {
+		src, err := tt.Action.Source()
+		if err != nil {
+			if !tt.Invalid {
+				t.Errorf("#%d: expected to succeed", i)
+			}
+		} else {
+			if tt.Invalid {
+				t.Errorf("#%d: expected to fail", i)
+			} else {
+				dst, err := json.Marshal(src)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if want, have := tt.Expected, string(dst); want != have {
+					t.Errorf("#%d: expected %s, got %s", i, want, have)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
As described in the Elasticsearch 5.0 and 6.0 documentation, there is an alias action that will remove an index as part of an Index Alias operation. This pull request implements that action.

An example is provided in the documentation just above the section labeled "Filtered Aliases": https://www.elastic.co/guide/en/elasticsearch/reference/6.0/indices-aliases.html#filtered

Relevant Java code: 
Definition of remove index action:
https://github.com/elastic/elasticsearch/blob/8e8fdc4f0efc6ddac866009baa22552668d94a12/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java#L136

Validate function only checks index name on a remove index action:
https://github.com/elastic/elasticsearch/blob/8e8fdc4f0efc6ddac866009baa22552668d94a12/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java#L251
