### PR TITLE
fix typo in HighlightQuery API call

### DIFF
--- a/highlight.go
+++ b/highlight.go
@@ -120,7 +120,7 @@ func (hl *Highlight) Fragmenter(fragmenter string) *Highlight {
 	return hl
 }
 
-func (hl *Highlight) HighlighQuery(highlightQuery Query) *Highlight {
+func (hl *Highlight) HighlightQuery(highlightQuery Query) *Highlight {
 	hl.highlightQuery = highlightQuery
 	return hl
 }


### PR DESCRIPTION
Hi! Just noticed a typo in the HighlightQuery API call on in `highlight.go` across several release versions. I suppose folks might already be dependent on the alternate spelling but just in case, I thought I'd submit a PR. Thanks, and once again great library 🙇 