### PR TITLE
Update SearchSuggestionOption Score field

### DIFF
--- a/search.go
+++ b/search.go
@@ -525,7 +525,7 @@ type SearchSuggestionOption struct {
 	Index        string           `json:"_index"`
 	Type         string           `json:"_type"`
 	Id           string           `json:"_id"`
-	Score        float64          `json:"score"`
+	Score        float64          `json:"_score"`
 	Highlighted  string           `json:"highlighted"`
 	CollateMatch bool             `json:"collate_match"`
 	Freq         int              `json:"freq"` // from TermSuggestion.Option in Java API


### PR DESCRIPTION
See https://www.elastic.co/guide/en/elasticsearch/reference/6.2/search-suggesters-completion.html

According to the link above the Score field in the SearchSuggestionOption references a missing tag, which should be `_score` rather than `score`.
```
{
  "_shards" : {
    "total" : 5,
    "successful" : 5,
    "skipped" : 0,
    "failed" : 0
  },
  "hits": ...
  "took": 2,
  "timed_out": false,
  "suggest": {
    "song-suggest" : [ {
      "text" : "nir",
      "offset" : 0,
      "length" : 3,
      "options" : [ {
        "text" : "Nirvana",
        "_index": "music",
        "_type": "song",
        "_id": "1",
        "_score": 1.0,
        "_source": {
          "suggest": ["Nevermind", "Nirvana"]
        }
      } ]
    } ]
  }
}
```