### PR TITLE
Fix NoStoredFields to not yield any stored fields

### DIFF
--- a/search_source.go
+++ b/search_source.go
@@ -268,7 +268,7 @@ func (s *SearchSource) FetchSourceIncludeExclude(include, exclude []string) *Sea
 // NoStoredFields indicates that no fields should be loaded, resulting in only
 // id and type to be returned per field.
 func (s *SearchSource) NoStoredFields() *SearchSource {
-	s.storedFieldNames = nil
+	s.storedFieldNames = []string{}
 	return s
 }
 

--- a/search_source_test.go
+++ b/search_source_test.go
@@ -39,7 +39,7 @@ func TestSearchSourceNoStoredFields(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"query":{"match_all":{}}}`
+	expected := `{"query":{"match_all":{}},"stored_fields":[]}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
Currently `NoStoredFields()` has no effect as when the `storedFieldNames` is `nil` as no `stored_fields` property gets sent to Elasticsearch and thus all fields are returned. See https://github.com/olivere/elastic/blob/0534a7b1bf47b1ccf57e905491a641709f8a623d/search_source.go#L406-L413

This PR changes NoStoredFields to set `storedNamesFields` to an empty string slice and thereby send `"stored_fields": []` to Elasticsearch.