### PR TITLE
Fix Go module path for v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/olivere/elastic.v5/v5
+module gopkg.in/olivere/elastic.v5
 
 require (
 	github.com/Sirupsen/logrus v1.0.6


### PR DESCRIPTION
A recent release of go.mod file breaks the backward compatibility of gopkg.in/olivere/elastic.v5 package.

Given
```
$ cat go.mod
require gopkg.in/olivere/elastic.v5 v5.0.53
```

Updating to newer patch version errors out with
```
$ GO111MODULE=on go get -u=patch
go: gopkg.in/olivere/elastic.v5@v5.0.72: go.mod has non-....v5 module path "gopkg.in/olivere/elastic.v5/v5" at revision v5.0.72
go get: error loading module requirements
```

Looking at recent v5 [go.mod file](https://github.com/olivere/elastic/blob/523a0a2a80ee432ac09830b9f9be37e8e2544310/go.mod#L1), why did we change the import path from `gopkg.in/olivere/elastic.v5` to `gopkg.in/olivere/elastic.v5/v5`?

As far as I know, `gopkg.in` packages are handled as a special case in Go modules, see:
https://github.com/golang/go/issues/24099
https://github.com/golang/vgo/commit/56434976d0d97315aa58728a7b757784a825f4b1

There's no need to change the import path at all. Or is it?