### PR TITLE
check for nested context errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -1275,7 +1275,7 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 
 		// Get response
 		res, err := c.c.Do((*http.Request)(req).WithContext(ctx))
-		if isContextErr(err) {
+		if IsContextErr(err) {
 			// Proceed, but don't mark the node as dead
 			return nil, err
 		}
@@ -1335,22 +1335,6 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 		float64(int64(duration/time.Millisecond))/1000)
 
 	return resp, nil
-}
-
-// isContextErr returns true if the error is from a context that was canceled or deadline exceeded
-func isContextErr(err error) bool {
-	if err == context.Canceled || err == context.DeadlineExceeded {
-		return true
-	}
-	// This happens e.g. on redirect errors, see https://golang.org/src/net/http/client_test.go#L329
-	if ue, ok := err.(*url.Error); ok {
-		if ue.Temporary() {
-			return true
-		}
-		// Use of an AWS Signing Transport can result in a wrapped url.Error
-		return isContextErr(ue.Err)
-	}
-	return false
 }
 
 // -- Document APIs --

--- a/errors.go
+++ b/errors.go
@@ -5,10 +5,12 @@
 package elastic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/pkg/errors"
 )
@@ -89,6 +91,22 @@ func (e *Error) Error() string {
 	} else {
 		return fmt.Sprintf("elastic: Error %d (%s)", e.Status, http.StatusText(e.Status))
 	}
+}
+
+// IsContextErr returns true if the error is from a context that was canceled or deadline exceeded
+func IsContextErr(err error) bool {
+	if err == context.Canceled || err == context.DeadlineExceeded {
+		return true
+	}
+	// This happens e.g. on redirect errors, see https://golang.org/src/net/http/client_test.go#L329
+	if ue, ok := err.(*url.Error); ok {
+		if ue.Temporary() {
+			return true
+		}
+		// Use of an AWS Signing Transport can result in a wrapped url.Error
+		return IsContextErr(ue.Err)
+	}
+	return false
 }
 
 // IsConnErr returns true if the error indicates that Elastic could not


### PR DESCRIPTION
I am using this library against AWS ElasticSearch Service, and found it was constantly logging out that the connection/nodes were dead, whenever the context was cancelled.
I looked and saw you were already handling that, so it took me a while to figure out why it wasn't being caught.

Turns out that the url.Error is wrapping a url.Error that is wrapping the context error, because of transport wrapping a second call to the http client:
https://github.com/olivere/elastic/blob/release-branch.v6/recipes/aws-connect/main.go#L32

I thought about avoiding the second call to the http client, however it is actually a good thing to make that second call after modifying the request, since the http client includes safeguards around not forwarding the authorization headers to untrusted domains.

So a simple solution is just to check for a url.Error wrapping the original url.Error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/olivere/elastic/836)
<!-- Reviewable:end -->
