### PR TITLE
Implement XPack Security user-management API

### DIFF
--- a/client.go
+++ b/client.go
@@ -1901,6 +1901,36 @@ func (c *Client) XPackSecurityDeleteRole(roleName string) *XPackSecurityDeleteRo
 // TODO: Clear role cache API
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html
 
+// XPackSecurityGetUser gets a native user.
+func (c *Client) XPackSecurityGetUser(userName string) *XPackSecurityGetUserService {
+	return NewXPackSecurityGetUserService(c).Name(userName)
+}
+
+// XPackSecurityPutUser adds or updates a native user.
+func (c *Client) XPackSecurityPutUser(userName string) *XPackSecurityPutUserService {
+	return NewXPackSecurityPutUserService(c).Name(userName)
+}
+
+// XPackSecurityEnableUser enables a native user.
+func (c *Client) XPackSecurityEnableUser(userName string) *XPackSecurityEnableUserService {
+	return NewXPackSecurityEnableUserService(c).Name(userName)
+}
+
+// XPackSecurityEnableUser disables a native user.
+func (c *Client) XPackSecurityDisableUser(userName string) *XPackSecurityDisableUserService {
+	return NewXPackSecurityDisableUserService(c).Name(userName)
+}
+
+// XPackSecurityChangeUserPassword changes a native user's password.
+func (c *Client) XPackSecurityChangeUserPassword(userName string) *XPackSecurityChangeUserPasswordService {
+	return NewXPackSecurityChangeUserPasswordService(c).Name(userName)
+}
+
+// XPackSecurityDeleteUser deletes a native user.
+func (c *Client) XPackSecurityDeleteUser(userName string) *XPackSecurityDeleteUserService {
+	return NewXPackSecurityDeleteUserService(c).Name(userName)
+}
+
 // -- X-Pack Watcher --
 
 // XPackWatchPut adds a watch.

--- a/xpack_security_change_user_password.go
+++ b/xpack_security_change_user_password.go
@@ -1,0 +1,117 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/thales-e-security/elastic/uritemplates"
+	"net/url"
+)
+
+// XPackSecurityChangeUserPasswordService changes a native user's password.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/6.6/security-api-change-password.html.
+type XPackSecurityChangeUserPasswordService struct {
+	client *Client
+	pretty bool
+	name   string
+	body   interface{}
+}
+
+// NewXPackSecurityChangeUserPasswordService creates a new XPackSecurityChangeUserPasswordService.
+func NewXPackSecurityChangeUserPasswordService(client *Client) *XPackSecurityChangeUserPasswordService {
+	return &XPackSecurityChangeUserPasswordService{
+		client: client,
+	}
+}
+
+// Name is name of the user to change.
+func (s *XPackSecurityChangeUserPasswordService) Name(name string) *XPackSecurityChangeUserPasswordService {
+	s.name = name
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *XPackSecurityChangeUserPasswordService) Pretty(pretty bool) *XPackSecurityChangeUserPasswordService {
+	s.pretty = pretty
+	return s
+}
+
+// Body specifies the password. Use a string or a type that will get serialized as JSON.
+func (s *XPackSecurityChangeUserPasswordService) Body(body interface{}) *XPackSecurityChangeUserPasswordService {
+	s.body = body
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackSecurityChangeUserPasswordService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_xpack/security/user/{name}/_password", map[string]string{
+		"name": s.name,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "true")
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackSecurityChangeUserPasswordService) Validate() error {
+	var invalid []string
+	if s.name == "" {
+		invalid = append(invalid, "Name")
+	}
+	if s.body == nil {
+		invalid = append(invalid, "Body")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackSecurityChangeUserPasswordService) Do(ctx context.Context) (*XPackSecurityChangeUserPasswordResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method: "POST",
+		Path:   path,
+		Params: params,
+		Body:   s.body,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(XPackSecurityChangeUserPasswordResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// XPackSecurityChangeUserPasswordResponse is the response of XPackSecurityChangeUserPasswordService.Do.
+// A successful call returns an empty JSON structure '{}'
+type XPackSecurityChangeUserPasswordResponse struct {
+}

--- a/xpack_security_change_user_password_test.go
+++ b/xpack_security_change_user_password_test.go
@@ -1,0 +1,64 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "testing"
+
+func TestXPackSecurityChangeUserPasswordBuildURL(t *testing.T) {
+	client := setupTestClientForXpackSecurity(t)
+
+	tests := []struct {
+		Name         string
+		Body         interface{}
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			nil,
+			"",
+			true,
+		},
+		{
+			"my-user",
+			nil,
+			"",
+			true,
+		},
+		{
+			"",
+			`{}`,
+			"",
+			true,
+		},
+		{
+			"my-user",
+			`{}`,
+			"/_xpack/security/user/my-user/_password",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackSecurityChangeUserPassword(test.Name).Body(test.Body)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}

--- a/xpack_security_delete_user.go
+++ b/xpack_security_delete_user.go
@@ -1,0 +1,107 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/olivere/elastic/uritemplates"
+)
+
+// XPackSecurityDeleteUserService delete a native user by its name.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/6.6/security-api-delete-user.html.
+type XPackSecurityDeleteUserService struct {
+	client *Client
+	pretty bool
+	name   string
+}
+
+// NewXPackSecurityDeleteUserService creates a new XPackSecurityDeleteUserService.
+func NewXPackSecurityDeleteUserService(client *Client) *XPackSecurityDeleteUserService {
+	return &XPackSecurityDeleteUserService{
+		client: client,
+	}
+}
+
+// Name is name of the native user to delete.
+func (s *XPackSecurityDeleteUserService) Name(name string) *XPackSecurityDeleteUserService {
+	s.name = name
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *XPackSecurityDeleteUserService) Pretty(pretty bool) *XPackSecurityDeleteUserService {
+	s.pretty = pretty
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackSecurityDeleteUserService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_xpack/security/user/{name}", map[string]string{
+		"name": s.name,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "true")
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackSecurityDeleteUserService) Validate() error {
+	var invalid []string
+	if s.name == "" {
+		invalid = append(invalid, "Name")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackSecurityDeleteUserService) Do(ctx context.Context) (*XPackSecurityDeleteUserResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method: "DELETE",
+		Path:   path,
+		Params: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(XPackSecurityDeleteUserResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// XPackSecurityDeleteUserResponse is the response of XPackSecurityDeleteUserService.Do.
+type XPackSecurityDeleteUserResponse struct {
+	Found bool `json:"found"`
+}

--- a/xpack_security_delete_user_test.go
+++ b/xpack_security_delete_user_test.go
@@ -1,0 +1,51 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"testing"
+)
+
+func TestXPackSecurityDeleteUserBuildURL(t *testing.T) {
+	client := setupTestClientForXpackSecurity(t)
+
+	tests := []struct {
+		Name         string
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			"",
+			true,
+		},
+		{
+			"my-user",
+			"/_xpack/security/user/my-user",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackSecurityDeleteUser(test.Name)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}

--- a/xpack_security_disable_user.go
+++ b/xpack_security_disable_user.go
@@ -1,0 +1,95 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"fmt"
+	"github.com/thales-e-security/elastic/uritemplates"
+	"net/url"
+)
+
+// XPackSecurityDisableUserService disables a native user by its name.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/6.6/security-api-disable-user.html.
+type XPackSecurityDisableUserService struct {
+	client *Client
+	pretty bool
+	name   string
+}
+
+// NewXPackSecurityDisableUserService creates a new XPackSecurityDisableUserService.
+func NewXPackSecurityDisableUserService(client *Client) *XPackSecurityDisableUserService {
+	return &XPackSecurityDisableUserService{
+		client: client,
+	}
+}
+
+// Name is name of the user to create.
+func (s *XPackSecurityDisableUserService) Name(name string) *XPackSecurityDisableUserService {
+	s.name = name
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *XPackSecurityDisableUserService) Pretty(pretty bool) *XPackSecurityDisableUserService {
+	s.pretty = pretty
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackSecurityDisableUserService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_xpack/security/user/{name}/_disable", map[string]string{
+		"name": s.name,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "true")
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackSecurityDisableUserService) Validate() error {
+	var invalid []string
+	if s.name == "" {
+		invalid = append(invalid, "Name")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackSecurityDisableUserService) Do(ctx context.Context) error {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return err
+	}
+
+	// Get HTTP response
+	_, err = s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method: "PUT",
+		Path:   path,
+		Params: params,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/xpack_security_disable_user_test.go
+++ b/xpack_security_disable_user_test.go
@@ -1,0 +1,49 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "testing"
+
+func TestXPackSecurityDisableUserBuildURL(t *testing.T) {
+	client := setupTestClientForXpackSecurity(t)
+
+	tests := []struct {
+		Name         string
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			"",
+			true,
+		},
+		{
+			"my-user",
+			"/_xpack/security/user/my-user/_disable",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackSecurityDisableUser(test.Name)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}

--- a/xpack_security_enable_user.go
+++ b/xpack_security_enable_user.go
@@ -1,0 +1,95 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"fmt"
+	"github.com/thales-e-security/elastic/uritemplates"
+	"net/url"
+)
+
+// XPackSecurityEnableUserService enables a native user by its name.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/6.6/security-api-enable-user.html.
+type XPackSecurityEnableUserService struct {
+	client *Client
+	pretty bool
+	name   string
+}
+
+// NewXPackSecurityEnableUserService creates a new XPackSecurityEnableUserService.
+func NewXPackSecurityEnableUserService(client *Client) *XPackSecurityEnableUserService {
+	return &XPackSecurityEnableUserService{
+		client: client,
+	}
+}
+
+// Name is name of the user to create.
+func (s *XPackSecurityEnableUserService) Name(name string) *XPackSecurityEnableUserService {
+	s.name = name
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *XPackSecurityEnableUserService) Pretty(pretty bool) *XPackSecurityEnableUserService {
+	s.pretty = pretty
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackSecurityEnableUserService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_xpack/security/user/{name}/_enable", map[string]string{
+		"name": s.name,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "true")
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackSecurityEnableUserService) Validate() error {
+	var invalid []string
+	if s.name == "" {
+		invalid = append(invalid, "Name")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackSecurityEnableUserService) Do(ctx context.Context) error {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return err
+	}
+
+	// Get HTTP response
+	_, err = s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method: "PUT",
+		Path:   path,
+		Params: params,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/xpack_security_enable_user_test.go
+++ b/xpack_security_enable_user_test.go
@@ -1,0 +1,49 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "testing"
+
+func TestXPackSecurityEnableUserBuildURL(t *testing.T) {
+	client := setupTestClientForXpackSecurity(t)
+
+	tests := []struct {
+		Name         string
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			"",
+			true,
+		},
+		{
+			"my-user",
+			"/_xpack/security/user/my-user/_enable",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackSecurityEnableUser(test.Name)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}

--- a/xpack_security_get_user.go
+++ b/xpack_security_get_user.go
@@ -1,0 +1,117 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/thales-e-security/elastic/uritemplates"
+	"net/url"
+)
+
+// XPackSecurityGetUserService retrieves a native user by its name.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/6.6/security-api-get-user.html.
+type XPackSecurityGetUserService struct {
+	client *Client
+	pretty bool
+	name   string
+}
+
+// NewXPackSecurityGetUserService creates a new XPackSecurityGetUserService.
+func NewXPackSecurityGetUserService(client *Client) *XPackSecurityGetUserService {
+	return &XPackSecurityGetUserService{
+		client: client,
+	}
+}
+
+// Name is name of the user to retrieve.
+func (s *XPackSecurityGetUserService) Name(name string) *XPackSecurityGetUserService {
+	s.name = name
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *XPackSecurityGetUserService) Pretty(pretty bool) *XPackSecurityGetUserService {
+	s.pretty = pretty
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackSecurityGetUserService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_xpack/security/user/{name}", map[string]string{
+		"name": s.name,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "true")
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackSecurityGetUserService) Validate() error {
+	var invalid []string
+	if s.name == "" {
+		invalid = append(invalid, "Name")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackSecurityGetUserService) Do(ctx context.Context) (*XPackSecurityGetUserResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method: "GET",
+		Path:   path,
+		Params: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := XPackSecurityGetUserResponse{}
+	if err := json.Unmarshal(res.Body, &ret); err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+// XPackSecurityGetUserResponse is the response of XPackSecurityGetUserService.Do.
+type XPackSecurityGetUserResponse map[string]XPackSecurityUser
+
+// XPackSecurityUser is the native user object.
+//
+// The Java source for this struct is defined here:
+// https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/User.java
+type XPackSecurityUser struct {
+	Username string                 `json:"username"`
+	Roles    []string               `json:"roles"`
+	FullName string                 `json:"full_name"`
+	Email    string                 `json:"email"`
+	Metadata map[string]interface{} `json:"metadata"`
+	Enabled  bool                   `json:"enabled"`
+}

--- a/xpack_security_get_user_test.go
+++ b/xpack_security_get_user_test.go
@@ -1,0 +1,49 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "testing"
+
+func TestXPackSecurityGetUserBuildURL(t *testing.T) {
+	client := setupTestClientForXpackSecurity(t)
+
+	tests := []struct {
+		Name         string
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			"",
+			true,
+		},
+		{
+			"my-user",
+			"/_xpack/security/user/my-user",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackSecurityGetUser(test.Name)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}

--- a/xpack_security_put_user.go
+++ b/xpack_security_put_user.go
@@ -1,0 +1,121 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/thales-e-security/elastic/uritemplates"
+	"net/url"
+)
+
+// XPackSecurityPutUserService retrieves a native user by its name.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/6.6/security-api-put-user.html.
+type XPackSecurityPutUserService struct {
+	client *Client
+	pretty bool
+	name   string
+	body   interface{}
+}
+
+// NewXPackSecurityPutUserService creates a new XPackSecurityPutUserService.
+func NewXPackSecurityPutUserService(client *Client) *XPackSecurityPutUserService {
+	return &XPackSecurityPutUserService{
+		client: client,
+	}
+}
+
+// Name is name of the user to create.
+func (s *XPackSecurityPutUserService) Name(name string) *XPackSecurityPutUserService {
+	s.name = name
+	return s
+}
+
+// Pretty indicates that the JSON response be indented and human readable.
+func (s *XPackSecurityPutUserService) Pretty(pretty bool) *XPackSecurityPutUserService {
+	s.pretty = pretty
+	return s
+}
+
+// Body specifies the user. Use a string or a type that will get serialized as JSON.
+func (s *XPackSecurityPutUserService) Body(body interface{}) *XPackSecurityPutUserService {
+	s.body = body
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackSecurityPutUserService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_xpack/security/user/{name}", map[string]string{
+		"name": s.name,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if s.pretty {
+		params.Set("pretty", "true")
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackSecurityPutUserService) Validate() error {
+	var invalid []string
+	if s.name == "" {
+		invalid = append(invalid, "Name")
+	}
+	if s.body == nil {
+		invalid = append(invalid, "Body")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackSecurityPutUserService) Do(ctx context.Context) (*XPackSecurityPutUserResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method: "PUT",
+		Path:   path,
+		Params: params,
+		Body:   s.body,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(XPackSecurityPutUserResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// XPackSecurityPutUserResponse is the response of XPackSecurityPutUserService.Do.
+type XPackSecurityPutUserResponse struct {
+	User XPackSecurityPutUser `json:"user"`
+}
+
+type XPackSecurityPutUser struct {
+	Created bool `json:"created"`
+}

--- a/xpack_security_put_user_test.go
+++ b/xpack_security_put_user_test.go
@@ -1,0 +1,64 @@
+// Copyright 2012-2018 Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "testing"
+
+func TestXPackSecurityPutUserBuildURL(t *testing.T) {
+	client := setupTestClientForXpackSecurity(t)
+
+	tests := []struct {
+		Name         string
+		Body         interface{}
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			nil,
+			"",
+			true,
+		},
+		{
+			"my-user",
+			nil,
+			"",
+			true,
+		},
+		{
+			"",
+			`{}`,
+			"",
+			true,
+		},
+		{
+			"my-user",
+			`{}`,
+			"/_xpack/security/user/my-user",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackSecurityPutUser(test.Name).Body(test.Body)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}


### PR DESCRIPTION
These changes add support for the user-management functions of the [X-Pack security API](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/security-api.html#security-user-apis).