### PR TITLE
add headers to request

### DIFF
--- a/client.go
+++ b/client.go
@@ -1182,6 +1182,7 @@ type PerformRequestOptions struct {
 	ContentType  string
 	IgnoreErrors []int
 	Retrier      Retrier
+	Headers      map[string]string
 }
 
 // PerformRequest does a HTTP request to Elasticsearch.
@@ -1259,6 +1260,12 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 		}
 		if opt.ContentType != "" {
 			req.Header.Set("Content-Type", opt.ContentType)
+		}
+
+		if len(opt.Headers) > 0 {
+			for headerName, headerValue := range opt.Headers {
+				req.Header.Set(headerName, headerValue)
+			}
 		}
 
 		// Set body

--- a/client.go
+++ b/client.go
@@ -1182,7 +1182,7 @@ type PerformRequestOptions struct {
 	ContentType  string
 	IgnoreErrors []int
 	Retrier      Retrier
-	Headers      map[string]string
+	Headers      http.Header
 }
 
 // PerformRequest does a HTTP request to Elasticsearch.
@@ -1263,8 +1263,10 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 		}
 
 		if len(opt.Headers) > 0 {
-			for headerName, headerValue := range opt.Headers {
-				req.Header.Set(headerName, headerValue)
+			for key, value := range opt.Headers {
+				for _, v := range value {
+					req.Header.Add(key, v)
+				}
 			}
 		}
 

--- a/scroll.go
+++ b/scroll.go
@@ -36,6 +36,7 @@ type ScrollService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
+	headers           map[string]string
 
 	mu       sync.RWMutex
 	scrollId string
@@ -49,6 +50,15 @@ func NewScrollService(client *Client) *ScrollService {
 		keepAlive: DefaultScrollKeepAlive,
 	}
 	return builder
+}
+
+// AddHeader sets headers on the request
+func (s *ScrollService) AddHeader(headerName string, headerValue string) *ScrollService {
+	if s.headers == nil {
+		s.headers = map[string]string{}
+	}
+	s.headers[headerName] = headerValue
+	return s
 }
 
 // Retrier allows to set specific retry logic for this ScrollService.
@@ -303,6 +313,7 @@ func (s *ScrollService) first(ctx context.Context) (*SearchResult, error) {
 		Params:  params,
 		Body:    body,
 		Retrier: s.retrier,
+		Headers: s.headers,
 	})
 	if err != nil {
 		return nil, err
@@ -423,6 +434,7 @@ func (s *ScrollService) next(ctx context.Context) (*SearchResult, error) {
 		Params:  params,
 		Body:    body,
 		Retrier: s.retrier,
+		Headers: s.headers,
 	})
 	if err != nil {
 		return nil, err

--- a/scroll.go
+++ b/scroll.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -36,7 +37,7 @@ type ScrollService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
-	headers           map[string]string
+	headers           http.Header
 
 	mu       sync.RWMutex
 	scrollId string
@@ -52,12 +53,12 @@ func NewScrollService(client *Client) *ScrollService {
 	return builder
 }
 
-// AddHeader sets headers on the request
-func (s *ScrollService) AddHeader(headerName string, headerValue string) *ScrollService {
+// Header sets headers on the request
+func (s *ScrollService) Header(name string, value string) *ScrollService {
 	if s.headers == nil {
-		s.headers = map[string]string{}
+		s.headers = http.Header{}
 	}
-	s.headers[headerName] = headerValue
+	s.headers.Add(name, value)
 	return s
 }
 

--- a/tasks_list.go
+++ b/tasks_list.go
@@ -7,6 +7,7 @@ package elastic
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -30,7 +31,7 @@ type TasksListService struct {
 	parentTaskId      *string
 	waitForCompletion *bool
 	groupBy           string
-	headers           map[string]string
+	headers           http.Header
 }
 
 // NewTasksListService creates a new TasksListService.
@@ -98,12 +99,12 @@ func (s *TasksListService) GroupBy(groupBy string) *TasksListService {
 	return s
 }
 
-// AddHeader sets headers on the request
-func (s *TasksListService) AddHeader(headerName string, headerValue string) *TasksListService {
+// Header sets headers on the request
+func (s *TasksListService) Header(name string, value string) *TasksListService {
 	if s.headers == nil {
-		s.headers = map[string]string{}
+		s.headers = http.Header{}
 	}
-	s.headers[headerName] = headerValue
+	s.headers.Add(name, value)
 	return s
 }
 
@@ -231,19 +232,19 @@ type DiscoveryNode struct {
 
 // TaskInfo represents information about a currently running task.
 type TaskInfo struct {
-	Node               string      `json:"node"`
-	Id                 int64       `json:"id"` // the task id (yes, this is a long in the Java source)
-	Type               string      `json:"type"`
-	Action             string      `json:"action"`
-	Status             interface{} `json:"status"`      // has separate implementations of Task.Status in Java for reindexing, replication, and "RawTaskStatus"
-	Description        interface{} `json:"description"` // same as Status
-	StartTime          string      `json:"start_time"`
-	StartTimeInMillis  int64       `json:"start_time_in_millis"`
-	RunningTime        string      `json:"running_time"`
-	RunningTimeInNanos int64       `json:"running_time_in_nanos"`
-	Cancellable        bool        `json:"cancellable"`
-	ParentTaskId       string      `json:"parent_task_id"` // like "YxJnVYjwSBm_AUbzddTajQ:12356"
-	Headers            interface{} `json:"headers"`
+	Node               string                 `json:"node"`
+	Id                 int64                  `json:"id"` // the task id (yes, this is a long in the Java source)
+	Type               string                 `json:"type"`
+	Action             string                 `json:"action"`
+	Status             interface{}            `json:"status"`      // has separate implementations of Task.Status in Java for reindexing, replication, and "RawTaskStatus"
+	Description        interface{}            `json:"description"` // same as Status
+	StartTime          string                 `json:"start_time"`
+	StartTimeInMillis  int64                  `json:"start_time_in_millis"`
+	RunningTime        string                 `json:"running_time"`
+	RunningTimeInNanos int64                  `json:"running_time_in_nanos"`
+	Cancellable        bool                   `json:"cancellable"`
+	ParentTaskId       string                 `json:"parent_task_id"` // like "YxJnVYjwSBm_AUbzddTajQ:12356"
+	Headers            map[string]interface{} `json:"headers"`
 }
 
 // StartTaskResult is used in cases where a task gets started asynchronously and

--- a/tasks_list.go
+++ b/tasks_list.go
@@ -30,6 +30,7 @@ type TasksListService struct {
 	parentTaskId      *string
 	waitForCompletion *bool
 	groupBy           string
+	headers           map[string]string
 }
 
 // NewTasksListService creates a new TasksListService.
@@ -94,6 +95,15 @@ func (s *TasksListService) WaitForCompletion(waitForCompletion bool) *TasksListS
 // As of now, it can either be "nodes" (default) or "parents".
 func (s *TasksListService) GroupBy(groupBy string) *TasksListService {
 	s.groupBy = groupBy
+	return s
+}
+
+// AddHeader sets headers on the request
+func (s *TasksListService) AddHeader(headerName string, headerValue string) *TasksListService {
+	if s.headers == nil {
+		s.headers = map[string]string{}
+	}
+	s.headers[headerName] = headerValue
 	return s
 }
 
@@ -171,9 +181,10 @@ func (s *TasksListService) Do(ctx context.Context) (*TasksListResponse, error) {
 
 	// Get HTTP response
 	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
-		Method: "GET",
-		Path:   path,
-		Params: params,
+		Method:  "GET",
+		Path:    path,
+		Params:  params,
+		Headers: s.headers,
 	})
 	if err != nil {
 		return nil, err
@@ -232,6 +243,7 @@ type TaskInfo struct {
 	RunningTimeInNanos int64       `json:"running_time_in_nanos"`
 	Cancellable        bool        `json:"cancellable"`
 	ParentTaskId       string      `json:"parent_task_id"` // like "YxJnVYjwSBm_AUbzddTajQ:12356"
+	Headers            interface{} `json:"headers"`
 }
 
 // StartTaskResult is used in cases where a task gets started asynchronously and


### PR DESCRIPTION
Added ability to append headers to rest calls.
I only added the field on scroll and tasks_list because those were my use case, but this could be useful everywhere.

References issue https://github.com/olivere/elastic/issues/862