### PR TITLE
Add 'bool_prefix' type to multi-match query

### DIFF
--- a/search_queries_multi_match.go
+++ b/search_queries_multi_match.go
@@ -60,7 +60,7 @@ func (q *MultiMatchQuery) FieldWithBoost(field string, boost float64) *MultiMatc
 }
 
 // Type can be "best_fields", "boolean", "most_fields", "cross_fields",
-// "phrase", or "phrase_prefix".
+// "phrase", "phrase_prefix" or "bool_prefix"
 func (q *MultiMatchQuery) Type(typ string) *MultiMatchQuery {
 	var zero = float64(0.0)
 	var one = float64(1.0)
@@ -80,6 +80,9 @@ func (q *MultiMatchQuery) Type(typ string) *MultiMatchQuery {
 		q.tieBreaker = &zero
 	case "phrase_prefix":
 		q.typ = "phrase_prefix"
+		q.tieBreaker = &zero
+	case "bool_prefix":
+		q.typ = "bool_prefix"
 		q.tieBreaker = &zero
 	}
 	return q

--- a/search_queries_multi_match_test.go
+++ b/search_queries_multi_match_test.go
@@ -129,3 +129,20 @@ func TestMultiMatchQueryBestFieldsWithCustomTieBreaker(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestMultiMatchQueryBoolPrefix(t *testing.T) {
+	q := NewMultiMatchQuery("this is a test", "subject", "message").Type("bool_prefix")
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"multi_match":{"fields":["subject","message"],"query":"this is a test","tie_breaker":0,"type":"bool_prefix"}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
Add `bool_prefix` missing type of Multi-match query. 

Docs: https://www.elastic.co/guide/en/elasticsearch/reference/7.x/query-dsl-multi-match-query.html#multi-match-types