### PR TITLE
Cannot reconnect if address changes

### DIFF
--- a/client.go
+++ b/client.go
@@ -723,7 +723,7 @@ func (c *Client) updateConns(conns []*conn) {
 	for _, conn := range conns {
 		var found bool
 		for _, oldConn := range c.conns {
-			if oldConn.NodeID() == conn.NodeID() {
+			if oldConn.NodeID() == conn.NodeID() && oldConn.URL() == conn.URL() {
 				// Take over the old connection
 				newConns = append(newConns, oldConn)
 				found = true


### PR DESCRIPTION
ES nodes may have their address changed while keeping their ID, in which cases a client may not be able to reconnect to it. This happens for instance with ES nodes deployed as kubernetes pods, after a rolling update.
