### PR TITLE
suggester context query && indexing differences

### DIFF
--- a/suggester_context_category.go
+++ b/suggester_context_category.go
@@ -129,7 +129,11 @@ func NewSuggesterCategoryIndex(name string, values ...string) *SuggesterCategory
 		name:   name,
 		values: values,
 	}
+	return q
+}
 
+func (q *SuggesterCategoryIndex) Values(values ...string) *SuggesterCategoryIndex {
+	q.values = append(q.values, values...)
 	return q
 }
 
@@ -140,6 +144,8 @@ func (q *SuggesterCategoryIndex) Source() (interface{}, error) {
 	switch len(q.values) {
 	case 0:
 		source[q.name] = make([]string, 0)
+	case 1:
+		source[q.name] = q.values[0]
 	default:
 		source[q.name] = q.values
 	}

--- a/suggester_context_category.go
+++ b/suggester_context_category.go
@@ -117,3 +117,32 @@ func (q *SuggesterCategoryQuery) Source() (interface{}, error) {
 
 	return source, nil
 }
+
+type SuggesterCategoryIndex struct {
+	name   string
+	values []string
+}
+
+// NewSuggesterCategoryIndex creates a new SuggesterCategoryIndex.
+func NewSuggesterCategoryIndex(name string, values ...string) *SuggesterCategoryIndex {
+	q := &SuggesterCategoryIndex{
+		name:   name,
+		values: values,
+	}
+
+	return q
+}
+
+// Source returns a map that will be used to serialize the context query as JSON.
+func (q *SuggesterCategoryIndex) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	switch len(q.values) {
+	case 0:
+		source[q.name] = make([]string, 0)
+	default:
+		source[q.name] = q.values
+	}
+
+	return source, nil
+}

--- a/suggester_context_category_test.go
+++ b/suggester_context_category_test.go
@@ -161,3 +161,37 @@ func TestSuggesterCategoryQueryWithoutBoost(t *testing.T) {
 		t.Errorf("expected any of %v\n,got:\n%s", expectedOutcomes, got)
 	}
 }
+
+func TestSuggesterCategoryIndex(t *testing.T) {
+	in := NewSuggesterCategoryIndex("color", "red")
+	src, err := in.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"color":"red"}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestSuggesterCategoryIndexWithTwoValues(t *testing.T) {
+	in := NewSuggesterCategoryIndex("color", "red", "yellow")
+	src, err := in.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"color":["red","yellow"]}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}

--- a/suggester_context_geo.go
+++ b/suggester_context_geo.go
@@ -84,20 +84,19 @@ func (q *SuggesterGeoMapping) Source() (interface{}, error) {
 type SuggesterGeoQuery struct {
 	name      string
 	location  *GeoPoint
-	precision []string
+	precision string
 }
 
 // NewSuggesterGeoQuery creates a new SuggesterGeoQuery.
 func NewSuggesterGeoQuery(name string, location *GeoPoint) *SuggesterGeoQuery {
 	return &SuggesterGeoQuery{
-		name:      name,
-		location:  location,
-		precision: make([]string, 0),
+		name:     name,
+		location: location,
 	}
 }
 
-func (q *SuggesterGeoQuery) Precision(precision ...string) *SuggesterGeoQuery {
-	q.precision = append(q.precision, precision...)
+func (q *SuggesterGeoQuery) Precision(precision string) *SuggesterGeoQuery {
+	q.precision = precision
 	return q
 }
 
@@ -105,25 +104,15 @@ func (q *SuggesterGeoQuery) Precision(precision ...string) *SuggesterGeoQuery {
 func (q *SuggesterGeoQuery) Source() (interface{}, error) {
 	source := make(map[string]interface{})
 
-	if len(q.precision) == 0 {
-		if q.location != nil {
-			source[q.name] = q.location.Source()
+	if q.location != nil {
+		val := make(map[string]interface{})
+		for k, v := range q.location.Source() {
+			val[k] = v
 		}
-	} else {
-		x := make(map[string]interface{})
-		source[q.name] = x
-
-		if q.location != nil {
-			x["value"] = q.location.Source()
+		if q.precision != "" {
+			val["precision"] = q.precision
 		}
-
-		switch len(q.precision) {
-		case 0:
-		case 1:
-			x["precision"] = q.precision[0]
-		default:
-			x["precision"] = q.precision
-		}
+		source[q.name] = val
 	}
 
 	return source, nil

--- a/suggester_context_geo.go
+++ b/suggester_context_geo.go
@@ -82,16 +82,19 @@ func (q *SuggesterGeoMapping) Source() (interface{}, error) {
 // SuggesterGeoQuery provides querying a geolocation context in a suggester.
 // See https://www.elastic.co/guide/en/elasticsearch/reference/6.2/suggester-context.html#_geo_location_query
 type SuggesterGeoQuery struct {
-	name      string
-	location  *GeoPoint
-	precision string
+	name       string
+	location   *GeoPoint
+	precision  string
+	neighbours []string
+	boost      *int
 }
 
 // NewSuggesterGeoQuery creates a new SuggesterGeoQuery.
 func NewSuggesterGeoQuery(name string, location *GeoPoint) *SuggesterGeoQuery {
 	return &SuggesterGeoQuery{
-		name:     name,
-		location: location,
+		name:       name,
+		location:   location,
+		neighbours: make([]string, 0),
 	}
 }
 
@@ -100,19 +103,75 @@ func (q *SuggesterGeoQuery) Precision(precision string) *SuggesterGeoQuery {
 	return q
 }
 
+func (q *SuggesterGeoQuery) Neighbours(neighbours ...string) *SuggesterGeoQuery {
+	q.neighbours = append(q.neighbours, neighbours...)
+	return q
+}
+
+func (q *SuggesterGeoQuery) Boost(boost int) *SuggesterGeoQuery {
+	q.boost = &boost
+	return q
+}
+
 // Source returns a map that will be used to serialize the context query as JSON.
 func (q *SuggesterGeoQuery) Source() (interface{}, error) {
 	source := make(map[string]interface{})
 
+	x := make(map[string]interface{})
+	source[q.name] = x
+
 	if q.location != nil {
-		val := make(map[string]interface{})
-		for k, v := range q.location.Source() {
-			val[k] = v
+		x["context"] = q.location.Source()
+	}
+	if q.precision != "" {
+		x["precision"] = q.precision
+	}
+	if q.boost != nil {
+		x["boost"] = q.boost
+	}
+	switch len(q.neighbours) {
+	case 0:
+	case 1:
+		x["neighbours"] = q.neighbours[0]
+	default:
+		x["neighbours"] = q.neighbours
+	}
+
+	return source, nil
+}
+
+type SuggesterGeoIndex struct {
+	name      string
+	locations []*GeoPoint
+}
+
+// NewSuggesterGeoQuery creates a new SuggesterGeoQuery.
+func NewSuggesterGeoIndex(name string) *SuggesterGeoIndex {
+	return &SuggesterGeoIndex{
+		name: name,
+	}
+}
+
+func (q *SuggesterGeoIndex) Locations(locations ...*GeoPoint) *SuggesterGeoIndex {
+	q.locations = append(q.locations, locations...)
+	return q
+}
+
+// Source returns a map that will be used to serialize the context query as JSON.
+func (q *SuggesterGeoIndex) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	switch len(q.locations) {
+	case 0:
+		source[q.name] = make([]string, 0)
+	case 1:
+		source[q.name] = q.locations[0].Source()
+	default:
+		var arr []interface{}
+		for _, p := range q.locations {
+			arr = append(arr, p.Source())
 		}
-		if q.precision != "" {
-			val["precision"] = q.precision
-		}
-		source[q.name] = val
+		source[q.name] = arr
 	}
 
 	return source, nil

--- a/suggester_context_geo_test.go
+++ b/suggester_context_geo_test.go
@@ -41,7 +41,7 @@ func TestSuggesterGeoQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"location":{"precision":"1km","value":{"lat":11.5,"lon":62.71}}}`
+	expected := `{"location":{"precision":"1km","lat":11.5,"lon":62.71}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/suggester_context_geo_test.go
+++ b/suggester_context_geo_test.go
@@ -41,7 +41,7 @@ func TestSuggesterGeoQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"location":{"precision":"1km","lat":11.5,"lon":62.71}}`
+	expected := `{"location":{"lat":11.5,"lon":62.71,"precision":"1km"}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/suggester_context_geo_test.go
+++ b/suggester_context_geo_test.go
@@ -31,8 +31,37 @@ func TestSuggesterGeoMapping(t *testing.T) {
 }
 
 func TestSuggesterGeoQuery(t *testing.T) {
-	q := NewSuggesterGeoQuery("location", GeoPointFromLatLon(11.5, 62.71)).Precision("1km")
+	q := NewSuggesterGeoQuery("location", GeoPointFromLatLon(11.5, 62.71)).Precision("1km").
+		Neighbours("2km", "3km").Boost(2)
 	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expectedOutcomes := []string{
+		`{"location":{"context":{"lat":11.5,"lon":62.71},"precision":"1km","boost":2,"neighbours":["2km","3km"]}}`,
+		`{"location":{"boost":2,"context":{"lat":11.5,"lon":62.71},"neighbours":["2km","3km"],"precision":"1km"}}`,
+	}
+	var match bool
+	for _, expected := range expectedOutcomes {
+		if got == expected {
+			match = true
+			break
+		}
+	}
+	if !match {
+		t.Errorf("expected any of %v\n,got:\n%s", expectedOutcomes, got)
+	}
+}
+
+func TestSuggesterGeoIndex(t *testing.T) {
+	in := NewSuggesterGeoIndex("location").Locations(GeoPointFromLatLon(11.5, 62.71))
+	src, err := in.Source()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +70,24 @@ func TestSuggesterGeoQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"location":{"lat":11.5,"lon":62.71,"precision":"1km"}}`
+	expected := `{"location":{"lat":11.5,"lon":62.71}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestSuggesterGeoIndexWithTwoValues(t *testing.T) {
+	in := NewSuggesterGeoIndex("location").Locations(GeoPointFromLatLon(11.5, 62.71), GeoPointFromLatLon(31.5, 22.71))
+	src, err := in.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"location":[{"lat":11.5,"lon":62.71},{"lat":31.5,"lon":22.71}]}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
1.SuggesterGeoQuery 
1.1. precision -> string array to string (defines precision of the geohash to be indexed, one location pairs one precision)
1.2. value key -> in source map, `value` key not defined in docs

2.SuggesterCategoryQuery
-For category query, we have to use `context` key in source map, and optionally `boost` key 
-For category indexing, I must not use `context` and `boost` keys in source map 