### PR TITLE
Update go.opencensus.io to 0.20.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9
-	go.opencensus.io v0.19.2
+	go.opencensus.io v0.20.1
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
This should(tm) be a small update of go.opencensus.io. The reason for the update is a circular-dependency in older versions, leading to https://github.com/golang/lint/issues/436 . The particular version updating to is taken from https://github.com/googleapis/google-cloud-go/issues/1359#issuecomment-480988126.