### PR TITLE
Changed headers type from http.Headers which is a map[string][]string…

### DIFF
--- a/tasks_list.go
+++ b/tasks_list.go
@@ -226,19 +226,19 @@ type DiscoveryNode struct {
 
 // TaskInfo represents information about a currently running task.
 type TaskInfo struct {
-	Node               string      `json:"node"`
-	Id                 int64       `json:"id"` // the task id (yes, this is a long in the Java source)
-	Type               string      `json:"type"`
-	Action             string      `json:"action"`
-	Status             interface{} `json:"status"`      // has separate implementations of Task.Status in Java for reindexing, replication, and "RawTaskStatus"
-	Description        interface{} `json:"description"` // same as Status
-	StartTime          string      `json:"start_time"`
-	StartTimeInMillis  int64       `json:"start_time_in_millis"`
-	RunningTime        string      `json:"running_time"`
-	RunningTimeInNanos int64       `json:"running_time_in_nanos"`
-	Cancellable        bool        `json:"cancellable"`
-	ParentTaskId       string      `json:"parent_task_id"` // like "YxJnVYjwSBm_AUbzddTajQ:12356"
-	Headers            http.Header `json:"headers"`
+	Node               string      	     `json:"node"`
+	Id                 int64       	     `json:"id"` // the task id (yes, this is a long in the Java source)
+	Type               string      	     `json:"type"`
+	Action             string      	     `json:"action"`
+	Status             interface{} 	     `json:"status"`      // has separate implementations of Task.Status in Java for reindexing, replication, and "RawTaskStatus"
+	Description        interface{} 	     `json:"description"` // same as Status
+	StartTime          string      	     `json:"start_time"`
+	StartTimeInMillis  int64       	     `json:"start_time_in_millis"`
+	RunningTime        string      	     `json:"running_time"`
+	RunningTimeInNanos int64       	     `json:"running_time_in_nanos"`
+	Cancellable        bool        	     `json:"cancellable"`
+	ParentTaskId       string      	     `json:"parent_task_id"` // like "YxJnVYjwSBm_AUbzddTajQ:12356"
+	Headers            map[string]string `json:"headers"`
 }
 
 // StartTaskResult is used in cases where a task gets started asynchronously and


### PR DESCRIPTION
… to map[string]string per elasticserch java documentation found here https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java

Without this type change, when you attempt to unmarshal a TasklistResponse, you get 
`json: cannot unmarshal object into Go struct field TaskInfo.headers of type []string`