### PR TITLE
Update GetTemplateResponse for v6.

### DIFF
--- a/indices_get_template.go
+++ b/indices_get_template.go
@@ -124,10 +124,10 @@ func (s *IndicesGetTemplateService) Do(ctx context.Context) (map[string]*Indices
 
 // IndicesGetTemplateResponse is the response of IndicesGetTemplateService.Do.
 type IndicesGetTemplateResponse struct {
-	Order    int                    `json:"order,omitempty"`
-	Version  int                    `json:"version,omitempty"`
-	Template string                 `json:"template,omitempty"`
-	Settings map[string]interface{} `json:"settings,omitempty"`
-	Mappings map[string]interface{} `json:"mappings,omitempty"`
-	Aliases  map[string]interface{} `json:"aliases,omitempty"`
+	Order         int                    `json:"order,omitempty"`
+	Version       int                    `json:"version,omitempty"`
+	IndexPatterns []string               `json:"index_patterns,omitempty"`
+	Settings      map[string]interface{} `json:"settings,omitempty"`
+	Mappings      map[string]interface{} `json:"mappings,omitempty"`
+	Aliases       map[string]interface{} `json:"aliases,omitempty"`
 }

--- a/indices_get_template_test.go
+++ b/indices_get_template_test.go
@@ -5,6 +5,7 @@
 package elastic
 
 import (
+	"context"
 	"testing"
 )
 
@@ -37,5 +38,55 @@ func TestIndexGetTemplateURL(t *testing.T) {
 		if path != test.Expected {
 			t.Errorf("expected %q; got: %q", test.Expected, path)
 		}
+	}
+}
+
+func TestIndexGetTemplateService(t *testing.T) {
+	client := setupTestClientAndCreateIndex(t)
+	create := true
+	body := `
+{
+  "index_patterns": ["te*"],
+  "settings": {
+    "index": {
+      "number_of_shards": 1
+    }
+  },
+  "mappings": {
+    "type1": {
+      "_source": {
+        "enabled": false
+      },
+      "properties": {
+        "host_name": {
+          "type": "keyword"
+        },
+        "created_at": {
+          "type": "date",
+          "format": "EEE MMM dd HH:mm:ss Z YYYY"
+        }
+      }
+    }
+  }
+}
+`
+	_, err := client.IndexPutTemplate(testIndexName).BodyString(body).Create(create).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.IndexGetTemplate(testIndexName).Do(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatalf("expected result; got: %v", res)
+	}
+	template := res[testIndexName]
+	if template == nil {
+		t.Fatalf("expected template %q to be != nil; got: %v", testIndexName, template)
+	}
+	if len(template.IndexPatterns) != 1 || template.IndexPatterns[0] != "te*" {
+		t.Fatalf("expected index settings of %q to be [\"index1\"]; got: %v", testIndexName, template.IndexPatterns)
 	}
 }


### PR DESCRIPTION
Closes https://github.com/olivere/elastic/issues/868.

Updates the `IndicesGetTemplateResponse` so that the `IndicesGetTemplateResponse` struct defines an `IndexPatterns` member not a `Template` member. In Elasticsearch v6, `index_patterns` is always returned instead of `template`. Adds a test to cover this struct.

As suggested in the issue, checked the response structure in the java source, and the rest of the response seems unchanged.