### PR TITLE
Cat api

### DIFF
--- a/cat.go
+++ b/cat.go
@@ -1,0 +1,88 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"net/url"
+)
+
+// CatIndicesService executes cat commands against the cluster.
+//
+// See https://www.elastic.co/guide/en/elasticsearch/reference/6.2/cat.html
+// for details.
+type CatService struct {
+	client *Client
+	pretty bool
+	model  string
+}
+
+// NewCatService creates a new CatService.
+func NewCatService(client *Client) *CatService {
+	return &CatService{
+		client: client,
+		pretty: true,
+	}
+}
+
+func (s *CatService) Indices() *CatService {
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *CatService) Pretty(pretty bool) *CatService {
+	s.pretty = pretty
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *CatService) buildURL() (string, url.Values, error) {
+	path := "/_cat/indices"
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "true")
+	}
+
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *CatService) Validate() error {
+	return nil
+}
+
+// Do executes the operation.
+func (s *CatService) Do(ctx context.Context) (string, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return "", err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return "", err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method: "GET",
+		Path:   path,
+		Params: params,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(res.Body), nil
+}
+
+// CatResponse is the response of CatService.Do.
+type CatResponse struct {
+	Response string
+}

--- a/cat.go
+++ b/cat.go
@@ -15,9 +15,11 @@ import (
 // See https://www.elastic.co/guide/en/elasticsearch/reference/6.2/cat.html
 // for details.
 type CatService struct {
-	client *Client
-	pretty bool
-	model  string
+	client  *Client
+	pretty  bool
+	help    bool
+	verbose bool
+	model   string
 }
 
 const (
@@ -170,6 +172,18 @@ func (s *CatService) ThreadPool() *CatService {
 	return s
 }
 
+// Verbose turns on verbose output.
+func (s *CatService) Verbose(v bool) *CatService {
+	s.verbose = v
+	return s
+}
+
+// Help sets the service to show information about the available fields for a certain model
+func (s *CatService) Help(h bool) *CatService {
+	s.help = h
+	return s
+}
+
 // Pretty indicates that the JSON response be indented and human readable.
 func (s *CatService) Pretty(pretty bool) *CatService {
 	s.pretty = pretty
@@ -184,6 +198,14 @@ func (s *CatService) buildURL() (string, url.Values, error) {
 	params := url.Values{}
 	if s.pretty {
 		params.Set("pretty", "true")
+	}
+
+	if s.help {
+		params.Set("help", "true")
+	}
+
+	if s.verbose {
+		params.Set("verbose", "true")
 	}
 
 	return path, params, nil

--- a/cat.go
+++ b/cat.go
@@ -6,10 +6,11 @@ package elastic
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 )
 
-// CatIndicesService executes cat commands against the cluster.
+// CatService executes cat commands against the cluster.
 //
 // See https://www.elastic.co/guide/en/elasticsearch/reference/6.2/cat.html
 // for details.
@@ -17,6 +18,46 @@ type CatService struct {
 	client *Client
 	pretty bool
 	model  string
+}
+
+const (
+	aliases      string = "aliases"
+	allocation   string = "allocation"
+	count        string = "count"
+	fielddata    string = "fielddata"
+	health       string = "health"
+	indices      string = "indices"
+	master       string = "master"
+	nodeattrs    string = "nodeattrs"
+	nodes        string = "nodes"
+	pendingtasks string = "pending_tasks"
+	plugins      string = "plugins"
+	recovery     string = "recovery"
+	repositories string = "repositories"
+	shards       string = "shards"
+	segments     string = "segments"
+	templates    string = "templates"
+	threadpool   string = "thread_pool"
+)
+
+var catModels = map[string]struct{}{
+	aliases:      struct{}{},
+	allocation:   struct{}{},
+	count:        struct{}{},
+	fielddata:    struct{}{},
+	health:       struct{}{},
+	indices:      struct{}{},
+	master:       struct{}{},
+	nodeattrs:    struct{}{},
+	nodes:        struct{}{},
+	pendingtasks: struct{}{},
+	plugins:      struct{}{},
+	recovery:     struct{}{},
+	repositories: struct{}{},
+	shards:       struct{}{},
+	segments:     struct{}{},
+	templates:    struct{}{},
+	threadpool:   struct{}{},
 }
 
 // NewCatService creates a new CatService.
@@ -27,7 +68,105 @@ func NewCatService(client *Client) *CatService {
 	}
 }
 
+// Aliases sets the service to show information about currently configured aliases to indices including filter and routing infos.
+func (s *CatService) Aliases() *CatService {
+	s.model = aliases
+	return s
+}
+
+// Allocation sets the service to show a snapshot of how many shards are allocated to each data node and how much disk space they are using.
+func (s *CatService) Allocation() *CatService {
+	s.model = allocation
+	return s
+}
+
+// Count sets the service to show the document count of the entire cluster, or individual indices.
+func (s *CatService) Count() *CatService {
+	s.model = count
+	return s
+}
+
+// FieldData sets the service to show how much heap memory is currently being used by fielddata on every data node in the cluster.
+func (s *CatService) FieldData() *CatService {
+	s.model = fielddata
+	return s
+}
+
+// Health sets the service to show a terse, one-line representation of the same information from /_cluster/health
+func (s *CatService) Health() *CatService {
+	s.model = health
+	return s
+}
+
+// Indices sets the service to show a cross-section of each index.
 func (s *CatService) Indices() *CatService {
+	s.model = indices
+	return s
+}
+
+// Master sets the service to show the master’s node ID, bound IP address, and node name.
+func (s *CatService) Master() *CatService {
+	s.model = master
+	return s
+}
+
+// NodeAttrs sets the service to show custom node attributes.
+func (s *CatService) NodeAttrs() *CatService {
+	s.model = nodeattrs
+	return s
+}
+
+// Nodes sets the service to show the cluster topology.
+func (s *CatService) Nodes() *CatService {
+	s.model = nodes
+	return s
+}
+
+// PendingTasks sets the service to show data about any pending updates to the cluster state.
+func (s *CatService) PendingTasks() *CatService {
+	s.model = pendingtasks
+	return s
+}
+
+// Plugins sets the service to show a view per node of running plugins.
+func (s *CatService) Plugins() *CatService {
+	s.model = plugins
+	return s
+}
+
+// Recovery sets the service to show a view of index shard recoveries, both on-going and previously completed.
+func (s *CatService) Recovery() *CatService {
+	s.model = recovery
+	return s
+}
+
+// Repositories sets the service to show the snapshot repositories registered in the cluster.
+func (s *CatService) Repositories() *CatService {
+	s.model = repositories
+	return s
+}
+
+// Segments sets the service to show low level information about the segments in the shards of an index.
+func (s *CatService) Segments() *CatService {
+	s.model = segments
+	return s
+}
+
+// Shards sets the service to show the detailed view of what nodes contain which shards.
+func (s *CatService) Shards() *CatService {
+	s.model = shards
+	return s
+}
+
+// Templates sets the service to show information about existing templates.
+func (s *CatService) Templates() *CatService {
+	s.model = templates
+	return s
+}
+
+// ThreadPool sets the service to show cluster wide thread pool statistics per node.
+func (s *CatService) ThreadPool() *CatService {
+	s.model = threadpool
 	return s
 }
 
@@ -39,7 +178,7 @@ func (s *CatService) Pretty(pretty bool) *CatService {
 
 // buildURL builds the URL for the operation.
 func (s *CatService) buildURL() (string, url.Values, error) {
-	path := "/_cat/indices"
+	path := fmt.Sprintf("/_cat/%s", s.model)
 
 	// Add query string parameters
 	params := url.Values{}
@@ -52,6 +191,14 @@ func (s *CatService) buildURL() (string, url.Values, error) {
 
 // Validate checks if the operation is valid.
 func (s *CatService) Validate() error {
+	if s.model == "" {
+		return fmt.Errorf("no model specified for cat command")
+	}
+
+	if _, ok := catModels[s.model]; !ok {
+		return fmt.Errorf("unknown model '%s' specified for cat command", s.model)
+	}
+
 	return nil
 }
 

--- a/cat_test.go
+++ b/cat_test.go
@@ -6,18 +6,74 @@ package elastic
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
-func TestCatIndices(t *testing.T) {
+func TestCatModels(t *testing.T) {
 	client := setupTestClientAndCreateIndex(t)
 
-	res, err := client.Cat().Indices().Pretty(true).Do(context.TODO())
-	if err != nil {
-		t.Fatalf("expected to not get an error, got %v", err)
+	c := client.Cat()
+
+	tests := []struct {
+		f    func() *CatService
+		name string
+	}{
+		{f: c.Aliases, name: "aliases"},
+		{f: c.Allocation, name: "allocation"},
+		{f: c.Count, name: "count"},
+		{f: c.FieldData, name: "fielddata"},
+		{f: c.Health, name: "health"},
+		{f: c.Indices, name: "indices"},
+		{f: c.Master, name: "master"},
+		{f: c.NodeAttrs, name: "nodeattrs"},
+		{f: c.Nodes, name: "nodes"},
+		{f: c.PendingTasks, name: "pendingtasks"},
+		{f: c.Plugins, name: "plugins"},
+		{f: c.Recovery, name: "recovery"},
+		{f: c.Repositories, name: "repositories"},
+		{f: c.Shards, name: "shards"},
+		{f: c.Segments, name: "segments"},
+// TODO - it is not possible to cat snapshots where no repo exists.
+// Creating one for the purpose of this test fails without setting the path.repo or repositories.url.allowed_url setting .
+// Putting this off to a later issue.
+		{f: c.Templates, name: "templates"},
+		{f: c.ThreadPool, name: "threadpool"},
 	}
 
-	if res == "" {
-		t.Fatalf("expected res to not be an empty string")
+	for _, tt := range tests {
+		model := tt.f
+		res, err := model().Do(context.TODO())
+
+		if err != nil {
+			t.Errorf("model %s - expected to not get an error, got %v", tt.name, err)
+		}
+
+		if res == "" {
+			t.Errorf("model %s - expected res to not be an empty string", tt.name)
+		}
+	}
+}
+
+func TestCatUnknownModel(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	c := client.Cat()
+	c.model = "boogers"
+
+	_, err := c.Do(context.TODO())
+
+	if err == nil {
+		t.Fatalf("expected to get an error, but did not", err)
+	}
+}
+
+func TestCatNoModel(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	_, err := client.Cat().Do(context.TODO())
+
+	if err == nil {
+		t.Fatalf("expected to get an error, but did not", err)
 	}
 }

--- a/cat_test.go
+++ b/cat_test.go
@@ -6,7 +6,6 @@ package elastic
 
 import (
 	"context"
-	"fmt"
 	"testing"
 )
 
@@ -34,9 +33,9 @@ func TestCatModels(t *testing.T) {
 		{f: c.Repositories, name: "repositories"},
 		{f: c.Shards, name: "shards"},
 		{f: c.Segments, name: "segments"},
-// TODO - it is not possible to cat snapshots where no repo exists.
-// Creating one for the purpose of this test fails without setting the path.repo or repositories.url.allowed_url setting .
-// Putting this off to a later issue.
+		// TODO - it is not possible to cat snapshots where no repo exists.
+		// Creating one for the purpose of this test fails without setting the path.repo or repositories.url.allowed_url setting .
+		// Putting this off to a later issue.
 		{f: c.Templates, name: "templates"},
 		{f: c.ThreadPool, name: "threadpool"},
 	}
@@ -64,7 +63,7 @@ func TestCatUnknownModel(t *testing.T) {
 	_, err := c.Do(context.TODO())
 
 	if err == nil {
-		t.Fatalf("expected to get an error, but did not", err)
+		t.Fatalf("expected to get an error, but did not")
 	}
 }
 
@@ -74,6 +73,20 @@ func TestCatNoModel(t *testing.T) {
 	_, err := client.Cat().Do(context.TODO())
 
 	if err == nil {
-		t.Fatalf("expected to get an error, but did not", err)
+		t.Fatalf("expected to get an error, but did not")
+	}
+}
+
+func TestCatHelpCommand(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	res, err := client.Cat().Health().Help(true).Do(context.TODO())
+
+	if err != nil {
+		t.Errorf("expected to not get an error with help command, got %v", err)
+	}
+
+	if res == "" {
+		t.Errorf("expected response from help command to not be an empty string")
 	}
 }

--- a/cat_test.go
+++ b/cat_test.go
@@ -1,0 +1,23 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCatIndices(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+
+	res, err := client.Cat().Indices().Pretty(true).Do(context.TODO())
+	if err != nil {
+		t.Fatalf("expected to not get an error, got %v", err)
+	}
+
+	if res == "" {
+		t.Fatalf("expected res to not be an empty string")
+	}
+}

--- a/client.go
+++ b/client.go
@@ -1684,6 +1684,13 @@ func (c *Client) TasksGetTask() *TasksGetTaskService {
 	return NewTasksGetTaskService(c)
 }
 
+// -- Cat APIs --
+
+// Cat retrieves data about the cluster in human readable formats
+func (c *Client) Cat() *CatService {
+	return NewCatService(c)
+}
+
 // TODO Pending cluster tasks
 // TODO Cluster Reroute
 // TODO Cluster Update Settings


### PR DESCRIPTION
Problem: the [cat API's](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat.html) are not currently supported. This implements these API's for all models but snapshots*. Subsequent PR's should flesh out the other options for each individual model as well as format type, column filtering and other interesting things. 

* `_cat/snapshots/$REPOSITORY_NAME?v` currently throws an exception if the repository does not exist, and the repository is required. Setting up a local cluster with a repository to test the command requires a non-trivial amount of work, and while I don't care to test the output of `cat` I would like to test that the command itself runs like I do for the other models.

