### PR TITLE
fix nodeid contains always _all

### DIFF
--- a/nodes_info.go
+++ b/nodes_info.go
@@ -30,7 +30,7 @@ type NodesInfoService struct {
 func NewNodesInfoService(client *Client) *NodesInfoService {
 	return &NodesInfoService{
 		client: client,
-		nodeId: []string{"_all"},
+		nodeId: make([]string, 0, 1),
 		metric: []string{"_all"},
 	}
 }
@@ -71,9 +71,15 @@ func (s *NodesInfoService) Pretty(pretty bool) *NodesInfoService {
 
 // buildURL builds the URL for the operation.
 func (s *NodesInfoService) buildURL() (string, url.Values, error) {
+	var nodeId string
+	if len(s.nodeId) > 0 {
+		nodeId = strings.Join(s.nodeId, ",")
+	} else {
+		nodeId = "_all"
+	}
 	// Build URL
 	path, err := uritemplates.Expand("/_nodes/{node_id}/{metric}", map[string]string{
-		"node_id": strings.Join(s.nodeId, ","),
+		"node_id": nodeId,
 		"metric":  strings.Join(s.metric, ","),
 	})
 	if err != nil {


### PR DESCRIPTION
This is my proposal for solving #1078.

It uses the nodeId `_all` only if no nodeid is set.
The empty check happens in the `buildURL()` method to allow calls to `NodeId()` after a `Do()` call happens on the same NodesInfoService.