### PR TITLE
XPackWatchStatus.ExecutionState should be string

### DIFF
--- a/xpack_watcher_get_watch.go
+++ b/xpack_watcher_get_watch.go
@@ -168,7 +168,7 @@ type XPackWatchStatus struct {
 	LastChecked      *time.Time                         `json:"last_checked,omitempty"`
 	LastMetCondition *time.Time                         `json:"last_met_condition,omitempty"`
 	Actions          map[string]*XPackWatchActionStatus `json:"actions,omitempty"`
-	ExecutionState   *XPackWatchActionExecutionState    `json:"execution_state,omitempty"`
+	ExecutionState   string                             `json:"execution_state,omitempty"`
 	Headers          map[string]string                  `json:"headers,omitempty"`
 	Version          int64                              `json:"version"`
 }
@@ -188,12 +188,6 @@ type XPackWatchActionStatus struct {
 type XPackWatchActionAckStatus struct {
 	Timestamp      time.Time `json:"timestamp"`
 	AckStatusState string    `json:"ack_status_state"`
-}
-
-type XPackWatchActionExecutionState struct {
-	Timestamp  time.Time `json:"timestamp"`
-	Successful bool      `json:"successful"`
-	Reason     string    `json:"reason,omitempty"`
 }
 
 type XPackWatchActionThrottle struct {


### PR DESCRIPTION
Elastic 7.3.2 and all earlier versions that I have seen do not use an
object for `execution_status`, but instead use a string. Execution state
is not mentioned at all in the current documentation.

#1006 f438c83fc introduced decoding of the `_watches/watch/$NAME` response. 

XPackWatchGetService.Do fails with `json: cannot unmarshal string into
Go struct field XPackWatchStatus.status.execution_state of type
elastic.XPackWatchActionExecutionState`.

This commit changes the type of XpackWatchStatus to string so that the
XPackWatchGetService.Do method succeeds.