### PR TITLE
Add rest_total_hits_as_int to Search and Msearch API

### DIFF
--- a/msearch.go
+++ b/msearch.go
@@ -20,6 +20,7 @@ type MultiSearchService struct {
 	pretty                bool
 	maxConcurrentRequests *int
 	preFilterShardSize    *int
+	restTotalHitsAsInt    *bool
 }
 
 func NewMultiSearchService(client *Client) *MultiSearchService {
@@ -54,6 +55,11 @@ func (s *MultiSearchService) PreFilterShardSize(size int) *MultiSearchService {
 	return s
 }
 
+func (s *MultiSearchService) RestTotalHitsAsInt(v bool) *MultiSearchService {
+	s.restTotalHitsAsInt = &v
+	return s
+}
+
 func (s *MultiSearchService) Do(ctx context.Context) (*MultiSearchResult, error) {
 	// Build url
 	path := "/_msearch"
@@ -68,6 +74,9 @@ func (s *MultiSearchService) Do(ctx context.Context) (*MultiSearchResult, error)
 	}
 	if v := s.preFilterShardSize; v != nil {
 		params.Set("pre_filter_shard_size", fmt.Sprintf("%v", *v))
+	}
+	if v := s.restTotalHitsAsInt; v != nil {
+		params.Set("rest_total_hits_as_int", fmt.Sprintf("%v", *v))
 	}
 
 	// Set body

--- a/search.go
+++ b/search.go
@@ -17,21 +17,22 @@ import (
 
 // Search for documents in Elasticsearch.
 type SearchService struct {
-	client            *Client
-	searchSource      *SearchSource
-	source            interface{}
-	pretty            bool
-	filterPath        []string
-	searchType        string
-	index             []string
-	typ               []string
-	routing           string
-	preference        string
-	requestCache      *bool
-	ignoreUnavailable *bool
-	allowNoIndices    *bool
-	expandWildcards   string
-	maxResponseSize   int64
+	client             *Client
+	searchSource       *SearchSource
+	source             interface{}
+	pretty             bool
+	filterPath         []string
+	searchType         string
+	index              []string
+	typ                []string
+	routing            string
+	preference         string
+	requestCache       *bool
+	ignoreUnavailable  *bool
+	allowNoIndices     *bool
+	expandWildcards    string
+	maxResponseSize    int64
+	restTotalHitsAsInt *bool
 }
 
 // NewSearchService creates a new service for searching in Elasticsearch.
@@ -348,6 +349,15 @@ func (s *SearchService) MaxResponseSize(maxResponseSize int64) *SearchService {
 	return s
 }
 
+// RestTotalHitsAsInt returns hits.total as an int instead of an object
+// on 7.x
+//
+// See https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#hits-total-now-object-search-response
+func (s *SearchService) RestTotalHitsAsInt(v bool) *SearchService {
+	s.restTotalHitsAsInt = &v
+	return s
+}
+
 // buildURL builds the URL for the operation.
 func (s *SearchService) buildURL() (string, url.Values, error) {
 	var err error
@@ -401,6 +411,9 @@ func (s *SearchService) buildURL() (string, url.Values, error) {
 	}
 	if len(s.filterPath) > 0 {
 		params.Set("filter_path", strings.Join(s.filterPath, ","))
+	}
+	if s.restTotalHitsAsInt != nil {
+		params.Set("rest_total_hits_as_int", fmt.Sprintf("%v", *s.restTotalHitsAsInt))
 	}
 	return path, params, nil
 }


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#hits-total-now-object-search-response

To aid migration from 6.x to 7.x.

In 7.x hits.total in the search response is an object instead of an int.

rest_total_hits_as_int can be used to tell a 7.x server to return hits.total as a number so that it is compatible with the 6.x search response format.  By merging this change into the v6 branch, it will be possible to use the v6 version of the client against both 6.x and 7.x servers whilst migrating to 7.x