### PR TITLE
Prefer strings.Builder over bytes.Buffer for building the bulk body.

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -5,7 +5,6 @@
 package elastic
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -211,7 +210,8 @@ func (s *BulkService) NumberOfActions() int {
 
 func (s *BulkService) bodyAsString() (string, error) {
 	// Pre-allocate to reduce allocs
-	buf := bytes.NewBuffer(make([]byte, 0, s.EstimatedSizeInBytes()))
+	var buf strings.Builder
+	buf.Grow(int(s.EstimatedSizeInBytes()))
 
 	for _, req := range s.requests {
 		source, err := req.Source()


### PR DESCRIPTION
The strings.Builder type is designed to mimimize memory copying.  

**Note strings.Builder available since go 1.10**