### PR TITLE
Add rollup search paramater

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Here are a few tips on how to get used to Elastic:
 - [x] Explain API
 - [x] Profile API
 - [x] Field Capabilities API
+- [x] Rollup Search API
 
 ### Aggregations
 


### PR DESCRIPTION
Based on the elasticsearch 7.0 rollup Restful API (https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rollup-search.html)
Changes
- Add rollup search paramater Into `Search Service`
- Add `Rollup` method to indicate this search request is searching for rollup index

Usage
```
func TestRollupSearch(t *testing.T) {
	esCli = GetEs()

	amountAggs := es7.NewSumAggregation().Field("amount")
	typeAggs := es7.NewTermsAggregation().Field("type").SubAggregation("amount", amountAggs)

	ss := esCli.Search().
		Index("transaction-summary").
		IgnoreUnavailable(true).
		Size(0).
		Rollup(true).
		Pretty(true).
		Aggregation("type", typeAggs)

	_, err := ss.Do(context.Background())
	if err != nil {
		t.Logf("%s", err)
	}
}
```