### PR TITLE
Fix TotalIndexingBufferInBytes unmarshal error

### DIFF
--- a/nodes_info.go
+++ b/nodes_info.go
@@ -156,7 +156,7 @@ type NodesInfoNode struct {
 	TotalIndexingBuffer int64 `json:"total_indexing_buffer"` // e.g. 16gb
 	// TotalIndexingBufferInBytes is the same as TotalIndexingBuffer, but
 	// expressed in bytes.
-	TotalIndexingBufferInBytes int64 `json:"total_indexing_buffer_in_bytes"`
+	TotalIndexingBufferInBytes string `json:"total_indexing_buffer_in_bytes"`
 
 	// Roles of the node, e.g. [master, ingest, data]
 	Roles []string `json:"roles"`


### PR DESCRIPTION
when `.Human(true)`, `total_indexing_buffer_in_bytes` is present in the node info api response, e.g.
```
    "total_indexing_buffer_in_bytes": "197.9mb",
    "total_indexing_buffer": 207591833,
```
`total_indexing_buffer_in_bytes` is string, not int64

Fix #782 