### PR TITLE
Add SearchService.MaxResponseSize() to guard against OOM situations

### DIFF
--- a/client.go
+++ b/client.go
@@ -1230,14 +1230,15 @@ func (c *Client) mustActiveConn() error {
 
 // PerformRequestOptions must be passed into PerformRequest.
 type PerformRequestOptions struct {
-	Method       string
-	Path         string
-	Params       url.Values
-	Body         interface{}
-	ContentType  string
-	IgnoreErrors []int
-	Retrier      Retrier
-	Headers      http.Header
+	Method          string
+	Path            string
+	Params          url.Values
+	Body            interface{}
+	ContentType     string
+	IgnoreErrors    []int
+	Retrier         Retrier
+	Headers         http.Header
+	MaxResponseSize int64
 }
 
 // PerformRequest does a HTTP request to Elasticsearch.
@@ -1376,14 +1377,14 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 		if err := checkResponse((*http.Request)(req), res, opt.IgnoreErrors...); err != nil {
 			// No retry if request succeeded
 			// We still try to return a response.
-			resp, _ = c.newResponse(res)
+			resp, _ = c.newResponse(res, opt.MaxResponseSize)
 			return resp, err
 		}
 
 		// We successfully made a request with this connection
 		conn.MarkAsHealthy()
 
-		resp, err = c.newResponse(res)
+		resp, err = c.newResponse(res, opt.MaxResponseSize)
 		if err != nil {
 			return nil, err
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1173,6 +1173,33 @@ func TestPerformRequestWithCustomLogger(t *testing.T) {
 	}
 }
 
+func TestPerformRequestWithMaxResponseSize(t *testing.T) {
+	client, err := NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := client.PerformRequest(context.TODO(), PerformRequestOptions{
+		Method:          "GET",
+		Path:            "/",
+		MaxResponseSize: 1000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("expected response to be != nil")
+	}
+
+	res, err = client.PerformRequest(context.TODO(), PerformRequestOptions{
+		Method:          "GET",
+		Path:            "/",
+		MaxResponseSize: 100,
+	})
+	if err != ErrResponseSize {
+		t.Fatal("expected response size error")
+	}
+}
+
 // failingTransport will run a fail callback if it sees a given URL path prefix.
 type failingTransport struct {
 	path string                                      // path prefix to look for

--- a/response_test.go
+++ b/response_test.go
@@ -29,7 +29,7 @@ func BenchmarkResponse(b *testing.B) {
 			StatusCode: http.StatusOK,
 		}
 		var err error
-		resp, err = c.newResponse(res)
+		resp, err = c.newResponse(res, 0)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
`elastic` currently decodes the entire ES response uncritically, which can cause out-of-memory errors with very large responses. This adds a `MaxResponseSize()` method to `SearchService` which causes it to error out with `ErrResponseSize` if the ES response exceeds the provided limit.