### PR TITLE
Fix decoding of some `CatIndicesResponseRow` fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,14 +266,12 @@ Here are a few tips on how to get used to Elastic:
 
 ### cat APIs
 
-The cat APIs are not implemented as of now. We think they are better suited for operating with Elasticsearch on the command line.
-
-- [ ] cat aliases
-- [ ] cat allocation
-- [ ] cat count
+- [X] cat aliases
+- [X] cat allocation
+- [X] cat count
 - [ ] cat fielddata
-- [ ] cat health
-- [ ] cat indices
+- [X] cat health
+- [X] cat indices
 - [ ] cat master
 - [ ] cat nodeattrs
 - [ ] cat nodes

--- a/cat_aliases_test.go
+++ b/cat_aliases_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCatAliases(t *testing.T) {
-	client := setupTestClientAndCreateIndexAndAddDocs(t) //, SetTraceLog(log.New(os.Stdout, "", 0)))
+	client := setupTestClientAndCreateIndexAndAddDocs(t, SetDecoder(&strictDecoder{})) //, SetTraceLog(log.New(os.Stdout, "", 0)))
 	ctx := context.Background()
 
 	// Add two aliases
@@ -30,7 +30,7 @@ func TestCatAliases(t *testing.T) {
 	}()
 
 	// Check all aliases
-	res, err := client.CatAliases().Pretty(true).Do(ctx)
+	res, err := client.CatAliases().Pretty(true).Columns("*").Do(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cat_allocation_test.go
+++ b/cat_allocation_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestCatAllocation(t *testing.T) {
-	client := setupTestClientAndCreateIndexAndAddDocs(t) // , SetTraceLog(log.New(os.Stdout, "", 0)))
+	client := setupTestClientAndCreateIndexAndAddDocs(t, SetDecoder(&strictDecoder{})) // , SetTraceLog(log.New(os.Stdout, "", 0)))
 	ctx := context.Background()
-	res, err := client.CatAllocation().Do(ctx)
+	res, err := client.CatAllocation().Columns("*").Do(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cat_count_test.go
+++ b/cat_count_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestCatCount(t *testing.T) {
-	client := setupTestClientAndCreateIndexAndAddDocs(t) // , SetTraceLog(log.New(os.Stdout, "", 0)))
+	client := setupTestClientAndCreateIndexAndAddDocs(t, SetDecoder(&strictDecoder{})) // , SetTraceLog(log.New(os.Stdout, "", 0)))
 	ctx := context.Background()
-	res, err := client.CatCount().Pretty(true).Do(ctx)
+	res, err := client.CatCount().Pretty(true).Columns("*").Do(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cat_health_test.go
+++ b/cat_health_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestCatHealth(t *testing.T) {
-	client := setupTestClientAndCreateIndexAndAddDocs(t) // , SetTraceLog(log.New(os.Stdout, "", 0)))
+	client := setupTestClientAndCreateIndexAndAddDocs(t, SetDecoder(&strictDecoder{})) // , SetTraceLog(log.New(os.Stdout, "", 0)))
 	ctx := context.Background()
-	res, err := client.CatHealth().Do(ctx)
+	res, err := client.CatHealth().Columns("*").Do(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cat_indices.go
+++ b/cat_indices.go
@@ -219,8 +219,8 @@ type CatIndicesResponseRow struct {
 	PriRequestCacheHitCount      int    `json:"pri.request_cache.hit_count,string"`  // request cache hit count on primaries
 	RequestCacheMissCount        int    `json:"request_cache.miss_count,string"`     // request cache miss count on primaries & replicas
 	PriRequestCacheMissCount     int    `json:"pri.request_cache.miss_count,string"` // request cache miss count on primaries
-	FlushTotal                   int    `json:"flush.total"`                         // number of flushes on primaries & replicas
-	PriFlushTotal                int    `json:"pri.flush.total"`                     // number of flushes on primaries
+	FlushTotal                   int    `json:"flush.total,string"`                  // number of flushes on primaries & replicas
+	PriFlushTotal                int    `json:"pri.flush.total,string"`              // number of flushes on primaries
 	FlushTotalTime               string `json:"flush.total_time"`                    // time spent in flush on primaries & replicas
 	PriFlushTotalTime            string `json:"pri.flush.total_time"`                // time spent in flush on primaries
 	GetCurrent                   int    `json:"get.current,string"`                  // number of current get ops on primaries & replicas
@@ -291,6 +291,7 @@ type CatIndicesResponseRow struct {
 	PriSearchScrollTime          string `json:"pri.search.scroll_time"`              // time scroll contexts held open on primaries, e.g. "0s"
 	SearchScrollTotal            int    `json:"search.scroll_total,string"`          // completed scroll contexts on primaries & replicas
 	PriSearchScrollTotal         int    `json:"pri.search.scroll_total,string"`      // completed scroll contexts on primaries
+	SearchThrottled              bool   `json:"search.throttled,string"`             // indicates if the index is search throttled
 	SegmentsCount                int    `json:"segments.count,string"`               // number of segments on primaries & replicas
 	PriSegmentsCount             int    `json:"pri.segments.count,string"`           // number of segments on primaries
 	SegmentsMemory               string `json:"segments.memory"`                     // memory used by segments on primaries & replicas, e.g. "1.3kb"
@@ -301,8 +302,8 @@ type CatIndicesResponseRow struct {
 	PriSegmentsVersionMapMemory  string `json:"pri.segments.version_map_memory"`     // memory used by version map on primaries, e.g. "0b"
 	SegmentsFixedBitsetMemory    string `json:"segments.fixed_bitset_memory"`        // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries & replicas, e.g. "0b"
 	PriSegmentsFixedBitsetMemory string `json:"pri.segments.fixed_bitset_memory"`    // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries, e.g. "0b"
-	WarmerCurrent                int    `json:"warmer.count,string"`                 // current warmer ops on primaries & replicas
-	PriWarmerCurrent             int    `json:"pri.warmer.count,string"`             // current warmer ops on primaries
+	WarmerCurrent                int    `json:"warmer.current,string"`               // current warmer ops on primaries & replicas
+	PriWarmerCurrent             int    `json:"pri.warmer.current,string"`           // current warmer ops on primaries
 	WarmerTotal                  int    `json:"warmer.total,string"`                 // total warmer ops on primaries & replicas
 	PriWarmerTotal               int    `json:"pri.warmer.total,string"`             // total warmer ops on primaries
 	WarmerTotalTime              string `json:"warmer.total_time"`                   // time spent in warmers on primaries & replicas, e.g. "47s"

--- a/cat_indices_test.go
+++ b/cat_indices_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestCatIndices(t *testing.T) {
-	client := setupTestClientAndCreateIndexAndAddDocs(t) // , SetTraceLog(log.New(os.Stdout, "", 0)))
+	client := setupTestClientAndCreateIndexAndAddDocs(t, SetDecoder(&strictDecoder{})) // , SetTraceLog(log.New(os.Stdout, "", 0)))
 	ctx := context.Background()
-	res, err := client.CatIndices().Do(ctx)
+	res, err := client.CatIndices().Columns("*").Do(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -5,7 +5,9 @@
 package elastic
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -290,6 +292,15 @@ type logger interface {
 	FailNow()
 	Log(args ...interface{})
 	Logf(format string, args ...interface{})
+}
+
+// strictDecoder returns an error if any JSON fields aren't decoded.
+type strictDecoder struct{}
+
+func (d *strictDecoder) Decode(data []byte, v interface{}) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
 }
 
 func setupTestClient(t logger, options ...ClientOptionFunc) (client *Client) {


### PR DESCRIPTION
This PR changes the tests for the `/_cat/*` endpoints to check that all fields returned by Elasticsearch get JSON-decoded, and fixes a couple of issues found with `CatIndicesResponseRow`.

It also updates the list of implemented cat APIs in the README.