### PR TITLE
Use %v to format nil argument in Fatalf

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -388,7 +388,7 @@ func ExampleAggregations() {
 		histogram, found := userBucket.DateHistogram("history")
 		if found {
 			for _, year := range histogram.Buckets {
-				fmt.Printf("user %q has %d tweets in %q\n", user, year.DocCount, year.KeyAsString)
+				fmt.Printf("user %q has %d tweets in %v\n", user, year.DocCount, year.KeyAsString)
 			}
 		}
 	}

--- a/search_aggs_test.go
+++ b/search_aggs_test.go
@@ -706,7 +706,7 @@ func TestAggs(t *testing.T) {
 		t.Errorf("expected %v; got: %v", 1.29384e+12, dateHistoRes.Buckets[0].Key)
 	}
 	if dateHistoRes.Buckets[0].KeyAsString == nil {
-		t.Fatalf("expected != nil; got: %q", dateHistoRes.Buckets[0].KeyAsString)
+		t.Fatalf("expected != nil; got: %v", dateHistoRes.Buckets[0].KeyAsString)
 	}
 	if *dateHistoRes.Buckets[0].KeyAsString != "2011-01-01T00:00:00.000Z" {
 		t.Errorf("expected %q; got: %q", "2011-01-01T00:00:00.000Z", *dateHistoRes.Buckets[0].KeyAsString)
@@ -718,7 +718,7 @@ func TestAggs(t *testing.T) {
 		t.Errorf("expected %v; got: %v", 1.325376e+12, dateHistoRes.Buckets[1].Key)
 	}
 	if dateHistoRes.Buckets[1].KeyAsString == nil {
-		t.Fatalf("expected != nil; got: %q", dateHistoRes.Buckets[1].KeyAsString)
+		t.Fatalf("expected != nil; got: %v", dateHistoRes.Buckets[1].KeyAsString)
 	}
 	if *dateHistoRes.Buckets[1].KeyAsString != "2012-01-01T00:00:00.000Z" {
 		t.Errorf("expected %q; got: %q", "2012-01-01T00:00:00.000Z", *dateHistoRes.Buckets[1].KeyAsString)

--- a/search_test.go
+++ b/search_test.go
@@ -352,7 +352,7 @@ func TestSearchSpecificFields(t *testing.T) {
 			t.Errorf("expected SearchResult.Hits.Hit.Index = %q; got %q", testIndexName, hit.Index)
 		}
 		if hit.Source != nil {
-			t.Fatalf("expected SearchResult.Hits.Hit.Source to be nil; got: %q", hit.Source)
+			t.Fatalf("expected SearchResult.Hits.Hit.Source to be nil; got: %v", hit.Source)
 		}
 		if hit.Fields == nil {
 			t.Fatal("expected SearchResult.Hits.Hit.Fields to be != nil")


### PR DESCRIPTION
Trivial suggestion to fix arguments to t.Fatalf in tests.