### PR TITLE
Set XPackWatchActionStatus members to type XPackWatchActionExecutionState

### DIFF
--- a/xpack_watcher_get_watch.go
+++ b/xpack_watcher_get_watch.go
@@ -179,15 +179,21 @@ type XPackWatchExecutionState struct {
 }
 
 type XPackWatchActionStatus struct {
-	AckStatus               *XPackWatchActionAckStatus `json:"ack"`
-	LastExecution           *time.Time                 `json:"last_execution,omitempty"`
-	LastSuccessfulExecution *time.Time                 `json:"last_successful_execution,omitempty"`
-	LastThrottle            *XPackWatchActionThrottle  `json:"last_throttle,omitempty"`
+	AckStatus               *XPackWatchActionAckStatus      `json:"ack"`
+	LastExecution           *XPackWatchActionExecutionState `json:"last_execution,omitempty"`
+	LastSuccessfulExecution *XPackWatchActionExecutionState `json:"last_successful_execution,omitempty"`
+	LastThrottle            *XPackWatchActionThrottle       `json:"last_throttle,omitempty"`
 }
 
 type XPackWatchActionAckStatus struct {
 	Timestamp      time.Time `json:"timestamp"`
 	AckStatusState string    `json:"ack_status_state"`
+}
+
+type XPackWatchActionExecutionState struct {
+	Timestamp  time.Time `json:"timestamp"`
+	Successful bool      `json:"successful"`
+	Reason     string    `json:"reason,omitempty"`
 }
 
 type XPackWatchActionThrottle struct {

--- a/xpack_watcher_get_watch_test.go
+++ b/xpack_watcher_get_watch_test.go
@@ -5,6 +5,8 @@
 package elastic
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -47,5 +49,51 @@ func TestXPackWatcherGetWatchBuildURL(t *testing.T) {
 				t.Errorf("case #%d: expected %q; got: %q", i+1, test.Expected, path)
 			}
 		}
+	}
+}
+
+func TestXPackWatchActionStatus_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		Input     []byte
+		ExpectErr bool
+	}{
+		{
+			[]byte(`
+			   {
+			     "ack" : {
+			       "timestamp" : "2019-10-22T15:01:12.163Z",
+			       "state" : "ackable"
+			     },
+			     "last_execution" : {
+			       "timestamp" : "2019-10-22T15:01:12.163Z",
+			       "successful" : true
+			     },
+			     "last_successful_execution" : {
+			       "timestamp" : "2019-10-22T15:01:12.163Z",
+			       "successful" : true
+			     }
+			   }
+			`),
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var status XPackWatchActionStatus
+			err := json.Unmarshal(test.Input, &status)
+			if err != nil {
+				t.Error(err)
+			}
+			if status.AckStatus == nil {
+				t.Error("nil AckStatus")
+			}
+			if status.LastExecution == nil {
+				t.Error("nil LastExecution")
+			}
+			if status.LastSuccessfulExecution == nil {
+				t.Error("nil LastSuccessfulExecution")
+			}
+		})
 	}
 }


### PR DESCRIPTION
XPackWatchActionStatus.LastExecution and LastSuccessfulExecution members
were of type `*time.Time`, but Elastic returns an object here. This was
the opposite case with XPackWatchStatus.ExecutionState which we changed
to a string because Elastic emits strings in #1211.

Without this change we get a parse error:
```
parsing time \"{\"timestamp\":\"2019-10-22T15:07:37.519Z\",\"successful\":true}\" as \"\"2006-01-02T15:04:05Z07:00\"\": cannot parse \"{\"timestamp\":\"2019-10-22T15:07:37.519Z\",\"successful\":true}\" as \"\"\"
```