### PR TITLE
<Fix>: dereferencing the pointer cutoffFrequency, not get the address of cutoffFrequency

### DIFF
--- a/search_queries_match.go
+++ b/search_queries_match.go
@@ -176,7 +176,7 @@ func (q *MatchQuery) Source() (interface{}, error) {
 		query["zero_terms_query"] = q.zeroTermsQuery
 	}
 	if q.cutoffFrequency != nil {
-		query["cutoff_frequency"] = q.cutoffFrequency
+		query["cutoff_frequency"] = *q.cutoffFrequency
 	}
 	if q.boost != nil {
 		query["boost"] = *q.boost


### PR DESCRIPTION
i've opened a [issue](https://github.com/olivere/elastic/issues/958)

the weird thing is that even i've dereferenced the pointer cutoffFrequency, these commonTermsQuery and MatchQuery still don't return the same results...

Also check this [blog](https://www.elastic.co/blog/stop-stopping-stop-words-a-look-at-common-terms-query) if you're available and I quote `Note: Common Terms has also been incorporated into the Match query and can be enabled by setting `cutoff_frequency` to a value like 0.001` 

Making me feel that Common Terms Query and Match query can return same results in some way