### PR TITLE
Add include type name to create index API

### DIFF
--- a/indices_create_test.go
+++ b/indices_create_test.go
@@ -6,7 +6,10 @@ package elastic
 
 import (
 	"context"
+	"net/url"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIndicesLifecycle(t *testing.T) {
@@ -59,5 +62,40 @@ func TestIndicesCreateValidate(t *testing.T) {
 	}
 	if res != nil {
 		t.Fatalf("expected result to be == nil; got: %v", res)
+	}
+}
+
+func TestIndicesCreateService_buildParams(t *testing.T) {
+	tests := []struct {
+		pretty          bool
+		masterTimeout   string
+		timeout         string
+		includeTypeName bool
+		expectedParams  url.Values
+	}{
+		{
+			pretty:          true,
+			masterTimeout:   "3s",
+			timeout:         "5s",
+			includeTypeName: true,
+			expectedParams: url.Values{
+				"pretty":            []string{"true"},
+				"master_timeout":    []string{"3s"},
+				"timeout":           []string{"5s"},
+				"include_type_name": []string{"true"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		params := NewIndicesCreateService(nil).
+			Pretty(tt.pretty).
+			MasterTimeout(tt.masterTimeout).
+			Timeout(tt.timeout).
+			IncludeTypeName(tt.includeTypeName).
+			buildParams()
+		if want, have := tt.expectedParams, params; !cmp.Equal(want, have) {
+			t.Errorf("expected params=%#v; got: %#v\ndiff: %s", want, have, cmp.Diff(want, have))
+		}
 	}
 }

--- a/indices_exists.go
+++ b/indices_exists.go
@@ -26,6 +26,7 @@ type IndicesExistsService struct {
 	allowNoIndices    *bool
 	expandWildcards   string
 	local             *bool
+	includeTypeName   *bool
 }
 
 // NewIndicesExistsService creates and initializes a new IndicesExistsService.
@@ -77,6 +78,12 @@ func (s *IndicesExistsService) Pretty(pretty bool) *IndicesExistsService {
 	return s
 }
 
+// IncludeTypeName specifies whether requests and responses should include a type name.
+func (s *IndicesExistsService) IncludeTypeName(includeTypeName bool) *IndicesExistsService {
+	s.includeTypeName = &includeTypeName
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *IndicesExistsService) buildURL() (string, url.Values, error) {
 	// Build URL
@@ -103,6 +110,9 @@ func (s *IndicesExistsService) buildURL() (string, url.Values, error) {
 	}
 	if s.expandWildcards != "" {
 		params.Set("expand_wildcards", s.expandWildcards)
+	}
+	if s.includeTypeName != nil {
+		params.Set("include_type_name", fmt.Sprintf("%v", *s.includeTypeName))
 	}
 	return path, params, nil
 }


### PR DESCRIPTION
This commit adds the ability to specify the query string parameter
`include_type_name` which indicates whether requests and responses
should include a type name in the index mapping.

This is useful when you're on Elasticsearch 6.7 and would like to create an index without a mapping type in preparation for 7.0.  Related to https://www.elastic.co/guide/en/elasticsearch/reference/6.7/removal-of-types.html

What do you think @olivere?