### PR TITLE
Range query: Follow latest DSL

### DIFF
--- a/search_aggs_bucket_filter_test.go
+++ b/search_aggs_bucket_filter_test.go
@@ -21,7 +21,7 @@ func TestFilterAggregation(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filter":{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}}}`
+	expected := `{"filter":{"range":{"stock":{"gt":0}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -41,7 +41,7 @@ func TestFilterAggregationWithSubAggregation(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"aggregations":{"avg_price":{"avg":{"field":"price"}}},"filter":{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}}}`
+	expected := `{"aggregations":{"avg_price":{"avg":{"field":"price"}}},"filter":{"range":{"stock":{"gt":0}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -59,7 +59,7 @@ func TestFilterAggregationWithMeta(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filter":{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},"meta":{"name":"Oliver"}}`
+	expected := `{"filter":{"range":{"stock":{"gt":0}}},"meta":{"name":"Oliver"}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_aggs_bucket_filters_test.go
+++ b/search_aggs_bucket_filters_test.go
@@ -22,7 +22,7 @@ func TestFiltersAggregationFilters(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filters":{"filters":[{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"symbol":"GOOG"}}]}}`
+	expected := `{"filters":{"filters":[{"range":{"stock":{"gt":0}}},{"term":{"symbol":"GOOG"}}]}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -43,7 +43,7 @@ func TestFiltersAggregationFilterWithName(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filters":{"filters":{"f1":{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},"f2":{"term":{"symbol":"GOOG"}}}}}`
+	expected := `{"filters":{"filters":{"f1":{"range":{"stock":{"gt":0}}},"f2":{"term":{"symbol":"GOOG"}}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -73,7 +73,7 @@ func TestFiltersAggregationWithSubAggregation(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"aggregations":{"avg_price":{"avg":{"field":"price"}}},"filters":{"filters":[{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"symbol":"GOOG"}}]}}`
+	expected := `{"aggregations":{"avg_price":{"avg":{"field":"price"}}},"filters":{"filters":[{"range":{"stock":{"gt":0}}},{"term":{"symbol":"GOOG"}}]}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -92,7 +92,7 @@ func TestFiltersAggregationWithMetaData(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"filters":{"filters":[{"range":{"stock":{"from":0,"include_lower":false,"include_upper":true,"to":null}}},{"term":{"symbol":"GOOG"}}]},"meta":{"name":"Oliver"}}`
+	expected := `{"filters":{"filters":[{"range":{"stock":{"gt":0}}},{"term":{"symbol":"GOOG"}}]},"meta":{"name":"Oliver"}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_bool_test.go
+++ b/search_queries_bool_test.go
@@ -26,7 +26,7 @@ func TestBoolQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"bool":{"_name":"Test","boost":10,"filter":{"term":{"account":"1"}},"must":{"term":{"tag":"wow"}},"must_not":{"range":{"age":{"from":10,"include_lower":true,"include_upper":true,"to":20}}},"should":[{"term":{"tag":"sometag"}},{"term":{"tag":"sometagtag"}}]}}`
+	expected := `{"bool":{"_name":"Test","boost":10,"filter":{"term":{"account":"1"}},"must":{"term":{"tag":"wow"}},"must_not":{"range":{"age":{"gte":10,"lte":20}}},"should":[{"term":{"tag":"sometag"}},{"term":{"tag":"sometagtag"}}]}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_boosting_test.go
+++ b/search_queries_boosting_test.go
@@ -23,7 +23,7 @@ func TestBoostingQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"boosting":{"negative":{"range":{"age":{"from":10,"include_lower":true,"include_upper":true,"to":20}}},"negative_boost":0.2,"positive":{"term":{"tag":"wow"}}}}`
+	expected := `{"boosting":{"negative":{"range":{"age":{"gte":10,"lte":20}}},"negative_boost":0.2,"positive":{"term":{"tag":"wow"}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_nested_test.go
+++ b/search_queries_nested_test.go
@@ -23,7 +23,7 @@ func TestNestedQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"nested":{"_name":"qname","path":"obj1","query":{"bool":{"must":[{"term":{"obj1.name":"blue"}},{"range":{"obj1.count":{"from":5,"include_lower":false,"include_upper":true,"to":null}}}]}}}}`
+	expected := `{"nested":{"_name":"qname","path":"obj1","query":{"bool":{"must":[{"term":{"obj1.name":"blue"}},{"range":{"obj1.count":{"gt":5}}}]}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -45,7 +45,7 @@ func TestNestedQueryWithInnerHit(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"nested":{"_name":"qname","inner_hits":{"name":"comments","query":{"term":{"user":"olivere"}}},"path":"obj1","query":{"bool":{"must":[{"term":{"obj1.name":"blue"}},{"range":{"obj1.count":{"from":5,"include_lower":false,"include_upper":true,"to":null}}}]}}}}`
+	expected := `{"nested":{"_name":"qname","inner_hits":{"name":"comments","query":{"term":{"user":"olivere"}}},"path":"obj1","query":{"bool":{"must":[{"term":{"obj1.name":"blue"}},{"range":{"obj1.count":{"gt":5}}}]}}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}

--- a/search_queries_range.go
+++ b/search_queries_range.go
@@ -9,80 +9,60 @@ package elastic
 // For details, see
 // https://www.elastic.co/guide/en/elasticsearch/reference/7.0/query-dsl-range-query.html
 type RangeQuery struct {
-	name         string
-	from         interface{}
-	to           interface{}
-	timeZone     string
-	includeLower bool
-	includeUpper bool
-	boost        *float64
-	queryName    string
-	format       string
-	relation     string
+	name      string
+	gt        interface{}
+	gte       interface{}
+	lt        interface{}
+	lte       interface{}
+	timeZone  string
+	boost     *float64
+	queryName string
+	format    string
+	relation  string
 }
 
 // NewRangeQuery creates and initializes a new RangeQuery.
 func NewRangeQuery(name string) *RangeQuery {
-	return &RangeQuery{name: name, includeLower: true, includeUpper: true}
+	return &RangeQuery{name: name}
 }
 
 // From indicates the from part of the RangeQuery.
 // Use nil to indicate an unbounded from part.
 func (q *RangeQuery) From(from interface{}) *RangeQuery {
-	q.from = from
-	return q
+	return q.Gte(from)
 }
 
 // Gt indicates a greater-than value for the from part.
 // Use nil to indicate an unbounded from part.
 func (q *RangeQuery) Gt(from interface{}) *RangeQuery {
-	q.from = from
-	q.includeLower = false
+	q.gt = from
 	return q
 }
 
 // Gte indicates a greater-than-or-equal value for the from part.
 // Use nil to indicate an unbounded from part.
 func (q *RangeQuery) Gte(from interface{}) *RangeQuery {
-	q.from = from
-	q.includeLower = true
+	q.gte = from
 	return q
 }
 
 // To indicates the to part of the RangeQuery.
 // Use nil to indicate an unbounded to part.
 func (q *RangeQuery) To(to interface{}) *RangeQuery {
-	q.to = to
-	return q
+	return q.Lte(to)
 }
 
 // Lt indicates a less-than value for the to part.
 // Use nil to indicate an unbounded to part.
 func (q *RangeQuery) Lt(to interface{}) *RangeQuery {
-	q.to = to
-	q.includeUpper = false
+	q.lt = to
 	return q
 }
 
 // Lte indicates a less-than-or-equal value for the to part.
 // Use nil to indicate an unbounded to part.
 func (q *RangeQuery) Lte(to interface{}) *RangeQuery {
-	q.to = to
-	q.includeUpper = true
-	return q
-}
-
-// IncludeLower indicates whether the lower bound should be included or not.
-// Defaults to true.
-func (q *RangeQuery) IncludeLower(includeLower bool) *RangeQuery {
-	q.includeLower = includeLower
-	return q
-}
-
-// IncludeUpper indicates whether the upper bound should be included or not.
-// Defaults to true.
-func (q *RangeQuery) IncludeUpper(includeUpper bool) *RangeQuery {
-	q.includeUpper = includeUpper
+	q.lte = to
 	return q
 }
 
@@ -130,8 +110,22 @@ func (q *RangeQuery) Source() (interface{}, error) {
 	params := make(map[string]interface{})
 	rangeQ[q.name] = params
 
-	params["from"] = q.from
-	params["to"] = q.to
+	if nil != q.gt {
+		params["gt"] = q.gt
+	}
+
+	if nil != q.gte {
+		params["gte"] = q.gte
+	}
+
+	if nil != q.lt {
+		params["lt"] = q.lt
+	}
+
+	if nil != q.lte {
+		params["lte"] = q.lte
+	}
+
 	if q.timeZone != "" {
 		params["time_zone"] = q.timeZone
 	}
@@ -144,8 +138,6 @@ func (q *RangeQuery) Source() (interface{}, error) {
 	if q.boost != nil {
 		params["boost"] = *q.boost
 	}
-	params["include_lower"] = q.includeLower
-	params["include_upper"] = q.includeUpper
 
 	if q.queryName != "" {
 		rangeQ["_name"] = q.queryName

--- a/search_queries_range_test.go
+++ b/search_queries_range_test.go
@@ -21,7 +21,7 @@ func TestRangeQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"_name":"my_query","postDate":{"boost":3,"from":"2010-03-01","include_lower":true,"include_upper":true,"relation":"within","to":"2010-04-01"}}}`
+	expected := `{"range":{"_name":"my_query","postDate":{"boost":3,"gte":"2010-03-01","lte":"2010-04-01","relation":"within"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -41,7 +41,7 @@ func TestRangeQueryWithTimeZone(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"born":{"from":"2012-01-01","include_lower":true,"include_upper":true,"time_zone":"+1:00","to":"now"}}}`
+	expected := `{"range":{"born":{"gte":"2012-01-01","lte":"now","time_zone":"+1:00"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -61,7 +61,7 @@ func TestRangeQueryWithFormat(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"born":{"format":"yyyy/MM/dd","from":"2012/01/01","include_lower":true,"include_upper":true,"to":"now"}}}`
+	expected := `{"range":{"born":{"format":"yyyy/MM/dd","gte":"2012/01/01","lte":"now"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
DSL for branch 7.x already changed, from/to/include_lower/include_upper are gone:

https://www.elastic.co/guide/en/elasticsearch/reference/7.0/query-dsl-range-query.html
