### PR TITLE
godoc: fix typo

### DIFF
--- a/search_queries_exists.go
+++ b/search_queries_exists.go
@@ -14,7 +14,7 @@ type ExistsQuery struct {
 	queryName string
 }
 
-// NewExistsQuery creates and initializes a new dis max query.
+// NewExistsQuery creates and initializes a new exists query.
 func NewExistsQuery(name string) *ExistsQuery {
 	return &ExistsQuery{
 		name: name,


### PR DESCRIPTION
A simple copy-pasta typo within the godoc