### PR TITLE
Veqryn aws support

### DIFF
--- a/aws/signV4.go
+++ b/aws/signV4.go
@@ -1,0 +1,32 @@
+package aws
+
+import (
+	"net/http"
+
+	"github.com/smartystreets/go-aws-auth"
+)
+
+// NewV4SigningClient returns an *http.Client that will sign all requests with AWS V4 Signing.
+func NewV4SigningClient(credentials awsauth.Credentials) *http.Client {
+	return &http.Client{
+		Transport: V4Transport{
+			HTTPClient:  http.DefaultClient,
+			Credentials: credentials,
+		},
+	}
+}
+
+// V4Transport is a RoundTripper that will sign requests with AWS V4 Signing
+type V4Transport struct {
+	HTTPClient  *http.Client
+	Credentials awsauth.Credentials
+}
+
+// RoundTrip uses the underlying RoundTripper transport, but signs request first with AWS V4 Signing
+func (st V4Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Instead of directly modifying the request then calling http.DefaultTransport,
+	// instead restart the request with the HTTPClient.Do function,
+	// because the HTTPClient includes safeguards around not forwarding the
+	// signed Authorization header to untrusted domains.
+	return st.HTTPClient.Do(awsauth.Sign4(req, st.Credentials))
+}

--- a/recipes/aws-connect/main.go
+++ b/recipes/aws-connect/main.go
@@ -14,23 +14,11 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net/http"
 
-	"github.com/olivere/env"
-	"github.com/smartystreets/go-aws-auth"
-
+	"github.com/olivere/aws"
 	"github.com/olivere/elastic"
+	"github.com/olivere/env"
 )
-
-type AWSSigningTransport struct {
-	HTTPClient  *http.Client
-	Credentials awsauth.Credentials
-}
-
-// RoundTrip implementation
-func (a AWSSigningTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return a.HTTPClient.Do(awsauth.Sign4(req, a.Credentials))
-}
 
 func main() {
 	var (
@@ -52,14 +40,10 @@ func main() {
 		log.Fatal("missing -secret-key or AWS_SECRET_KEY environment variable")
 	}
 
-	signingTransport := AWSSigningTransport{
-		Credentials: awsauth.Credentials{
-			AccessKeyID:     *accessKey,
-			SecretAccessKey: *secretKey,
-		},
-		HTTPClient: http.DefaultClient,
-	}
-	signingClient := &http.Client{Transport: http.RoundTripper(signingTransport)}
+	signingClient := aws.NewV4SigningClient(awsauth.Credentials{
+		AccessKeyID:     *accessKey,
+		SecretAccessKey: *secretKey,
+	})
 
 	// Create an Elasticsearch client
 	client, err := elastic.NewClient(


### PR DESCRIPTION
Include an actual AWS Signing client as supported in the repo.
The aws stuff is in its own package, so it won't get compiled into the end binary unless it is actually being used.
Also updated the recipe example.