### PR TITLE
Change bulk reset func to exportable

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -52,7 +52,8 @@ func NewBulkService(client *Client) *BulkService {
 	return builder
 }
 
-func (s *BulkService) reset() {
+// Reset cleans up the request queue
+func (s *BulkService) Reset() {
 	s.requests = make([]BulkableRequest, 0)
 	s.sizeInBytes = 0
 	s.sizeInBytesCursor = 0
@@ -265,7 +266,7 @@ func (s *BulkService) Do(ctx context.Context) (*BulkResponse, error) {
 	}
 
 	// Reset so the request can be reused
-	s.reset()
+	s.Reset()
 
 	return ret, nil
 }

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -483,7 +483,7 @@ func TestBulkEstimatedSizeInBytes(t *testing.T) {
 	}
 
 	// Reset should also reset the calculated estimated byte size
-	bulkRequest.reset()
+	bulkRequest.Reset()
 
 	if got, want := bulkRequest.EstimatedSizeInBytes(), int64(0); got != want {
 		t.Errorf("expected an EstimatedSizeInBytes = %d; got: %v", want, got)
@@ -537,7 +537,7 @@ func BenchmarkBulkEstimatedSizeInBytesWith1Request(b *testing.B) {
 		s = s.Add(NewBulkUpdateRequest().Index(testIndexName).Type("doc").Id("1").Doc(struct{ A string }{"2"}))
 		s = s.Add(NewBulkDeleteRequest().Index(testIndexName).Type("doc").Id("1"))
 		result = s.EstimatedSizeInBytes()
-		s.reset()
+		s.Reset()
 	}
 	b.ReportAllocs()
 	benchmarkBulkEstimatedSizeInBytes = result // ensure the compiler doesn't optimize
@@ -554,7 +554,7 @@ func BenchmarkBulkEstimatedSizeInBytesWith100Requests(b *testing.B) {
 			s = s.Add(NewBulkDeleteRequest().Index(testIndexName).Type("doc").Id("1"))
 		}
 		result = s.EstimatedSizeInBytes()
-		s.reset()
+		s.Reset()
 	}
 	b.ReportAllocs()
 	benchmarkBulkEstimatedSizeInBytes = result // ensure the compiler doesn't optimize


### PR DESCRIPTION
the reason of this change is: all requests are persistent.

if `s.client.PerformRequestWithOptions` (https://github.com/olivere/elastic/blob/release-branch.v6/bulk.go#L249) returns an error, the request won't be reseted, but in some special cases, I would like to decide that.

So by exporting the Reset function, it gives the user the flexibity to reset the queue and possibily write those requests to the file system, if wished.

If this change gets merged, I will make sure to update all other versions.

Great project btw.