### PR TITLE
Add SearchSource to TopHitsAggregation

### DIFF
--- a/search_aggs_metrics_top_hits.go
+++ b/search_aggs_metrics_top_hits.go
@@ -24,6 +24,14 @@ func NewTopHitsAggregation() *TopHitsAggregation {
 	}
 }
 
+func (a *TopHitsAggregation) SearchSource(searchSource *SearchSource) *TopHitsAggregation {
+	a.searchSource = searchSource
+	if a.searchSource == nil {
+		a.searchSource = NewSearchSource()
+	}
+	return a
+}
+
 func (a *TopHitsAggregation) From(from int) *TopHitsAggregation {
 	a.searchSource = a.searchSource.From(from)
 	return a


### PR DESCRIPTION
This PR adds a `SearchSource` function to `TopHitsAggregation`, similar to the one exposed by `SearchService`. This makes it easier for users of the library to reuse code between the two cases.