### PR TITLE
Added roles field to node info

### DIFF
--- a/nodes_info.go
+++ b/nodes_info.go
@@ -150,6 +150,9 @@ type NodesInfoNode struct {
 	// HTTPSAddress, e.g. "127.0.0.1:9200"
 	HTTPSAddress string `json:"https_address"`
 
+	// Roles of the node, e.g. [master, ingest, data]
+	Roles []string `json:"roles"`
+
 	// Attributes of the node.
 	Attributes map[string]interface{} `json:"attributes"`
 


### PR DESCRIPTION
This will add the Roles field to node info.

This is exactly the same change made in #745, but in the Elasticsearch 5.X branch.