### PR TITLE
search: added the feature to use a stored template at search time.

### DIFF
--- a/search.go
+++ b/search.go
@@ -320,6 +320,18 @@ func (s *SearchService) MaxResponseSize(maxResponseSize int64) *SearchService {
 	return s
 }
 
+// StoredTemplateId allows to specify Name of a stored template script.
+func (s *SearchService) StoredTemplateId(id string) *SearchService {
+	s.searchSource.StoredTemplateId(id)
+	return s
+}
+
+// Param allows to specify a parameter to use when searching with StoredTemplates.
+func (s *SearchService) Param(name string, value interface{}) *SearchService {
+	s.searchSource.Param(name, value)
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *SearchService) buildURL() (string, url.Values, error) {
 	var err error
@@ -343,6 +355,10 @@ func (s *SearchService) buildURL() (string, url.Values, error) {
 	}
 	if err != nil {
 		return "", url.Values{}, err
+	}
+
+	if s.searchSource.storedTemplateId != "" {
+		path = path + "/template"
 	}
 
 	// Add query string parameters

--- a/search_source.go
+++ b/search_source.go
@@ -40,6 +40,8 @@ type SearchSource struct {
 	innerHits                map[string]*InnerHit
 	collapse                 *CollapseBuilder
 	profile                  bool
+	storedTemplateId         string
+	params                   map[string]interface{}
 	// TODO extBuilders []SearchExtBuilder
 }
 
@@ -51,6 +53,7 @@ func NewSearchSource() *SearchSource {
 		aggregations: make(map[string]Aggregation),
 		indexBoosts:  make(map[string]float64),
 		innerHits:    make(map[string]*InnerHit),
+		params:       make(map[string]interface{}),
 	}
 }
 
@@ -338,6 +341,18 @@ func (s *SearchSource) Collapse(collapse *CollapseBuilder) *SearchSource {
 	return s
 }
 
+// StoredTemplateId allows to specify Name of a stored template script.
+func (s *SearchSource) StoredTemplateId(id string) *SearchSource {
+	s.storedTemplateId = id
+	return s
+}
+
+// Param allows to specify a parameter to use when searching with StoredTemplates.
+func (s *SearchSource) Param(name string, value interface{}) *SearchSource {
+	s.params[name] = value
+	return s
+}
+
 // Source returns the serializable JSON for the source builder.
 func (s *SearchSource) Source() (interface{}, error) {
 	source := make(map[string]interface{})
@@ -510,6 +525,14 @@ func (s *SearchSource) Source() (interface{}, error) {
 			return nil, err
 		}
 		source["collapse"] = src
+	}
+
+	if s.storedTemplateId != "" {
+		source["id"] = s.storedTemplateId
+	}
+
+	if len(s.params) > 0 {
+		source["params"] = s.params
 	}
 
 	if len(s.innerHits) > 0 {


### PR DESCRIPTION
sometimes there is a need to a stored template when we use search method, especially when our query is very large, it's a good practice to store the query in Elasticsearch first, then use the search method in client with template_id and some parameters to pass it.
link to elasticsearch feature: [Search Template](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html)