### PR TITLE
Fixes #1192 Close every valid res.Body to stop network leak

### DIFF
--- a/aws/v4/aws_v4.go
+++ b/aws/v4/aws_v4.go
@@ -6,6 +6,7 @@ package v4
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -71,11 +72,17 @@ func (st Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 	resp, err := st.client.Do(req)
+
+	//Make sure resp.Body is closed, if it exists, regardless of error state
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	if resp.Body != nil {
-		defer resp.Body.Close()
 		buf := new(bytes.Buffer)
 		_, err = buf.ReadFrom(resp.Body)
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -949,15 +949,13 @@ func (c *Client) sniffNode(ctx context.Context, url string) []*conn {
 	c.mu.RUnlock()
 
 	res, err := c.c.Do((*http.Request)(req).WithContext(ctx))
+
+	//Make sure resp.Body is closed, if it exists, regardless of error state
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		return nodes
-	}
-	if res == nil {
-		return nodes
-	}
-
-	if res.Body != nil {
-		defer res.Body.Close()
 	}
 
 	var info NodesInfoResponse
@@ -1342,6 +1340,12 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 
 		// Get response
 		res, err := c.c.Do((*http.Request)(req).WithContext(ctx))
+
+		//Make sure res.Body is closed, if it exists, regardless of error state
+		if res != nil && res.Body != nil {
+			defer res.Body.Close()
+		}
+
 		if IsContextErr(err) {
 			// Proceed, but don't mark the node as dead
 			return nil, err
@@ -1362,9 +1366,6 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 			retried = true
 			time.Sleep(wait)
 			continue // try again
-		}
-		if res.Body != nil {
-			defer res.Body.Close()
 		}
 
 		// Tracing

--- a/ping.go
+++ b/ping.go
@@ -110,10 +110,13 @@ func (s *PingService) Do(ctx context.Context) (*PingResult, int, error) {
 	}
 
 	res, err := s.client.c.Do((*http.Request)(req).WithContext(ctx))
+	//Make sure resp.Body is closed, if it exists, regardless of error state
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		return nil, 0, err
 	}
-	defer res.Body.Close()
 
 	var ret *PingResult
 	if !s.httpHeadOnly {


### PR DESCRIPTION
Fix network leak when res.Body co-exists with a non-nil err object