### PR TITLE
call MarkAsHealthy after response is read to avoid memory leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -1382,7 +1382,7 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 		}
 
 		// We successfully made a request with this connection
-		conn.MarkAsHealthy()
+		defer conn.MarkAsHealthy()
 
 		resp, err = c.newResponse(res, opt.MaxResponseSize)
 		if err != nil {


### PR DESCRIPTION
If the connection is marked healthy before the response is read, a new
request may reuse the connection and send a new HTTP request before the
previous ioutil.ReadAll returns. This may cause memory leak if the
connection is constantly being reused.
