### PR TITLE
Fix typo in HighlightQuery API call (release-branch.v5)

### DIFF
--- a/highlight.go
+++ b/highlight.go
@@ -125,7 +125,7 @@ func (hl *Highlight) Fragmenter(fragmenter string) *Highlight {
 	return hl
 }
 
-func (hl *Highlight) HighlighQuery(highlightQuery Query) *Highlight {
+func (hl *Highlight) HighlightQuery(highlightQuery Query) *Highlight {
 	hl.highlightQuery = highlightQuery
 	return hl
 }


### PR DESCRIPTION
- Fix the HighlightQuery API call typo on release-branch.v5 based on your fix on master branch.