### PR TITLE
Initialize TermsSetQuery values

### DIFF
--- a/search_queries_terms_set.go
+++ b/search_queries_terms_set.go
@@ -25,7 +25,8 @@ type TermsSetQuery struct {
 // NewTermsSetQuery creates and initializes a new TermsSetQuery.
 func NewTermsSetQuery(name string, values ...interface{}) *TermsSetQuery {
 	q := &TermsSetQuery{
-		name: name,
+		name:   name,
+		values: make([]interface{}, 0),
 	}
 	if len(values) > 0 {
 		q.values = append(q.values, values...)


### PR DESCRIPTION
If `values` is not initialized, and no values are provided, this attempts to send a `null` to ES instead of `[]`, resulting in an error.

Matches existing functionality from `TermsQuery` and `IdsQuery`

P.S.  Not sure if this is the right branch, it's just what github chose by default (would actually be nice to get it applied to all releases)