### PR TITLE
Allow RetrierFunc to be an adapter

### DIFF
--- a/retrier.go
+++ b/retrier.go
@@ -10,8 +10,15 @@ import (
 	"time"
 )
 
-// RetrierFunc specifies the signature of a Retry function.
+// RetrierFunc specifies the signature of a Retry function, and is an adapter
+// to allow the use of ordinary Retry functions. If f is a function with the
+// appropriate signature, RetrierFunc(f) is a Retrier that calls f.
 type RetrierFunc func(context.Context, int, *http.Request, *http.Response, error) (time.Duration, bool, error)
+
+// Retry calls f.
+func (f RetrierFunc) Retry(ctx context.Context, retry int, req *http.Request, resp *http.Response, err error) (time.Duration, bool, error) {
+	return f(ctx, retry, req, resp, err)
+}
 
 // Retrier decides whether to retry a failed HTTP request with Elasticsearch.
 type Retrier interface {


### PR DESCRIPTION
This PR allows the use of RetrierFunc as an adapter:
```go
client, err := NewClient(
	SetRetrier(RetrierFunc(func(context.Context, int, *http.Request, *http.Response, error) (time.Duration, bool, error){
		return 0, false, nil
	})),
)
```

Here is an example from the stdlib: https://github.com/golang/go/blob/00ebfcde7f3b6e63447e2a3962975e0a8c3729dd/src/net/http/server.go#L1964-L1973

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/olivere/elastic/827)
<!-- Reviewable:end -->
