### PR TITLE
#1207 Expose sigma in ExtendedStatsAggregation

### DIFF
--- a/search_aggs_metrics_extended_stats.go
+++ b/search_aggs_metrics_extended_stats.go
@@ -13,6 +13,8 @@ type ExtendedStatsAggregation struct {
 	field           string
 	script          *Script
 	format          string
+	sigma           float64
+	sigmaSet        bool
 	missing         interface{}
 	subAggregations map[string]Aggregation
 	meta            map[string]interface{}
@@ -36,6 +38,12 @@ func (a *ExtendedStatsAggregation) Script(script *Script) *ExtendedStatsAggregat
 
 func (a *ExtendedStatsAggregation) Format(format string) *ExtendedStatsAggregation {
 	a.format = format
+	return a
+}
+
+func (a *ExtendedStatsAggregation) Sigma(sigma float64) *ExtendedStatsAggregation {
+	a.sigma = sigma
+	a.sigmaSet = true
 	return a
 }
 
@@ -84,6 +92,9 @@ func (a *ExtendedStatsAggregation) Source() (interface{}, error) {
 	}
 	if a.missing != nil {
 		opts["missing"] = a.missing
+	}
+	if a.sigmaSet && a.sigma >= 0 {
+		opts["sigma"] = a.sigma
 	}
 
 	// AggregationBuilder (SubAggregations)

--- a/search_aggs_metrics_extended_stats_test.go
+++ b/search_aggs_metrics_extended_stats_test.go
@@ -45,3 +45,45 @@ func TestExtendedStatsAggregationWithOptions(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestExtendedStatsAggregationWithSigma(t *testing.T) {
+	agg := NewExtendedStatsAggregation().
+		Field("grade").
+		Format("000.0").
+		Missing(1.2).
+		Sigma(1.6)
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"extended_stats":{"field":"grade","format":"000.0","missing":1.2,"sigma":1.6}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestExtendedStatsAggregationWithInvalidSigma(t *testing.T) {
+	agg := NewExtendedStatsAggregation().
+		Field("grade").
+		Format("000.0").
+		Missing(1.2).
+		Sigma(-1.0)
+	src, err := agg.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"extended_stats":{"field":"grade","format":"000.0","missing":1.2}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
This PR adds the `sigma` field to `ExtendedStatsAggregation`.

Addresses #1207 
