### PR TITLE
removed types from updates

### DIFF
--- a/update.go
+++ b/update.go
@@ -27,7 +27,6 @@ type UpdateService struct {
 	headers    http.Header // custom request-level HTTP headers
 
 	index               string
-	typ                 string
 	id                  string
 	routing             string
 	parent              string
@@ -53,7 +52,6 @@ type UpdateService struct {
 func NewUpdateService(client *Client) *UpdateService {
 	return &UpdateService{
 		client: client,
-		typ:    "_doc",
 		fields: make([]string, 0),
 	}
 }
@@ -108,7 +106,6 @@ func (s *UpdateService) Index(name string) *UpdateService {
 //
 // Deprecated: Types are in the process of being removed.
 func (s *UpdateService) Type(typ string) *UpdateService {
-	s.typ = typ
 	return s
 }
 
@@ -257,18 +254,10 @@ func (s *UpdateService) url() (string, url.Values, error) {
 	// Build url
 	var path string
 	var err error
-	if s.typ == "" || s.typ == "_doc" {
-		path, err = uritemplates.Expand("/{index}/_update/{id}", map[string]string{
-			"index": s.index,
-			"id":    s.id,
-		})
-	} else {
-		path, err = uritemplates.Expand("/{index}/{type}/{id}/_update", map[string]string{
-			"index": s.index,
-			"type":  s.typ,
-			"id":    s.id,
-		})
-	}
+	path, err = uritemplates.Expand("/{index}/_doc/{id}", map[string]string{
+		"index": s.index,
+		"id":    s.id,
+	})
 	if err != nil {
 		return "", url.Values{}, err
 	}

--- a/update_test.go
+++ b/update_test.go
@@ -21,7 +21,7 @@ func TestUpdateViaScript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to return URL, got: %v", err)
 	}
-	expectedPath := `/test/type1/1/_update`
+	expectedPath := `/test/_doc/1`
 	if expectedPath != path {
 		t.Errorf("expected URL path\n%s\ngot:\n%s", expectedPath, path)
 	}
@@ -65,7 +65,7 @@ func TestUpdateViaScriptId(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to return URL, got: %v", err)
 	}
-	expectedPath := `/sessions/session/dh3sgudg8gsrgl/_update`
+	expectedPath := `/sessions/_doc/dh3sgudg8gsrgl`
 	if expectedPath != path {
 		t.Errorf("expected URL path\n%s\ngot:\n%s", expectedPath, path)
 	}
@@ -99,7 +99,7 @@ func TestUpdateViaScriptAndUpsert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to return URL, got: %v", err)
 	}
-	expectedPath := `/test/type1/1/_update`
+	expectedPath := `/test/_doc/1`
 	if expectedPath != path {
 		t.Errorf("expected URL path\n%s\ngot:\n%s", expectedPath, path)
 	}
@@ -133,7 +133,7 @@ func TestUpdateViaDoc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to return URL, got: %v", err)
 	}
-	expectedPath := `/test/type1/1/_update`
+	expectedPath := `/test/_doc/1`
 	if expectedPath != path {
 		t.Errorf("expected URL path\n%s\ngot:\n%s", expectedPath, path)
 	}
@@ -169,7 +169,7 @@ func TestUpdateViaDocAndUpsert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to return URL, got: %v", err)
 	}
-	expectedPath := `/test/type1/1/_update`
+	expectedPath := `/test/_doc/1`
 	if expectedPath != path {
 		t.Errorf("expected URL path\n%s\ngot:\n%s", expectedPath, path)
 	}
@@ -206,7 +206,7 @@ func TestUpdateViaDocAndUpsertAndFetchSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to return URL, got: %v", err)
 	}
-	expectedPath := `/test/type1/1/_update`
+	expectedPath := `/test/_doc/1`
 	if expectedPath != path {
 		t.Errorf("expected URL path\n%s\ngot:\n%s", expectedPath, path)
 	}


### PR DESCRIPTION
As types are removed, updates are still using types.

In https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html it is stated:

> Specifying types in requests is deprecated. For instance, indexing a document no longer requires a document type. The new index APIs are PUT {index}/_doc/{id} in case of explicit ids and POST {index}/_doc for auto-generated ids. Note that in 7.0, _doc is a permanent part of the path, and represents the endpoint name rather than the document type.

These changes reflect that.