### PR TITLE
Return the SearchResult, even in the case of EOF error, to allow for root cause analysis

### DIFF
--- a/scroll.go
+++ b/scroll.go
@@ -347,7 +347,7 @@ func (s *ScrollService) first(ctx context.Context) (*SearchResult, error) {
 	s.scrollId = ret.ScrollId
 	s.mu.Unlock()
 	if ret.Hits == nil || len(ret.Hits.Hits) == 0 {
-		return nil, io.EOF
+		return ret, io.EOF
 	}
 	return ret, nil
 }
@@ -474,7 +474,7 @@ func (s *ScrollService) next(ctx context.Context) (*SearchResult, error) {
 	s.scrollId = ret.ScrollId
 	s.mu.Unlock()
 	if ret.Hits == nil || len(ret.Hits.Hits) == 0 {
-		return nil, io.EOF
+		return ret, io.EOF
 	}
 	return ret, nil
 }


### PR DESCRIPTION
Upon performing a scrolled search with a scroll size greater than index.max_result_window, Elasticsearch will not process the request and return zero hits, thus leading to a blanket io.EOF error being returned by this client.

As the SearchResult is not returned with the io.EOF error, it is not problematically possible to inspect the root cause of the error, which resulted in us taking a PCAP in order to diagnose the issue.

By returning the SearchResult, along with the error, it allows for inspection of the Shards.Failures list to see the true reason why the query failed.