### PR TITLE
Add GetRequest function to retrieve the requests from the queue

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -163,6 +163,11 @@ func (s *BulkService) estimateSizeInBytes(r BulkableRequest) int64 {
 	return int64(size)
 }
 
+// GetRequests returns the bulkable requests from the queue
+func (s *BulkService) GetRequests() []BulkableRequest {
+	return s.requests
+}
+
 // NumberOfActions returns the number of bulkable requests that need to
 // be sent to Elasticsearch on the next batch.
 func (s *BulkService) NumberOfActions() int {


### PR DESCRIPTION
I would like to add some external checks for the requests. As long the `requests` var is not exported, I've wrote a small func for returning them.

Well, if this gets merged, I will make sure to update the other versions as well.