### PR TITLE
Add missing "missing" options to some aggregations

### DIFF
--- a/search_aggs_metrics_avg.go
+++ b/search_aggs_metrics_avg.go
@@ -14,6 +14,7 @@ package elastic
 type AvgAggregation struct {
 	field           string
 	script          *Script
+	missing         interface{}
 	format          string
 	subAggregations map[string]Aggregation
 	meta            map[string]interface{}
@@ -32,6 +33,12 @@ func (a *AvgAggregation) Field(field string) *AvgAggregation {
 
 func (a *AvgAggregation) Script(script *Script) *AvgAggregation {
 	a.script = script
+	return a
+}
+
+// Missing configures the value to use when documents miss a value.
+func (a *AvgAggregation) Missing(missing interface{}) *AvgAggregation {
+	a.missing = missing
 	return a
 }
 
@@ -74,6 +81,9 @@ func (a *AvgAggregation) Source() (interface{}, error) {
 			return nil, err
 		}
 		opts["script"] = src
+	}
+	if a.missing != nil {
+		opts["missing"] = a.missing
 	}
 
 	if a.format != "" {

--- a/search_aggs_metrics_avg_test.go
+++ b/search_aggs_metrics_avg_test.go
@@ -59,3 +59,20 @@ func TestAvgAggregationWithMetaData(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestAvgAggregationWithMissing(t *testing.T) {
+	agg := NewAvgAggregation().Field("grade").Missing(95)
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"avg":{"field":"grade","missing":95}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}

--- a/search_aggs_metrics_percentile_ranks.go
+++ b/search_aggs_metrics_percentile_ranks.go
@@ -9,6 +9,7 @@ package elastic
 type PercentileRanksAggregation struct {
 	field           string
 	script          *Script
+	missing         interface{}
 	format          string
 	subAggregations map[string]Aggregation
 	meta            map[string]interface{}
@@ -31,6 +32,12 @@ func (a *PercentileRanksAggregation) Field(field string) *PercentileRanksAggrega
 
 func (a *PercentileRanksAggregation) Script(script *Script) *PercentileRanksAggregation {
 	a.script = script
+	return a
+}
+
+// Missing configures the value to use when documents miss a value.
+func (a *PercentileRanksAggregation) Missing(missing interface{}) *PercentileRanksAggregation {
+	a.missing = missing
 	return a
 }
 
@@ -95,6 +102,9 @@ func (a *PercentileRanksAggregation) Source() (interface{}, error) {
 			return nil, err
 		}
 		opts["script"] = src
+	}
+	if a.missing != nil {
+		opts["missing"] = a.missing
 	}
 	if a.format != "" {
 		opts["format"] = a.format

--- a/search_aggs_metrics_percentile_ranks_test.go
+++ b/search_aggs_metrics_percentile_ranks_test.go
@@ -76,3 +76,20 @@ func TestPercentileRanksAggregationWithMetaData(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestPercentileRanksAggregationWithMissing(t *testing.T) {
+	agg := NewPercentileRanksAggregation().Field("load_time").Missing(12.4)
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"percentile_ranks":{"field":"load_time","missing":12.4}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}

--- a/search_aggs_metrics_percentiles.go
+++ b/search_aggs_metrics_percentiles.go
@@ -14,6 +14,7 @@ package elastic
 type PercentilesAggregation struct {
 	field           string
 	script          *Script
+	missing         interface{}
 	format          string
 	subAggregations map[string]Aggregation
 	meta            map[string]interface{}
@@ -36,6 +37,12 @@ func (a *PercentilesAggregation) Field(field string) *PercentilesAggregation {
 
 func (a *PercentilesAggregation) Script(script *Script) *PercentilesAggregation {
 	a.script = script
+	return a
+}
+
+// Missing configures the value to use when documents miss a value.
+func (a *PercentilesAggregation) Missing(missing interface{}) *PercentilesAggregation {
+	a.missing = missing
 	return a
 }
 
@@ -99,6 +106,9 @@ func (a *PercentilesAggregation) Source() (interface{}, error) {
 			return nil, err
 		}
 		opts["script"] = src
+	}
+	if a.missing != nil {
+		opts["missing"] = a.missing
 	}
 	if a.format != "" {
 		opts["format"] = a.format

--- a/search_aggs_metrics_percentiles_test.go
+++ b/search_aggs_metrics_percentiles_test.go
@@ -76,3 +76,20 @@ func TestPercentilesAggregationWithMetaData(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestPercentilesAggregationWithMissing(t *testing.T) {
+	agg := NewPercentilesAggregation().Field("price").Missing(95)
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"percentiles":{"field":"price","missing":95}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
A simple copy/paste job to add an option for averaging aggregators to use for missing data elements.