### PR TITLE
add keyed option to date histogram aggregation

### DIFF
--- a/search_aggs_bucket_date_histogram.go
+++ b/search_aggs_bucket_date_histogram.go
@@ -23,6 +23,7 @@ type DateHistogramAggregation struct {
 	timeZone          string
 	format            string
 	offset            string
+	keyed             *bool
 }
 
 // NewDateHistogramAggregation creates a new DateHistogramAggregation.
@@ -175,6 +176,14 @@ func (a *DateHistogramAggregation) Offset(offset string) *DateHistogramAggregati
 	return a
 }
 
+// Keyed sets the keyed flag.
+// Setting the keyed flag to true will associate a unique string key with each bucket
+// and return the ranges as a hash rather than an array.
+func (a *DateHistogramAggregation) Keyed(keyed bool) *DateHistogramAggregation {
+	a.keyed = &keyed
+	return a
+}
+
 // ExtendedBounds accepts int, int64, string, or time.Time values.
 // In case the lower value in the histogram would be greater than min or the
 // upper value would be less than max, empty buckets will be generated.
@@ -248,6 +257,9 @@ func (a *DateHistogramAggregation) Source() (interface{}, error) {
 	}
 	if a.offset != "" {
 		opts["offset"] = a.offset
+	}
+	if a.keyed != nil {
+		opts["keyed"] = *a.keyed
 	}
 	if a.format != "" {
 		opts["format"] = a.format

--- a/search_aggs_bucket_date_histogram_test.go
+++ b/search_aggs_bucket_date_histogram_test.go
@@ -47,3 +47,20 @@ func TestDateHistogramAggregationWithMissing(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestDateHistogramAggregationWithKeyedFlag(t *testing.T) {
+	agg := NewDateHistogramAggregation().Field("date").Interval("year").Keyed(true)
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"date_histogram":{"field":"date","interval":"year","keyed":true}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
The keyed option is present since version 5.4 (see https://www.elastic.co/guide/en/elasticsearch/reference/5.4/search-aggregations-bucket-datehistogram-aggregation.html).

