### PR TITLE
Add Snapshot deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,8 @@ The cat APIs are not implemented as of now. We think they are better suited for 
 
 - Snapshot and Restore
   - [x] Repositories
-  - [x] Snapshot
+  - [x] Snapshot create
+  - [x] Snapshot delete
   - [ ] Restore
   - [ ] Snapshot status
   - [ ] Monitoring snapshot/restore status

--- a/snapshot_delete.go
+++ b/snapshot_delete.go
@@ -1,0 +1,124 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// SnapshotDeleteService is documented at https://www.elastic.co/guide/en/elasticsearch/reference/6.2/modules-snapshots.html.
+type SnapshotDeleteService struct {
+	client            *Client
+	pretty            bool
+	repository        string
+	snapshot          string
+	masterTimeout     string
+	waitForCompletion *bool
+	bodyJson          interface{}
+	bodyString        string
+}
+
+func (c *Client) SnapshotDelete(repository string, snapshot string) *SnapshotDeleteService {
+	return NewSnapshotDeleteService(c).Repository(repository).Snapshot(snapshot)
+}
+
+// NewSnapshotDeleteService creates a new SnapshotDeleteService.
+func NewSnapshotDeleteService(client *Client) *SnapshotDeleteService {
+	return &SnapshotDeleteService{
+		client: client,
+	}
+}
+
+// Repository is the repository name.
+func (s *SnapshotDeleteService) Repository(repository string) *SnapshotDeleteService {
+	s.repository = repository
+	return s
+}
+
+// Snapshot is the snapshot name.
+func (s *SnapshotDeleteService) Snapshot(snapshot string) *SnapshotDeleteService {
+	s.snapshot = snapshot
+	return s
+}
+
+// BodyJson is documented as: The snapshot definition.
+func (s *SnapshotDeleteService) BodyJson(body interface{}) *SnapshotDeleteService {
+	s.bodyJson = body
+	return s
+}
+
+// BodyString is documented as: The snapshot definition.
+func (s *SnapshotDeleteService) BodyString(body string) *SnapshotDeleteService {
+	s.bodyString = body
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *SnapshotDeleteService) buildURL() string {
+	// Build URL
+	path := fmt.Sprintf("/_snapshot/%s/%s", s.repository, s.snapshot)
+
+	return path
+}
+
+// Validate checks if the operation is valid.
+func (s *SnapshotDeleteService) Validate() error {
+	var invalid []string
+	if s.repository == "" {
+		invalid = append(invalid, "Repository")
+	}
+	if s.snapshot == "" {
+		invalid = append(invalid, "Snapshot")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *SnapshotDeleteService) Do(ctx context.Context) (*SnapshotDeleteResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path := s.buildURL()
+
+	// Setup HTTP request body
+	var body interface{}
+	if s.bodyJson != nil {
+		body = s.bodyJson
+	} else {
+		body = s.bodyString
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method: "DELETE",
+		Path:   path,
+		Body:   body,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(SnapshotDeleteResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// SnapshotDeleteResponse is the response of SnapshotDeleteService.Do.
+type SnapshotDeleteResponse struct {
+	// Accepted indicates whether the delete operation was successful.
+	// It's available when waitForCompletion is false.
+	Accepted *bool `json:"acknowledged"`
+}

--- a/snapshot_delete.go
+++ b/snapshot_delete.go
@@ -12,14 +12,11 @@ import (
 
 // SnapshotDeleteService is documented at https://www.elastic.co/guide/en/elasticsearch/reference/6.2/modules-snapshots.html.
 type SnapshotDeleteService struct {
-	client            *Client
-	pretty            bool
-	repository        string
-	snapshot          string
-	masterTimeout     string
-	waitForCompletion *bool
-	bodyJson          interface{}
-	bodyString        string
+	client     *Client
+	repository string
+	snapshot   string
+	bodyJson   interface{}
+	bodyString string
 }
 
 func (c *Client) SnapshotDelete(repository string, snapshot string) *SnapshotDeleteService {

--- a/snapshot_delete.go
+++ b/snapshot_delete.go
@@ -78,10 +78,10 @@ func (s *SnapshotDeleteService) Validate() error {
 }
 
 // Do executes the operation.
-func (s *SnapshotDeleteService) Do(ctx context.Context) (*SnapshotDeleteResponse, error) {
+func (s *SnapshotDeleteService) Do(ctx context.Context) (*SnapshotDeleteResponse, int, error) {
 	// Check pre-conditions
 	if err := s.Validate(); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// Get URL for request
@@ -102,15 +102,15 @@ func (s *SnapshotDeleteService) Do(ctx context.Context) (*SnapshotDeleteResponse
 		Body:   body,
 	})
 	if err != nil {
-		return nil, err
+		return nil, res.StatusCode, err
 	}
 
 	// Return operation response
 	ret := new(SnapshotDeleteResponse)
 	if err := json.Unmarshal(res.Body, ret); err != nil {
-		return nil, err
+		return nil, res.StatusCode, err
 	}
-	return ret, nil
+	return ret, res.StatusCode, nil
 }
 
 // SnapshotDeleteResponse is the response of SnapshotDeleteService.Do.

--- a/snapshot_delete_test.go
+++ b/snapshot_delete_test.go
@@ -1,0 +1,44 @@
+package elastic
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestSnapshotRepoValidate(t *testing.T) {
+	var client *Client
+
+	err := NewSnapshotDeleteService(client).Validate()
+	got := err.Error()
+	expected := "missing required fields: [Repository Snapshot]"
+	if got != expected {
+		t.Errorf("expected %q; got: %q", expected, got)
+	}
+}
+
+func TestSnapshotDeleteURL(t *testing.T) {
+	var client *Client
+
+	tests := []struct {
+		Repository     string
+		Snapshot       string
+		ExpectedPath   string
+		ExpectedParams url.Values
+	}{
+		{
+			Repository:   "repo",
+			Snapshot:     "snapshot_of_sunday",
+			ExpectedPath: "/_snapshot/repo/snapshot_of_sunday",
+		},
+	}
+
+	for _, test := range tests {
+		path := NewSnapshotDeleteService(client).client.SnapshotDelete(
+			test.Repository, test.Snapshot,
+		).buildURL()
+
+		if path != test.ExpectedPath {
+			t.Errorf("expected %q; got: %q", test.ExpectedPath, path)
+		}
+	}
+}


### PR DESCRIPTION
The Elasticsearch snapshot deletion API is a single endpoint that accepts a `DELETE` verb to delete a previously created snapshot.

This PR add 2 new files following the same structure used by `snapshot_create.go` but simplified for the delete feature.

1. snapshot_delete.go
2. snapshot_delete_test.go

I have it running successfully in an internal project, so pushing the contribution back upstream.

Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html