### PR TITLE
feature: column aliases in cat indices API

### DIFF
--- a/cat_indices.go
+++ b/cat_indices.go
@@ -10,7 +10,6 @@ import (
 	"github.com/olivere/elastic/v7/uritemplates"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strings"
 )
 
@@ -256,176 +255,276 @@ type CatIndicesResponse []CatIndicesResponseRow
 // be filled; that depends on the number of columns chose in the
 // request (see CatIndicesService.Columns).
 type CatIndicesResponseRow struct {
-	Health                       string `json:"health" alias:"h"`                                                    // "green", "yellow", or "red"
-	Status                       string `json:"status" alias:"s"`                                                    // "open" or "closed"
-	Index                        string `json:"index" alias:"i,idx"`                                                 // index name
-	UUID                         string `json:"uuid" alias:"id"`                                                     // index uuid
-	Pri                          int    `json:"pri,string" alias:"p,shards.primary,shardsPrimary"`                   // number of primary shards
-	Rep                          int    `json:"rep,string" alias:"r,shards.replica,shardsReplica"`                   // number of replica shards
-	DocsCount                    int    `json:"docs.count,string" alias:"dc,docsCount"`                              // number of available documents
-	DocsDeleted                  int    `json:"docs.deleted,string" alias:"dd,docsDeleted"`                          // number of deleted documents
-	CreationDate                 int64  `json:"creation.date,string" alias:"cd"`                                     // index creation date (millisecond value), e.g. 1527077221644
-	CreationDateString           string `json:"creation.date.string" alias:"cds"`                                    // index creation date (as string), e.g. "2018-05-23T12:07:01.644Z"
-	StoreSize                    string `json:"store.size" alias:"ss,storeSize"`                                     // store size of primaries & replicas, e.g. "4.6kb"
-	PriStoreSize                 string `json:"pri.store.size"`                                                      // store size of primaries, e.g. "230b"
-	CompletionSize               string `json:"completion.size" alias:"cs,completionSize"`                           // size of completion on primaries & replicas
-	PriCompletionSize            string `json:"pri.completion.size"`                                                 // size of completion on primaries
-	FielddataMemorySize          string `json:"fielddata.memory_size" alias:"fm,fielddataMemory"`                    // used fielddata cache on primaries & replicas
-	PriFielddataMemorySize       string `json:"pri.fielddata.memory_size"`                                           // used fielddata cache on primaries
-	FielddataEvictions           int    `json:"fielddata.evictions,string" alias:"fe,fielddataEvictions"`            // fielddata evictions on primaries & replicas
-	PriFielddataEvictions        int    `json:"pri.fielddata.evictions,string"`                                      // fielddata evictions on primaries
-	QueryCacheMemorySize         string `json:"query_cache.memory_size" alias:"qcm,queryCacheMemory"`                // used query cache on primaries & replicas
-	PriQueryCacheMemorySize      string `json:"pri.query_cache.memory_size"`                                         // used query cache on primaries
-	QueryCacheEvictions          int    `json:"query_cache.evictions,string"  alias:"qce,queryCacheEvictions"`       // query cache evictions on primaries & replicas
-	PriQueryCacheEvictions       int    `json:"pri.query_cache.evictions,string"`                                    // query cache evictions on primaries
-	RequestCacheMemorySize       string `json:"request_cache.memory_size" alias:"rcm,requestCacheMemory"`            // used request cache on primaries & replicas
-	PriRequestCacheMemorySize    string `json:"pri.request_cache.memory_size"`                                       // used request cache on primaries
-	RequestCacheEvictions        int    `json:"request_cache.evictions,string" alias:"rce,requestCacheEvictions"`    // request cache evictions on primaries & replicas
-	PriRequestCacheEvictions     int    `json:"pri.request_cache.evictions,string"`                                  // request cache evictions on primaries
-	RequestCacheHitCount         int    `json:"request_cache.hit_count,string" alias:"rchc,requestCacheHitCount"`    // request cache hit count on primaries & replicas
-	PriRequestCacheHitCount      int    `json:"pri.request_cache.hit_count,string"`                                  // request cache hit count on primaries
-	RequestCacheMissCount        int    `json:"request_cache.miss_count,string" alias:"rcmc,requestCacheMissCount"`  // request cache miss count on primaries & replicas
-	PriRequestCacheMissCount     int    `json:"pri.request_cache.miss_count,string"`                                 // request cache miss count on primaries
-	FlushTotal                   int    `json:"flush.total,string" alias:"ft,flushTotal"`                            // number of flushes on primaries & replicas
-	PriFlushTotal                int    `json:"pri.flush.total,string"`                                              // number of flushes on primaries
-	FlushTotalTime               string `json:"flush.total_time" alias:"ftt,flushTotalTime"`                         // time spent in flush on primaries & replicas
-	PriFlushTotalTime            string `json:"pri.flush.total_time"`                                                // time spent in flush on primaries
-	GetCurrent                   int    `json:"get.current,string" alias:"gc,getCurrent"`                            // number of current get ops on primaries & replicas
-	PriGetCurrent                int    `json:"pri.get.current,string"`                                              // number of current get ops on primaries
-	GetTime                      string `json:"get.time" alias:"gti,getTime"`                                        // time spent in get on primaries & replicas
-	PriGetTime                   string `json:"pri.get.time"`                                                        // time spent in get on primaries
-	GetTotal                     int    `json:"get.total,string" alias:"gto,getTotal"`                               // number of get ops on primaries & replicas
-	PriGetTotal                  int    `json:"pri.get.total,string"`                                                // number of get ops on primaries
-	GetExistsTime                string `json:"get.exists_time" alias:"geti,getExistsTime"`                          // time spent in successful gets on primaries & replicas
-	PriGetExistsTime             string `json:"pri.get.exists_time"`                                                 // time spent in successful gets on primaries
-	GetExistsTotal               int    `json:"get.exists_total,string" alias:"geto,getExistsTotal"`                 // number of successful gets on primaries & replicas
-	PriGetExistsTotal            int    `json:"pri.get.exists_total,string"`                                         // number of successful gets on primaries
-	GetMissingTime               string `json:"get.missing_time" alias:"gmti,getMissingTime"`                        // time spent in failed gets on primaries & replicas
-	PriGetMissingTime            string `json:"pri.get.missing_time"`                                                // time spent in failed gets on primaries
-	GetMissingTotal              int    `json:"get.missing_total,string" alias:"gmto,getMissingTotal"`               // number of failed gets on primaries & replicas
-	PriGetMissingTotal           int    `json:"pri.get.missing_total,string"`                                        // number of failed gets on primaries
-	IndexingDeleteCurrent        int    `json:"indexing.delete_current,string" alias:"idc,indexingDeleteCurrent"`    // number of current deletions on primaries & replicas
-	PriIndexingDeleteCurrent     int    `json:"pri.indexing.delete_current,string"`                                  // number of current deletions on primaries
-	IndexingDeleteTime           string `json:"indexing.delete_time" alias:"idti,indexingDeleteTime"`                // time spent in deletions on primaries & replicas
-	PriIndexingDeleteTime        string `json:"pri.indexing.delete_time"`                                            // time spent in deletions on primaries
-	IndexingDeleteTotal          int    `json:"indexing.delete_total,string" alias:"idto,indexingDeleteTotal"`       // number of delete ops on primaries & replicas
-	PriIndexingDeleteTotal       int    `json:"pri.indexing.delete_total,string"`                                    // number of delete ops on primaries
-	IndexingIndexCurrent         int    `json:"indexing.index_current,string" alias:"iic,indexingIdexCurrent"`       // number of current indexing on primaries & replicas
-	PriIndexingIndexCurrent      int    `json:"pri.indexing.index_current,string"`                                   // number of current indexing on primaries
-	IndexingIndexTime            string `json:"indexing.index_time" alias:"iiti,indexingIndexTime"`                  // time spent in indexing on primaries & replicas
-	PriIndexingIndexTime         string `json:"pri.indexing.index_time"`                                             // time spent in indexing on primaries
-	IndexingIndexTotal           int    `json:"indexing.index_total,string" alias:"iito,indexingIndexTotal"`         // number of index ops on primaries & replicas
-	PriIndexingIndexTotal        int    `json:"pri.indexing.index_total,string"`                                     // number of index ops on primaries
-	IndexingIndexFailed          int    `json:"indexing.index_failed,string" alias:"iif,indexingIndexFailed"`        // number of failed indexing ops on primaries & replicas
-	PriIndexingIndexFailed       int    `json:"pri.indexing.index_failed,string"`                                    // number of failed indexing ops on primaries
-	MergesCurrent                int    `json:"merges.current,string" alias:"mc,mergesCurrent"`                      // number of current merges on primaries & replicas
-	PriMergesCurrent             int    `json:"pri.merges.current,string"`                                           // number of current merges on primaries
-	MergesCurrentDocs            int    `json:"merges.current_docs,string" alias:"mcd,mergesCurrentDocs"`            // number of current merging docs on primaries & replicas
-	PriMergesCurrentDocs         int    `json:"pri.merges.current_docs,string"`                                      // number of current merging docs on primaries
-	MergesCurrentSize            string `json:"merges.current_size" alias:"mcs,mergesCurrentSize"`                   // size of current merges on primaries & replicas
-	PriMergesCurrentSize         string `json:"pri.merges.current_size"`                                             // size of current merges on primaries
-	MergesTotal                  int    `json:"merges.total,string" alias:"mt,mergesTotal"`                          // number of completed merge ops on primaries & replicas
-	PriMergesTotal               int    `json:"pri.merges.total,string"`                                             // number of completed merge ops on primaries
-	MergesTotalDocs              int    `json:"merges.total_docs,string" alias:"mtd,mergesTotalDocs"`                // docs merged on primaries & replicas
-	PriMergesTotalDocs           int    `json:"pri.merges.total_docs,string"`                                        // docs merged on primaries
-	MergesTotalSize              string `json:"merges.total_size" alias:"mts,mergesTotalSize"`                       // size merged on primaries & replicas
-	PriMergesTotalSize           string `json:"pri.merges.total_size"`                                               // size merged on primaries
-	MergesTotalTime              string `json:"merges.total_time" alias:"mtt,mergesTotalTIme"`                       // time spent in merges on primaries & replicas
-	PriMergesTotalTime           string `json:"pri.merges.total_time"`                                               // time spent in merges on primaries
-	RefreshTotal                 int    `json:"refresh.total,string" alias:"rto,refreshTotal"`                       // total refreshes on primaries & replicas
-	PriRefreshTotal              int    `json:"pri.refresh.total,string"`                                            // total refreshes on primaries
-	RefreshExternalTotal         int    `json:"refresh.external_total,string" alias:"rto,refreshTotal"`              // total external refreshes on primaries & replicas
-	PriRefreshExternalTotal      int    `json:"pri.refresh.external_total,string"`                                   // total external refreshes on primaries
-	RefreshTime                  string `json:"refresh.time" alias:"rti,refreshTime"`                                // time spent in refreshes on primaries & replicas
-	PriRefreshTime               string `json:"pri.refresh.time"`                                                    // time spent in refreshes on primaries
-	RefreshExternalTime          string `json:"refresh.external_time" alias:"rti,refreshTime"`                       // external time spent in refreshes on primaries & replicas
-	PriRefreshExternalTime       string `json:"pri.refresh.external_time"`                                           // external time spent in refreshes on primaries
-	RefreshListeners             int    `json:"refresh.listeners,string" alias:"rli,refreshListeners"`               // number of pending refresh listeners on primaries & replicas
-	PriRefreshListeners          int    `json:"pri.refresh.listeners,string"`                                        // number of pending refresh listeners on primaries
-	SearchFetchCurrent           int    `json:"search.fetch_current,string" alias:"sfc,searchFetchCurrent"`          // current fetch phase ops on primaries & replicas
-	PriSearchFetchCurrent        int    `json:"pri.search.fetch_current,string"`                                     // current fetch phase ops on primaries
-	SearchFetchTime              string `json:"search.fetch_time" alias:"sfti,searchFetchTime"`                      // time spent in fetch phase on primaries & replicas
-	PriSearchFetchTime           string `json:"pri.search.fetch_time"`                                               // time spent in fetch phase on primaries
-	SearchFetchTotal             int    `json:"search.fetch_total,string" alias:"sfto,searchFetchTotal"`             // total fetch ops on primaries & replicas
-	PriSearchFetchTotal          int    `json:"pri.search.fetch_total,string"`                                       // total fetch ops on primaries
-	SearchOpenContexts           int    `json:"search.open_contexts,string" alias:"so,searchOpenContexts"`           // open search contexts on primaries & replicas
-	PriSearchOpenContexts        int    `json:"pri.search.open_contexts,string"`                                     // open search contexts on primaries
-	SearchQueryCurrent           int    `json:"search.query_current,string" alias:"sqc,searchQueryCurrent"`          // current query phase ops on primaries & replicas
-	PriSearchQueryCurrent        int    `json:"pri.search.query_current,string"`                                     // current query phase ops on primaries
-	SearchQueryTime              string `json:"search.query_time" alias:"sqti,searchQueryTime"`                      // time spent in query phase on primaries & replicas, e.g. "0s"
-	PriSearchQueryTime           string `json:"pri.search.query_time"`                                               // time spent in query phase on primaries, e.g. "0s"
-	SearchQueryTotal             int    `json:"search.query_total,string" alias:"sqto,searchQueryTotal"`             // total query phase ops on primaries & replicas
-	PriSearchQueryTotal          int    `json:"pri.search.query_total,string"`                                       // total query phase ops on primaries
-	SearchScrollCurrent          int    `json:"search.scroll_current,string" alias:"scc,searchScrollCurrent"`        // open scroll contexts on primaries & replicas
-	PriSearchScrollCurrent       int    `json:"pri.search.scroll_current,string"`                                    // open scroll contexts on primaries
-	SearchScrollTime             string `json:"search.scroll_time" alias:"scti,searchScrollTime"`                    // time scroll contexts held open on primaries & replicas, e.g. "0s"
-	PriSearchScrollTime          string `json:"pri.search.scroll_time"`                                              // time scroll contexts held open on primaries, e.g. "0s"
-	SearchScrollTotal            int    `json:"search.scroll_total,string" alias:"scto,searchScrollTotal"`           // completed scroll contexts on primaries & replicas
-	PriSearchScrollTotal         int    `json:"pri.search.scroll_total,string"`                                      // completed scroll contexts on primaries
-	SearchThrottled              bool   `json:"search.throttled,string" alias:"sth"`                                 // indicates if the index is search throttled
-	SegmentsCount                int    `json:"segments.count,string" alias:"sc,segmentsCount"`                      // number of segments on primaries & replicas
-	PriSegmentsCount             int    `json:"pri.segments.count,string"`                                           // number of segments on primaries
-	SegmentsMemory               string `json:"segments.memory" alias:"sc,segmentsMemory"`                           // memory used by segments on primaries & replicas, e.g. "1.3kb"
-	PriSegmentsMemory            string `json:"pri.segments.memory"`                                                 // memory used by segments on primaries, e.g. "1.3kb"
-	SegmentsIndexWriterMemory    string `json:"segments.index_writer_memory" alias:"siwm,segmentsIndexWriterMemory"` // memory used by index writer on primaries & replicas, e.g. "0b"
-	PriSegmentsIndexWriterMemory string `json:"pri.segments.index_writer_memory"`                                    // memory used by index writer on primaries, e.g. "0b"
-	SegmentsVersionMapMemory     string `json:"segments.version_map_memory" alias:"svmm,segmentsVersionMapMemory"`   // memory used by version map on primaries & replicas, e.g. "0b"
-	PriSegmentsVersionMapMemory  string `json:"pri.segments.version_map_memory"`                                     // memory used by version map on primaries, e.g. "0b"
-	SegmentsFixedBitsetMemory    string `json:"segments.fixed_bitset_memory" alias:"sfbm,fixedBitsetMemory"`         // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries & replicas, e.g. "0b"
-	PriSegmentsFixedBitsetMemory string `json:"pri.segments.fixed_bitset_memory"`                                    // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries, e.g. "0b"
-	WarmerCurrent                int    `json:"warmer.current,string" alias:"wc,warmerCurrent"`                      // current warmer ops on primaries & replicas
-	PriWarmerCurrent             int    `json:"pri.warmer.current,string"`                                           // current warmer ops on primaries
-	WarmerTotal                  int    `json:"warmer.total,string" alias:"wto,warmerTotal"`                         // total warmer ops on primaries & replicas
-	PriWarmerTotal               int    `json:"pri.warmer.total,string"`                                             // total warmer ops on primaries
-	WarmerTotalTime              string `json:"warmer.total_time" alias:"wtt,warmerTotalTime"`                       // time spent in warmers on primaries & replicas, e.g. "47s"
-	PriWarmerTotalTime           string `json:"pri.warmer.total_time"`                                               // time spent in warmers on primaries, e.g. "47s"
-	SuggestCurrent               int    `json:"suggest.current,string" alias:"suc,suggestCurrent"`                   // number of current suggest ops on primaries & replicas
-	PriSuggestCurrent            int    `json:"pri.suggest.current,string"`                                          // number of current suggest ops on primaries
-	SuggestTime                  string `json:"suggest.time" alias:"suti,suggestTime"`                               // time spend in suggest on primaries & replicas, "31s"
-	PriSuggestTime               string `json:"pri.suggest.time"`                                                    // time spend in suggest on primaries, e.g. "31s"
-	SuggestTotal                 int    `json:"suggest.total,string" alias:"suto,suggestTotal"`                      // number of suggest ops on primaries & replicas
-	PriSuggestTotal              int    `json:"pri.suggest.total,string"`                                            // number of suggest ops on primaries
-	MemoryTotal                  string `json:"memory.total" alias:"tm,memoryTotal"`                                 // total user memory on primaries & replicas, e.g. "1.5kb"
-	PriMemoryTotal               string `json:"pri.memory.total"`                                                    // total user memory on primaries, e.g. "1.5kb"
+	Health                       string `json:"health"`                              // "green", "yellow", or "red"
+	Status                       string `json:"status"`                              // "open" or "closed"
+	Index                        string `json:"index"`                               // index name
+	UUID                         string `json:"uuid"`                                // index uuid
+	Pri                          int    `json:"pri,string"`                          // number of primary shards
+	Rep                          int    `json:"rep,string"`                          // number of replica shards
+	DocsCount                    int    `json:"docs.count,string"`                   // number of available documents
+	DocsDeleted                  int    `json:"docs.deleted,string"`                 // number of deleted documents
+	CreationDate                 int64  `json:"creation.date,string"`                // index creation date (millisecond value), e.g. 1527077221644
+	CreationDateString           string `json:"creation.date.string"`                // index creation date (as string), e.g. "2018-05-23T12:07:01.644Z"
+	StoreSize                    string `json:"store.size"`                          // store size of primaries & replicas, e.g. "4.6kb"
+	PriStoreSize                 string `json:"pri.store.size"`                      // store size of primaries, e.g. "230b"
+	CompletionSize               string `json:"completion.size"`                     // size of completion on primaries & replicas
+	PriCompletionSize            string `json:"pri.completion.size"`                 // size of completion on primaries
+	FielddataMemorySize          string `json:"fielddata.memory_size"`               // used fielddata cache on primaries & replicas
+	PriFielddataMemorySize       string `json:"pri.fielddata.memory_size"`           // used fielddata cache on primaries
+	FielddataEvictions           int    `json:"fielddata.evictions,string"`          // fielddata evictions on primaries & replicas
+	PriFielddataEvictions        int    `json:"pri.fielddata.evictions,string"`      // fielddata evictions on primaries
+	QueryCacheMemorySize         string `json:"query_cache.memory_size"`             // used query cache on primaries & replicas
+	PriQueryCacheMemorySize      string `json:"pri.query_cache.memory_size"`         // used query cache on primaries
+	QueryCacheEvictions          int    `json:"query_cache.evictions,string"`        // query cache evictions on primaries & replicas
+	PriQueryCacheEvictions       int    `json:"pri.query_cache.evictions,string"`    // query cache evictions on primaries
+	RequestCacheMemorySize       string `json:"request_cache.memory_size"`           // used request cache on primaries & replicas
+	PriRequestCacheMemorySize    string `json:"pri.request_cache.memory_size"`       // used request cache on primaries
+	RequestCacheEvictions        int    `json:"request_cache.evictions,string"`      // request cache evictions on primaries & replicas
+	PriRequestCacheEvictions     int    `json:"pri.request_cache.evictions,string"`  // request cache evictions on primaries
+	RequestCacheHitCount         int    `json:"request_cache.hit_count,string"`      // request cache hit count on primaries & replicas
+	PriRequestCacheHitCount      int    `json:"pri.request_cache.hit_count,string"`  // request cache hit count on primaries
+	RequestCacheMissCount        int    `json:"request_cache.miss_count,string"`     // request cache miss count on primaries & replicas
+	PriRequestCacheMissCount     int    `json:"pri.request_cache.miss_count,string"` // request cache miss count on primaries
+	FlushTotal                   int    `json:"flush.total,string"`                  // number of flushes on primaries & replicas
+	PriFlushTotal                int    `json:"pri.flush.total,string"`              // number of flushes on primaries
+	FlushTotalTime               string `json:"flush.total_time"`                    // time spent in flush on primaries & replicas
+	PriFlushTotalTime            string `json:"pri.flush.total_time"`                // time spent in flush on primaries
+	GetCurrent                   int    `json:"get.current,string"`                  // number of current get ops on primaries & replicas
+	PriGetCurrent                int    `json:"pri.get.current,string"`              // number of current get ops on primaries
+	GetTime                      string `json:"get.time"`                            // time spent in get on primaries & replicas
+	PriGetTime                   string `json:"pri.get.time"`                        // time spent in get on primaries
+	GetTotal                     int    `json:"get.total,string"`                    // number of get ops on primaries & replicas
+	PriGetTotal                  int    `json:"pri.get.total,string"`                // number of get ops on primaries
+	GetExistsTime                string `json:"get.exists_time"`                     // time spent in successful gets on primaries & replicas
+	PriGetExistsTime             string `json:"pri.get.exists_time"`                 // time spent in successful gets on primaries
+	GetExistsTotal               int    `json:"get.exists_total,string"`             // number of successful gets on primaries & replicas
+	PriGetExistsTotal            int    `json:"pri.get.exists_total,string"`         // number of successful gets on primaries
+	GetMissingTime               string `json:"get.missing_time"`                    // time spent in failed gets on primaries & replicas
+	PriGetMissingTime            string `json:"pri.get.missing_time"`                // time spent in failed gets on primaries
+	GetMissingTotal              int    `json:"get.missing_total,string"`            // number of failed gets on primaries & replicas
+	PriGetMissingTotal           int    `json:"pri.get.missing_total,string"`        // number of failed gets on primaries
+	IndexingDeleteCurrent        int    `json:"indexing.delete_current,string"`      // number of current deletions on primaries & replicas
+	PriIndexingDeleteCurrent     int    `json:"pri.indexing.delete_current,string"`  // number of current deletions on primaries
+	IndexingDeleteTime           string `json:"indexing.delete_time"`                // time spent in deletions on primaries & replicas
+	PriIndexingDeleteTime        string `json:"pri.indexing.delete_time"`            // time spent in deletions on primaries
+	IndexingDeleteTotal          int    `json:"indexing.delete_total,string"`        // number of delete ops on primaries & replicas
+	PriIndexingDeleteTotal       int    `json:"pri.indexing.delete_total,string"`    // number of delete ops on primaries
+	IndexingIndexCurrent         int    `json:"indexing.index_current,string"`       // number of current indexing on primaries & replicas
+	PriIndexingIndexCurrent      int    `json:"pri.indexing.index_current,string"`   // number of current indexing on primaries
+	IndexingIndexTime            string `json:"indexing.index_time"`                 // time spent in indexing on primaries & replicas
+	PriIndexingIndexTime         string `json:"pri.indexing.index_time"`             // time spent in indexing on primaries
+	IndexingIndexTotal           int    `json:"indexing.index_total,string"`         // number of index ops on primaries & replicas
+	PriIndexingIndexTotal        int    `json:"pri.indexing.index_total,string"`     // number of index ops on primaries
+	IndexingIndexFailed          int    `json:"indexing.index_failed,string"`        // number of failed indexing ops on primaries & replicas
+	PriIndexingIndexFailed       int    `json:"pri.indexing.index_failed,string"`    // number of failed indexing ops on primaries
+	MergesCurrent                int    `json:"merges.current,string"`               // number of current merges on primaries & replicas
+	PriMergesCurrent             int    `json:"pri.merges.current,string"`           // number of current merges on primaries
+	MergesCurrentDocs            int    `json:"merges.current_docs,string"`          // number of current merging docs on primaries & replicas
+	PriMergesCurrentDocs         int    `json:"pri.merges.current_docs,string"`      // number of current merging docs on primaries
+	MergesCurrentSize            string `json:"merges.current_size"`                 // size of current merges on primaries & replicas
+	PriMergesCurrentSize         string `json:"pri.merges.current_size"`             // size of current merges on primaries
+	MergesTotal                  int    `json:"merges.total,string"`                 // number of completed merge ops on primaries & replicas
+	PriMergesTotal               int    `json:"pri.merges.total,string"`             // number of completed merge ops on primaries
+	MergesTotalDocs              int    `json:"merges.total_docs,string"`            // docs merged on primaries & replicas
+	PriMergesTotalDocs           int    `json:"pri.merges.total_docs,string"`        // docs merged on primaries
+	MergesTotalSize              string `json:"merges.total_size"`                   // size merged on primaries & replicas
+	PriMergesTotalSize           string `json:"pri.merges.total_size"`               // size merged on primaries
+	MergesTotalTime              string `json:"merges.total_time"`                   // time spent in merges on primaries & replicas
+	PriMergesTotalTime           string `json:"pri.merges.total_time"`               // time spent in merges on primaries
+	RefreshTotal                 int    `json:"refresh.total,string"`                // total refreshes on primaries & replicas
+	PriRefreshTotal              int    `json:"pri.refresh.total,string"`            // total refreshes on primaries
+	RefreshExternalTotal         int    `json:"refresh.external_total,string"`       // total external refreshes on primaries & replicas
+	PriRefreshExternalTotal      int    `json:"pri.refresh.external_total,string"`   // total external refreshes on primaries
+	RefreshTime                  string `json:"refresh.time"`                        // time spent in refreshes on primaries & replicas
+	PriRefreshTime               string `json:"pri.refresh.time"`                    // time spent in refreshes on primaries
+	RefreshExternalTime          string `json:"refresh.external_time"`               // external time spent in refreshes on primaries & replicas
+	PriRefreshExternalTime       string `json:"pri.refresh.external_time"`           // external time spent in refreshes on primaries
+	RefreshListeners             int    `json:"refresh.listeners,string"`            // number of pending refresh listeners on primaries & replicas
+	PriRefreshListeners          int    `json:"pri.refresh.listeners,string"`        // number of pending refresh listeners on primaries
+	SearchFetchCurrent           int    `json:"search.fetch_current,string"`         // current fetch phase ops on primaries & replicas
+	PriSearchFetchCurrent        int    `json:"pri.search.fetch_current,string"`     // current fetch phase ops on primaries
+	SearchFetchTime              string `json:"search.fetch_time"`                   // time spent in fetch phase on primaries & replicas
+	PriSearchFetchTime           string `json:"pri.search.fetch_time"`               // time spent in fetch phase on primaries
+	SearchFetchTotal             int    `json:"search.fetch_total,string"`           // total fetch ops on primaries & replicas
+	PriSearchFetchTotal          int    `json:"pri.search.fetch_total,string"`       // total fetch ops on primaries
+	SearchOpenContexts           int    `json:"search.open_contexts,string"`         // open search contexts on primaries & replicas
+	PriSearchOpenContexts        int    `json:"pri.search.open_contexts,string"`     // open search contexts on primaries
+	SearchQueryCurrent           int    `json:"search.query_current,string"`         // current query phase ops on primaries & replicas
+	PriSearchQueryCurrent        int    `json:"pri.search.query_current,string"`     // current query phase ops on primaries
+	SearchQueryTime              string `json:"search.query_time"`                   // time spent in query phase on primaries & replicas, e.g. "0s"
+	PriSearchQueryTime           string `json:"pri.search.query_time"`               // time spent in query phase on primaries, e.g. "0s"
+	SearchQueryTotal             int    `json:"search.query_total,string"`           // total query phase ops on primaries & replicas
+	PriSearchQueryTotal          int    `json:"pri.search.query_total,string"`       // total query phase ops on primaries
+	SearchScrollCurrent          int    `json:"search.scroll_current,string"`        // open scroll contexts on primaries & replicas
+	PriSearchScrollCurrent       int    `json:"pri.search.scroll_current,string"`    // open scroll contexts on primaries
+	SearchScrollTime             string `json:"search.scroll_time"`                  // time scroll contexts held open on primaries & replicas, e.g. "0s"
+	PriSearchScrollTime          string `json:"pri.search.scroll_time"`              // time scroll contexts held open on primaries, e.g. "0s"
+	SearchScrollTotal            int    `json:"search.scroll_total,string"`          // completed scroll contexts on primaries & replicas
+	PriSearchScrollTotal         int    `json:"pri.search.scroll_total,string"`      // completed scroll contexts on primaries
+	SearchThrottled              bool   `json:"search.throttled,string"`             // indicates if the index is search throttled
+	SegmentsCount                int    `json:"segments.count,string"`               // number of segments on primaries & replicas
+	PriSegmentsCount             int    `json:"pri.segments.count,string"`           // number of segments on primaries
+	SegmentsMemory               string `json:"segments.memory"`                     // memory used by segments on primaries & replicas, e.g. "1.3kb"
+	PriSegmentsMemory            string `json:"pri.segments.memory"`                 // memory used by segments on primaries, e.g. "1.3kb"
+	SegmentsIndexWriterMemory    string `json:"segments.index_writer_memory"`        // memory used by index writer on primaries & replicas, e.g. "0b"
+	PriSegmentsIndexWriterMemory string `json:"pri.segments.index_writer_memory"`    // memory used by index writer on primaries, e.g. "0b"
+	SegmentsVersionMapMemory     string `json:"segments.version_map_memory"`         // memory used by version map on primaries & replicas, e.g. "0b"
+	PriSegmentsVersionMapMemory  string `json:"pri.segments.version_map_memory"`     // memory used by version map on primaries, e.g. "0b"
+	SegmentsFixedBitsetMemory    string `json:"segments.fixed_bitset_memory"`        // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries & replicas, e.g. "0b"
+	PriSegmentsFixedBitsetMemory string `json:"pri.segments.fixed_bitset_memory"`    // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries, e.g. "0b"
+	WarmerCurrent                int    `json:"warmer.current,string"`               // current warmer ops on primaries & replicas
+	PriWarmerCurrent             int    `json:"pri.warmer.current,string"`           // current warmer ops on primaries
+	WarmerTotal                  int    `json:"warmer.total,string"`                 // total warmer ops on primaries & replicas
+	PriWarmerTotal               int    `json:"pri.warmer.total,string"`             // total warmer ops on primaries
+	WarmerTotalTime              string `json:"warmer.total_time"`                   // time spent in warmers on primaries & replicas, e.g. "47s"
+	PriWarmerTotalTime           string `json:"pri.warmer.total_time"`               // time spent in warmers on primaries, e.g. "47s"
+	SuggestCurrent               int    `json:"suggest.current,string"`              // number of current suggest ops on primaries & replicas
+	PriSuggestCurrent            int    `json:"pri.suggest.current,string"`          // number of current suggest ops on primaries
+	SuggestTime                  string `json:"suggest.time"`                        // time spend in suggest on primaries & replicas, "31s"
+	PriSuggestTime               string `json:"pri.suggest.time"`                    // time spend in suggest on primaries, e.g. "31s"
+	SuggestTotal                 int    `json:"suggest.total,string"`                // number of suggest ops on primaries & replicas
+	PriSuggestTotal              int    `json:"pri.suggest.total,string"`            // number of suggest ops on primaries
+	MemoryTotal                  string `json:"memory.total"`                        // total user memory on primaries & replicas, e.g. "1.5kb"
+	PriMemoryTotal               string `json:"pri.memory.total"`                    // total user memory on primaries, e.g. "1.5kb"
 }
 
-// catIndicesResponseRowAliasesMap holds the global compiled map for columns aliases
+// catIndicesResponseRowAliasesMap holds the global map for columns aliases
 // the map is used by CatIndicesService.buildURL
-var catIndicesResponseRowAliasesMap map[string]string
-
-// catIndicesResponseRowAliasesMap needs reflect to be built
-// but it is used once only on the the application start (so considered not harmful for performance)
-func init() {
-	catIndicesResponseRowAliasesMap = make(map[string]string)
-
-	valType := reflect.TypeOf(CatIndicesResponseRow{})
-
-	for i := 0; i < valType.NumField(); i++ {
-		field := valType.Field(i)
-
-		jsonVal := field.Tag.Get("json")
-		if jsonVal == "" {
-			continue
-		}
-
-		jsonVal = strings.Split(jsonVal, ",")[0]
-
-		aliasVal := field.Tag.Get("alias")
-		if aliasVal == "" {
-			continue
-		}
-
-		// for backwards compatibility some fields are able to have the same aliases
-		// that means that one alias can be translated to different columns (from different elastic versions)
-		// example for understanding: rto -> RefreshTotal, RefreshExternalTotal
-		for _, alias := range strings.Split(aliasVal, ",") {
-			if existed, ok := catIndicesResponseRowAliasesMap[alias]; ok {
-				catIndicesResponseRowAliasesMap[alias] = existed + "," + jsonVal
-			} else {
-				catIndicesResponseRowAliasesMap[alias] = jsonVal
-			}
-		}
-	}
-
-	return
+// for backwards compatibility some fields are able to have the same aliases
+// that means that one alias can be translated to different columns (from different elastic versions)
+// example for understanding: rto -> RefreshTotal, RefreshExternalTotal
+var catIndicesResponseRowAliasesMap = map[string]string{
+	"qce":                       "query_cache.evictions",
+	"searchFetchTime":           "search.fetch_time",
+	"memoryTotal":               "memory.total",
+	"requestCacheEvictions":     "request_cache.evictions",
+	"ftt":                       "flush.total_time",
+	"iic":                       "indexing.index_current",
+	"mtt":                       "merges.total_time",
+	"scti":                      "search.scroll_time",
+	"searchScrollTime":          "search.scroll_time",
+	"segmentsCount":             "segments.count",
+	"getTotal":                  "get.total",
+	"sfti":                      "search.fetch_time",
+	"searchScrollCurrent":       "search.scroll_current",
+	"svmm":                      "segments.version_map_memory",
+	"warmerTotalTime":           "warmer.total_time",
+	"r":                         "rep",
+	"indexingIndexTime":         "indexing.index_time",
+	"refreshTotal":              "refresh.total,refresh.external_total",
+	"scc":                       "search.scroll_current",
+	"suggestTime":               "suggest.time",
+	"idc":                       "indexing.delete_current",
+	"rti":                       "refresh.time,refresh.external_time",
+	"sfto":                      "search.fetch_total",
+	"completionSize":            "completion.size",
+	"mt":                        "merges.total",
+	"segmentsVersionMapMemory":  "segments.version_map_memory",
+	"rto":                       "refresh.total,refresh.external_total",
+	"id":                        "uuid",
+	"dd":                        "docs.deleted",
+	"docsDeleted":               "docs.deleted",
+	"fielddataMemory":           "fielddata.memory_size",
+	"getTime":                   "get.time",
+	"getExistsTime":             "get.exists_time",
+	"mtd":                       "merges.total_docs",
+	"rli":                       "refresh.listeners",
+	"h":                         "health",
+	"cds":                       "creation.date.string",
+	"rcmc":                      "request_cache.miss_count",
+	"iif":                       "indexing.index_failed",
+	"warmerCurrent":             "warmer.current",
+	"gti":                       "get.time",
+	"indexingIndexFailed":       "indexing.index_failed",
+	"mts":                       "merges.total_size",
+	"sqti":                      "search.query_time",
+	"segmentsIndexWriterMemory": "segments.index_writer_memory",
+	"iiti":                      "indexing.index_time",
+	"iito":                      "indexing.index_total",
+	"cd":                        "creation.date",
+	"gc":                        "get.current",
+	"searchFetchTotal":          "search.fetch_total",
+	"sqc":                       "search.query_current",
+	"segmentsMemory":            "segments.memory",
+	"dc":                        "docs.count",
+	"qcm":                       "query_cache.memory_size",
+	"queryCacheMemory":          "query_cache.memory_size",
+	"mergesTotalDocs":           "merges.total_docs",
+	"searchOpenContexts":        "search.open_contexts",
+	"shards.primary":            "pri",
+	"cs":                        "completion.size",
+	"mergesTotalTIme":           "merges.total_time",
+	"wtt":                       "warmer.total_time",
+	"mergesCurrentSize":         "merges.current_size",
+	"mergesTotal":               "merges.total",
+	"refreshTime":               "refresh.time,refresh.external_time",
+	"wc":                        "warmer.current",
+	"p":                         "pri",
+	"idti":                      "indexing.delete_time",
+	"searchQueryCurrent":        "search.query_current",
+	"warmerTotal":               "warmer.total",
+	"suggestTotal":              "suggest.total",
+	"tm":                        "memory.total",
+	"ss":                        "store.size",
+	"ft":                        "flush.total",
+	"getExistsTotal":            "get.exists_total",
+	"scto":                      "search.scroll_total",
+	"s":                         "status",
+	"queryCacheEvictions":       "query_cache.evictions",
+	"rce":                       "request_cache.evictions",
+	"geto":                      "get.exists_total",
+	"refreshListeners":          "refresh.listeners",
+	"suto":                      "suggest.total",
+	"storeSize":                 "store.size",
+	"gmti":                      "get.missing_time",
+	"indexingIdexCurrent":       "indexing.index_current",
+	"searchFetchCurrent":        "search.fetch_current",
+	"idx":                       "index",
+	"fm":                        "fielddata.memory_size",
+	"geti":                      "get.exists_time",
+	"indexingDeleteCurrent":     "indexing.delete_current",
+	"mergesCurrentDocs":         "merges.current_docs",
+	"sth":                       "search.throttled",
+	"flushTotal":                "flush.total",
+	"sfc":                       "search.fetch_current",
+	"wto":                       "warmer.total",
+	"suti":                      "suggest.time",
+	"shardsReplica":             "rep",
+	"mergesCurrent":             "merges.current",
+	"mcs":                       "merges.current_size",
+	"so":                        "search.open_contexts",
+	"i":                         "index",
+	"siwm":                      "segments.index_writer_memory",
+	"sfbm":                      "segments.fixed_bitset_memory",
+	"fe":                        "fielddata.evictions",
+	"requestCacheMissCount":     "request_cache.miss_count",
+	"idto":                      "indexing.delete_total",
+	"mergesTotalSize":           "merges.total_size",
+	"suc":                       "suggest.current",
+	"suggestCurrent":            "suggest.current",
+	"flushTotalTime":            "flush.total_time",
+	"getMissingTotal":           "get.missing_total",
+	"sqto":                      "search.query_total",
+	"searchScrollTotal":         "search.scroll_total",
+	"fixedBitsetMemory":         "segments.fixed_bitset_memory",
+	"getMissingTime":            "get.missing_time",
+	"indexingDeleteTotal":       "indexing.delete_total",
+	"mcd":                       "merges.current_docs",
+	"docsCount":                 "docs.count",
+	"gto":                       "get.total",
+	"mc":                        "merges.current",
+	"fielddataEvictions":        "fielddata.evictions",
+	"rcm":                       "request_cache.memory_size",
+	"requestCacheHitCount":      "request_cache.hit_count",
+	"gmto":                      "get.missing_total",
+	"searchQueryTime":           "search.query_time",
+	"shards.replica":            "rep",
+	"requestCacheMemory":        "request_cache.memory_size",
+	"rchc":                      "request_cache.hit_count",
+	"getCurrent":                "get.current",
+	"indexingIndexTotal":        "indexing.index_total",
+	"sc":                        "segments.count,segments.memory",
+	"shardsPrimary":             "pri",
+	"indexingDeleteTime":        "indexing.delete_time",
+	"searchQueryTotal":          "search.query_total",
 }

--- a/cat_indices.go
+++ b/cat_indices.go
@@ -7,11 +7,11 @@ package elastic
 import (
 	"context"
 	"fmt"
+	"github.com/olivere/elastic/v7/uritemplates"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
-
-	"github.com/olivere/elastic/v7/uritemplates"
 )
 
 // CatIndicesService returns the list of indices plus some additional
@@ -189,6 +189,22 @@ func (s *CatIndicesService) buildURL() (string, url.Values, error) {
 		params.Set("master_timeout", s.masterTimeout)
 	}
 	if len(s.columns) > 0 {
+		// loop through all columns and apply alias if needed
+		for i, column := range s.columns {
+			if fullValueRaw, isAliased := catIndicesResponseRowAliasesMap[column]; isAliased {
+				// alias can be translated to multiple fields,
+				// so if translated value contains a comma, than replace the first value
+				// and append the others
+				if strings.Contains(fullValueRaw, ",") {
+					fullValues := strings.Split(fullValueRaw, ",")
+					s.columns[i] = fullValues[0]
+					s.columns = append(s.columns, fullValues[1:]...)
+				} else {
+					s.columns[i] = fullValueRaw
+				}
+			}
+		}
+
 		params.Set("h", strings.Join(s.columns, ","))
 	}
 	if s.health != "" {
@@ -240,135 +256,176 @@ type CatIndicesResponse []CatIndicesResponseRow
 // be filled; that depends on the number of columns chose in the
 // request (see CatIndicesService.Columns).
 type CatIndicesResponseRow struct {
-	Health                       string `json:"health"`                              // "green", "yellow", or "red"
-	Status                       string `json:"status"`                              // "open" or "closed"
-	Index                        string `json:"index"`                               // index name
-	UUID                         string `json:"uuid"`                                // index uuid
-	Pri                          int    `json:"pri,string"`                          // number of primary shards
-	Rep                          int    `json:"rep,string"`                          // number of replica shards
-	DocsCount                    int    `json:"docs.count,string"`                   // number of available documents
-	DocsDeleted                  int    `json:"docs.deleted,string"`                 // number of deleted documents
-	CreationDate                 int64  `json:"creation.date,string"`                // index creation date (millisecond value), e.g. 1527077221644
-	CreationDateString           string `json:"creation.date.string"`                // index creation date (as string), e.g. "2018-05-23T12:07:01.644Z"
-	StoreSize                    string `json:"store.size"`                          // store size of primaries & replicas, e.g. "4.6kb"
-	PriStoreSize                 string `json:"pri.store.size"`                      // store size of primaries, e.g. "230b"
-	CompletionSize               string `json:"completion.size"`                     // size of completion on primaries & replicas
-	PriCompletionSize            string `json:"pri.completion.size"`                 // size of completion on primaries
-	FielddataMemorySize          string `json:"fielddata.memory_size"`               // used fielddata cache on primaries & replicas
-	PriFielddataMemorySize       string `json:"pri.fielddata.memory_size"`           // used fielddata cache on primaries
-	FielddataEvictions           int    `json:"fielddata.evictions,string"`          // fielddata evictions on primaries & replicas
-	PriFielddataEvictions        int    `json:"pri.fielddata.evictions,string"`      // fielddata evictions on primaries
-	QueryCacheMemorySize         string `json:"query_cache.memory_size"`             // used query cache on primaries & replicas
-	PriQueryCacheMemorySize      string `json:"pri.query_cache.memory_size"`         // used query cache on primaries
-	QueryCacheEvictions          int    `json:"query_cache.evictions,string"`        // query cache evictions on primaries & replicas
-	PriQueryCacheEvictions       int    `json:"pri.query_cache.evictions,string"`    // query cache evictions on primaries
-	RequestCacheMemorySize       string `json:"request_cache.memory_size"`           // used request cache on primaries & replicas
-	PriRequestCacheMemorySize    string `json:"pri.request_cache.memory_size"`       // used request cache on primaries
-	RequestCacheEvictions        int    `json:"request_cache.evictions,string"`      // request cache evictions on primaries & replicas
-	PriRequestCacheEvictions     int    `json:"pri.request_cache.evictions,string"`  // request cache evictions on primaries
-	RequestCacheHitCount         int    `json:"request_cache.hit_count,string"`      // request cache hit count on primaries & replicas
-	PriRequestCacheHitCount      int    `json:"pri.request_cache.hit_count,string"`  // request cache hit count on primaries
-	RequestCacheMissCount        int    `json:"request_cache.miss_count,string"`     // request cache miss count on primaries & replicas
-	PriRequestCacheMissCount     int    `json:"pri.request_cache.miss_count,string"` // request cache miss count on primaries
-	FlushTotal                   int    `json:"flush.total,string"`                  // number of flushes on primaries & replicas
-	PriFlushTotal                int    `json:"pri.flush.total,string"`              // number of flushes on primaries
-	FlushTotalTime               string `json:"flush.total_time"`                    // time spent in flush on primaries & replicas
-	PriFlushTotalTime            string `json:"pri.flush.total_time"`                // time spent in flush on primaries
-	GetCurrent                   int    `json:"get.current,string"`                  // number of current get ops on primaries & replicas
-	PriGetCurrent                int    `json:"pri.get.current,string"`              // number of current get ops on primaries
-	GetTime                      string `json:"get.time"`                            // time spent in get on primaries & replicas
-	PriGetTime                   string `json:"pri.get.time"`                        // time spent in get on primaries
-	GetTotal                     int    `json:"get.total,string"`                    // number of get ops on primaries & replicas
-	PriGetTotal                  int    `json:"pri.get.total,string"`                // number of get ops on primaries
-	GetExistsTime                string `json:"get.exists_time"`                     // time spent in successful gets on primaries & replicas
-	PriGetExistsTime             string `json:"pri.get.exists_time"`                 // time spent in successful gets on primaries
-	GetExistsTotal               int    `json:"get.exists_total,string"`             // number of successful gets on primaries & replicas
-	PriGetExistsTotal            int    `json:"pri.get.exists_total,string"`         // number of successful gets on primaries
-	GetMissingTime               string `json:"get.missing_time"`                    // time spent in failed gets on primaries & replicas
-	PriGetMissingTime            string `json:"pri.get.missing_time"`                // time spent in failed gets on primaries
-	GetMissingTotal              int    `json:"get.missing_total,string"`            // number of failed gets on primaries & replicas
-	PriGetMissingTotal           int    `json:"pri.get.missing_total,string"`        // number of failed gets on primaries
-	IndexingDeleteCurrent        int    `json:"indexing.delete_current,string"`      // number of current deletions on primaries & replicas
-	PriIndexingDeleteCurrent     int    `json:"pri.indexing.delete_current,string"`  // number of current deletions on primaries
-	IndexingDeleteTime           string `json:"indexing.delete_time"`                // time spent in deletions on primaries & replicas
-	PriIndexingDeleteTime        string `json:"pri.indexing.delete_time"`            // time spent in deletions on primaries
-	IndexingDeleteTotal          int    `json:"indexing.delete_total,string"`        // number of delete ops on primaries & replicas
-	PriIndexingDeleteTotal       int    `json:"pri.indexing.delete_total,string"`    // number of delete ops on primaries
-	IndexingIndexCurrent         int    `json:"indexing.index_current,string"`       // number of current indexing on primaries & replicas
-	PriIndexingIndexCurrent      int    `json:"pri.indexing.index_current,string"`   // number of current indexing on primaries
-	IndexingIndexTime            string `json:"indexing.index_time"`                 // time spent in indexing on primaries & replicas
-	PriIndexingIndexTime         string `json:"pri.indexing.index_time"`             // time spent in indexing on primaries
-	IndexingIndexTotal           int    `json:"indexing.index_total,string"`         // number of index ops on primaries & replicas
-	PriIndexingIndexTotal        int    `json:"pri.indexing.index_total,string"`     // number of index ops on primaries
-	IndexingIndexFailed          int    `json:"indexing.index_failed,string"`        // number of failed indexing ops on primaries & replicas
-	PriIndexingIndexFailed       int    `json:"pri.indexing.index_failed,string"`    // number of failed indexing ops on primaries
-	MergesCurrent                int    `json:"merges.current,string"`               // number of current merges on primaries & replicas
-	PriMergesCurrent             int    `json:"pri.merges.current,string"`           // number of current merges on primaries
-	MergesCurrentDocs            int    `json:"merges.current_docs,string"`          // number of current merging docs on primaries & replicas
-	PriMergesCurrentDocs         int    `json:"pri.merges.current_docs,string"`      // number of current merging docs on primaries
-	MergesCurrentSize            string `json:"merges.current_size"`                 // size of current merges on primaries & replicas
-	PriMergesCurrentSize         string `json:"pri.merges.current_size"`             // size of current merges on primaries
-	MergesTotal                  int    `json:"merges.total,string"`                 // number of completed merge ops on primaries & replicas
-	PriMergesTotal               int    `json:"pri.merges.total,string"`             // number of completed merge ops on primaries
-	MergesTotalDocs              int    `json:"merges.total_docs,string"`            // docs merged on primaries & replicas
-	PriMergesTotalDocs           int    `json:"pri.merges.total_docs,string"`        // docs merged on primaries
-	MergesTotalSize              string `json:"merges.total_size"`                   // size merged on primaries & replicas
-	PriMergesTotalSize           string `json:"pri.merges.total_size"`               // size merged on primaries
-	MergesTotalTime              string `json:"merges.total_time"`                   // time spent in merges on primaries & replicas
-	PriMergesTotalTime           string `json:"pri.merges.total_time"`               // time spent in merges on primaries
-	RefreshTotal                 int    `json:"refresh.total,string"`                // total refreshes on primaries & replicas
-	PriRefreshTotal              int    `json:"pri.refresh.total,string"`            // total refreshes on primaries
-	RefreshExternalTotal         int    `json:"refresh.external_total,string"`       // total external refreshes on primaries & replicas
-	PriRefreshExternalTotal      int    `json:"pri.refresh.external_total,string"`   // total external refreshes on primaries
-	RefreshTime                  string `json:"refresh.time"`                        // time spent in refreshes on primaries & replicas
-	PriRefreshTime               string `json:"pri.refresh.time"`                    // time spent in refreshes on primaries
-	RefreshExternalTime          string `json:"refresh.external_time"`               // external time spent in refreshes on primaries & replicas
-	PriRefreshExternalTime       string `json:"pri.refresh.external_time"`           // external time spent in refreshes on primaries
-	RefreshListeners             int    `json:"refresh.listeners,string"`            // number of pending refresh listeners on primaries & replicas
-	PriRefreshListeners          int    `json:"pri.refresh.listeners,string"`        // number of pending refresh listeners on primaries
-	SearchFetchCurrent           int    `json:"search.fetch_current,string"`         // current fetch phase ops on primaries & replicas
-	PriSearchFetchCurrent        int    `json:"pri.search.fetch_current,string"`     // current fetch phase ops on primaries
-	SearchFetchTime              string `json:"search.fetch_time"`                   // time spent in fetch phase on primaries & replicas
-	PriSearchFetchTime           string `json:"pri.search.fetch_time"`               // time spent in fetch phase on primaries
-	SearchFetchTotal             int    `json:"search.fetch_total,string"`           // total fetch ops on primaries & replicas
-	PriSearchFetchTotal          int    `json:"pri.search.fetch_total,string"`       // total fetch ops on primaries
-	SearchOpenContexts           int    `json:"search.open_contexts,string"`         // open search contexts on primaries & replicas
-	PriSearchOpenContexts        int    `json:"pri.search.open_contexts,string"`     // open search contexts on primaries
-	SearchQueryCurrent           int    `json:"search.query_current,string"`         // current query phase ops on primaries & replicas
-	PriSearchQueryCurrent        int    `json:"pri.search.query_current,string"`     // current query phase ops on primaries
-	SearchQueryTime              string `json:"search.query_time"`                   // time spent in query phase on primaries & replicas, e.g. "0s"
-	PriSearchQueryTime           string `json:"pri.search.query_time"`               // time spent in query phase on primaries, e.g. "0s"
-	SearchQueryTotal             int    `json:"search.query_total,string"`           // total query phase ops on primaries & replicas
-	PriSearchQueryTotal          int    `json:"pri.search.query_total,string"`       // total query phase ops on primaries
-	SearchScrollCurrent          int    `json:"search.scroll_current,string"`        // open scroll contexts on primaries & replicas
-	PriSearchScrollCurrent       int    `json:"pri.search.scroll_current,string"`    // open scroll contexts on primaries
-	SearchScrollTime             string `json:"search.scroll_time"`                  // time scroll contexts held open on primaries & replicas, e.g. "0s"
-	PriSearchScrollTime          string `json:"pri.search.scroll_time"`              // time scroll contexts held open on primaries, e.g. "0s"
-	SearchScrollTotal            int    `json:"search.scroll_total,string"`          // completed scroll contexts on primaries & replicas
-	PriSearchScrollTotal         int    `json:"pri.search.scroll_total,string"`      // completed scroll contexts on primaries
-	SearchThrottled              bool   `json:"search.throttled,string"`             // indicates if the index is search throttled
-	SegmentsCount                int    `json:"segments.count,string"`               // number of segments on primaries & replicas
-	PriSegmentsCount             int    `json:"pri.segments.count,string"`           // number of segments on primaries
-	SegmentsMemory               string `json:"segments.memory"`                     // memory used by segments on primaries & replicas, e.g. "1.3kb"
-	PriSegmentsMemory            string `json:"pri.segments.memory"`                 // memory used by segments on primaries, e.g. "1.3kb"
-	SegmentsIndexWriterMemory    string `json:"segments.index_writer_memory"`        // memory used by index writer on primaries & replicas, e.g. "0b"
-	PriSegmentsIndexWriterMemory string `json:"pri.segments.index_writer_memory"`    // memory used by index writer on primaries, e.g. "0b"
-	SegmentsVersionMapMemory     string `json:"segments.version_map_memory"`         // memory used by version map on primaries & replicas, e.g. "0b"
-	PriSegmentsVersionMapMemory  string `json:"pri.segments.version_map_memory"`     // memory used by version map on primaries, e.g. "0b"
-	SegmentsFixedBitsetMemory    string `json:"segments.fixed_bitset_memory"`        // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries & replicas, e.g. "0b"
-	PriSegmentsFixedBitsetMemory string `json:"pri.segments.fixed_bitset_memory"`    // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries, e.g. "0b"
-	WarmerCurrent                int    `json:"warmer.current,string"`               // current warmer ops on primaries & replicas
-	PriWarmerCurrent             int    `json:"pri.warmer.current,string"`           // current warmer ops on primaries
-	WarmerTotal                  int    `json:"warmer.total,string"`                 // total warmer ops on primaries & replicas
-	PriWarmerTotal               int    `json:"pri.warmer.total,string"`             // total warmer ops on primaries
-	WarmerTotalTime              string `json:"warmer.total_time"`                   // time spent in warmers on primaries & replicas, e.g. "47s"
-	PriWarmerTotalTime           string `json:"pri.warmer.total_time"`               // time spent in warmers on primaries, e.g. "47s"
-	SuggestCurrent               int    `json:"suggest.current,string"`              // number of current suggest ops on primaries & replicas
-	PriSuggestCurrent            int    `json:"pri.suggest.current,string"`          // number of current suggest ops on primaries
-	SuggestTime                  string `json:"suggest.time"`                        // time spend in suggest on primaries & replicas, "31s"
-	PriSuggestTime               string `json:"pri.suggest.time"`                    // time spend in suggest on primaries, e.g. "31s"
-	SuggestTotal                 int    `json:"suggest.total,string"`                // number of suggest ops on primaries & replicas
-	PriSuggestTotal              int    `json:"pri.suggest.total,string"`            // number of suggest ops on primaries
-	MemoryTotal                  string `json:"memory.total"`                        // total user memory on primaries & replicas, e.g. "1.5kb"
-	PriMemoryTotal               string `json:"pri.memory.total"`                    // total user memory on primaries, e.g. "1.5kb"
+	Health                       string `json:"health" alias:"h"`                                                    // "green", "yellow", or "red"
+	Status                       string `json:"status" alias:"s"`                                                    // "open" or "closed"
+	Index                        string `json:"index" alias:"i,idx"`                                                 // index name
+	UUID                         string `json:"uuid" alias:"id"`                                                     // index uuid
+	Pri                          int    `json:"pri,string" alias:"p,shards.primary,shardsPrimary"`                   // number of primary shards
+	Rep                          int    `json:"rep,string" alias:"r,shards.replica,shardsReplica"`                   // number of replica shards
+	DocsCount                    int    `json:"docs.count,string" alias:"dc,docsCount"`                              // number of available documents
+	DocsDeleted                  int    `json:"docs.deleted,string" alias:"dd,docsDeleted"`                          // number of deleted documents
+	CreationDate                 int64  `json:"creation.date,string" alias:"cd"`                                     // index creation date (millisecond value), e.g. 1527077221644
+	CreationDateString           string `json:"creation.date.string" alias:"cds"`                                    // index creation date (as string), e.g. "2018-05-23T12:07:01.644Z"
+	StoreSize                    string `json:"store.size" alias:"ss,storeSize"`                                     // store size of primaries & replicas, e.g. "4.6kb"
+	PriStoreSize                 string `json:"pri.store.size"`                                                      // store size of primaries, e.g. "230b"
+	CompletionSize               string `json:"completion.size" alias:"cs,completionSize"`                           // size of completion on primaries & replicas
+	PriCompletionSize            string `json:"pri.completion.size"`                                                 // size of completion on primaries
+	FielddataMemorySize          string `json:"fielddata.memory_size" alias:"fm,fielddataMemory"`                    // used fielddata cache on primaries & replicas
+	PriFielddataMemorySize       string `json:"pri.fielddata.memory_size"`                                           // used fielddata cache on primaries
+	FielddataEvictions           int    `json:"fielddata.evictions,string" alias:"fe,fielddataEvictions"`            // fielddata evictions on primaries & replicas
+	PriFielddataEvictions        int    `json:"pri.fielddata.evictions,string"`                                      // fielddata evictions on primaries
+	QueryCacheMemorySize         string `json:"query_cache.memory_size" alias:"qcm,queryCacheMemory"`                // used query cache on primaries & replicas
+	PriQueryCacheMemorySize      string `json:"pri.query_cache.memory_size"`                                         // used query cache on primaries
+	QueryCacheEvictions          int    `json:"query_cache.evictions,string"  alias:"qce,queryCacheEvictions"`       // query cache evictions on primaries & replicas
+	PriQueryCacheEvictions       int    `json:"pri.query_cache.evictions,string"`                                    // query cache evictions on primaries
+	RequestCacheMemorySize       string `json:"request_cache.memory_size" alias:"rcm,requestCacheMemory"`            // used request cache on primaries & replicas
+	PriRequestCacheMemorySize    string `json:"pri.request_cache.memory_size"`                                       // used request cache on primaries
+	RequestCacheEvictions        int    `json:"request_cache.evictions,string" alias:"rce,requestCacheEvictions"`    // request cache evictions on primaries & replicas
+	PriRequestCacheEvictions     int    `json:"pri.request_cache.evictions,string"`                                  // request cache evictions on primaries
+	RequestCacheHitCount         int    `json:"request_cache.hit_count,string" alias:"rchc,requestCacheHitCount"`    // request cache hit count on primaries & replicas
+	PriRequestCacheHitCount      int    `json:"pri.request_cache.hit_count,string"`                                  // request cache hit count on primaries
+	RequestCacheMissCount        int    `json:"request_cache.miss_count,string" alias:"rcmc,requestCacheMissCount"`  // request cache miss count on primaries & replicas
+	PriRequestCacheMissCount     int    `json:"pri.request_cache.miss_count,string"`                                 // request cache miss count on primaries
+	FlushTotal                   int    `json:"flush.total,string" alias:"ft,flushTotal"`                            // number of flushes on primaries & replicas
+	PriFlushTotal                int    `json:"pri.flush.total,string"`                                              // number of flushes on primaries
+	FlushTotalTime               string `json:"flush.total_time" alias:"ftt,flushTotalTime"`                         // time spent in flush on primaries & replicas
+	PriFlushTotalTime            string `json:"pri.flush.total_time"`                                                // time spent in flush on primaries
+	GetCurrent                   int    `json:"get.current,string" alias:"gc,getCurrent"`                            // number of current get ops on primaries & replicas
+	PriGetCurrent                int    `json:"pri.get.current,string"`                                              // number of current get ops on primaries
+	GetTime                      string `json:"get.time" alias:"gti,getTime"`                                        // time spent in get on primaries & replicas
+	PriGetTime                   string `json:"pri.get.time"`                                                        // time spent in get on primaries
+	GetTotal                     int    `json:"get.total,string" alias:"gto,getTotal"`                               // number of get ops on primaries & replicas
+	PriGetTotal                  int    `json:"pri.get.total,string"`                                                // number of get ops on primaries
+	GetExistsTime                string `json:"get.exists_time" alias:"geti,getExistsTime"`                          // time spent in successful gets on primaries & replicas
+	PriGetExistsTime             string `json:"pri.get.exists_time"`                                                 // time spent in successful gets on primaries
+	GetExistsTotal               int    `json:"get.exists_total,string" alias:"geto,getExistsTotal"`                 // number of successful gets on primaries & replicas
+	PriGetExistsTotal            int    `json:"pri.get.exists_total,string"`                                         // number of successful gets on primaries
+	GetMissingTime               string `json:"get.missing_time" alias:"gmti,getMissingTime"`                        // time spent in failed gets on primaries & replicas
+	PriGetMissingTime            string `json:"pri.get.missing_time"`                                                // time spent in failed gets on primaries
+	GetMissingTotal              int    `json:"get.missing_total,string" alias:"gmto,getMissingTotal"`               // number of failed gets on primaries & replicas
+	PriGetMissingTotal           int    `json:"pri.get.missing_total,string"`                                        // number of failed gets on primaries
+	IndexingDeleteCurrent        int    `json:"indexing.delete_current,string" alias:"idc,indexingDeleteCurrent"`    // number of current deletions on primaries & replicas
+	PriIndexingDeleteCurrent     int    `json:"pri.indexing.delete_current,string"`                                  // number of current deletions on primaries
+	IndexingDeleteTime           string `json:"indexing.delete_time" alias:"idti,indexingDeleteTime"`                // time spent in deletions on primaries & replicas
+	PriIndexingDeleteTime        string `json:"pri.indexing.delete_time"`                                            // time spent in deletions on primaries
+	IndexingDeleteTotal          int    `json:"indexing.delete_total,string" alias:"idto,indexingDeleteTotal"`       // number of delete ops on primaries & replicas
+	PriIndexingDeleteTotal       int    `json:"pri.indexing.delete_total,string"`                                    // number of delete ops on primaries
+	IndexingIndexCurrent         int    `json:"indexing.index_current,string" alias:"iic,indexingIdexCurrent"`       // number of current indexing on primaries & replicas
+	PriIndexingIndexCurrent      int    `json:"pri.indexing.index_current,string"`                                   // number of current indexing on primaries
+	IndexingIndexTime            string `json:"indexing.index_time" alias:"iiti,indexingIndexTime"`                  // time spent in indexing on primaries & replicas
+	PriIndexingIndexTime         string `json:"pri.indexing.index_time"`                                             // time spent in indexing on primaries
+	IndexingIndexTotal           int    `json:"indexing.index_total,string" alias:"iito,indexingIndexTotal"`         // number of index ops on primaries & replicas
+	PriIndexingIndexTotal        int    `json:"pri.indexing.index_total,string"`                                     // number of index ops on primaries
+	IndexingIndexFailed          int    `json:"indexing.index_failed,string" alias:"iif,indexingIndexFailed"`        // number of failed indexing ops on primaries & replicas
+	PriIndexingIndexFailed       int    `json:"pri.indexing.index_failed,string"`                                    // number of failed indexing ops on primaries
+	MergesCurrent                int    `json:"merges.current,string" alias:"mc,mergesCurrent"`                      // number of current merges on primaries & replicas
+	PriMergesCurrent             int    `json:"pri.merges.current,string"`                                           // number of current merges on primaries
+	MergesCurrentDocs            int    `json:"merges.current_docs,string" alias:"mcd,mergesCurrentDocs"`            // number of current merging docs on primaries & replicas
+	PriMergesCurrentDocs         int    `json:"pri.merges.current_docs,string"`                                      // number of current merging docs on primaries
+	MergesCurrentSize            string `json:"merges.current_size" alias:"mcs,mergesCurrentSize"`                   // size of current merges on primaries & replicas
+	PriMergesCurrentSize         string `json:"pri.merges.current_size"`                                             // size of current merges on primaries
+	MergesTotal                  int    `json:"merges.total,string" alias:"mt,mergesTotal"`                          // number of completed merge ops on primaries & replicas
+	PriMergesTotal               int    `json:"pri.merges.total,string"`                                             // number of completed merge ops on primaries
+	MergesTotalDocs              int    `json:"merges.total_docs,string" alias:"mtd,mergesTotalDocs"`                // docs merged on primaries & replicas
+	PriMergesTotalDocs           int    `json:"pri.merges.total_docs,string"`                                        // docs merged on primaries
+	MergesTotalSize              string `json:"merges.total_size" alias:"mts,mergesTotalSize"`                       // size merged on primaries & replicas
+	PriMergesTotalSize           string `json:"pri.merges.total_size"`                                               // size merged on primaries
+	MergesTotalTime              string `json:"merges.total_time" alias:"mtt,mergesTotalTIme"`                       // time spent in merges on primaries & replicas
+	PriMergesTotalTime           string `json:"pri.merges.total_time"`                                               // time spent in merges on primaries
+	RefreshTotal                 int    `json:"refresh.total,string" alias:"rto,refreshTotal"`                       // total refreshes on primaries & replicas
+	PriRefreshTotal              int    `json:"pri.refresh.total,string"`                                            // total refreshes on primaries
+	RefreshExternalTotal         int    `json:"refresh.external_total,string" alias:"rto,refreshTotal"`              // total external refreshes on primaries & replicas
+	PriRefreshExternalTotal      int    `json:"pri.refresh.external_total,string"`                                   // total external refreshes on primaries
+	RefreshTime                  string `json:"refresh.time" alias:"rti,refreshTime"`                                // time spent in refreshes on primaries & replicas
+	PriRefreshTime               string `json:"pri.refresh.time"`                                                    // time spent in refreshes on primaries
+	RefreshExternalTime          string `json:"refresh.external_time" alias:"rti,refreshTime"`                       // external time spent in refreshes on primaries & replicas
+	PriRefreshExternalTime       string `json:"pri.refresh.external_time"`                                           // external time spent in refreshes on primaries
+	RefreshListeners             int    `json:"refresh.listeners,string" alias:"rli,refreshListeners"`               // number of pending refresh listeners on primaries & replicas
+	PriRefreshListeners          int    `json:"pri.refresh.listeners,string"`                                        // number of pending refresh listeners on primaries
+	SearchFetchCurrent           int    `json:"search.fetch_current,string" alias:"sfc,searchFetchCurrent"`          // current fetch phase ops on primaries & replicas
+	PriSearchFetchCurrent        int    `json:"pri.search.fetch_current,string"`                                     // current fetch phase ops on primaries
+	SearchFetchTime              string `json:"search.fetch_time" alias:"sfti,searchFetchTime"`                      // time spent in fetch phase on primaries & replicas
+	PriSearchFetchTime           string `json:"pri.search.fetch_time"`                                               // time spent in fetch phase on primaries
+	SearchFetchTotal             int    `json:"search.fetch_total,string" alias:"sfto,searchFetchTotal"`             // total fetch ops on primaries & replicas
+	PriSearchFetchTotal          int    `json:"pri.search.fetch_total,string"`                                       // total fetch ops on primaries
+	SearchOpenContexts           int    `json:"search.open_contexts,string" alias:"so,searchOpenContexts"`           // open search contexts on primaries & replicas
+	PriSearchOpenContexts        int    `json:"pri.search.open_contexts,string"`                                     // open search contexts on primaries
+	SearchQueryCurrent           int    `json:"search.query_current,string" alias:"sqc,searchQueryCurrent"`          // current query phase ops on primaries & replicas
+	PriSearchQueryCurrent        int    `json:"pri.search.query_current,string"`                                     // current query phase ops on primaries
+	SearchQueryTime              string `json:"search.query_time" alias:"sqti,searchQueryTime"`                      // time spent in query phase on primaries & replicas, e.g. "0s"
+	PriSearchQueryTime           string `json:"pri.search.query_time"`                                               // time spent in query phase on primaries, e.g. "0s"
+	SearchQueryTotal             int    `json:"search.query_total,string" alias:"sqto,searchQueryTotal"`             // total query phase ops on primaries & replicas
+	PriSearchQueryTotal          int    `json:"pri.search.query_total,string"`                                       // total query phase ops on primaries
+	SearchScrollCurrent          int    `json:"search.scroll_current,string" alias:"scc,searchScrollCurrent"`        // open scroll contexts on primaries & replicas
+	PriSearchScrollCurrent       int    `json:"pri.search.scroll_current,string"`                                    // open scroll contexts on primaries
+	SearchScrollTime             string `json:"search.scroll_time" alias:"scti,searchScrollTime"`                    // time scroll contexts held open on primaries & replicas, e.g. "0s"
+	PriSearchScrollTime          string `json:"pri.search.scroll_time"`                                              // time scroll contexts held open on primaries, e.g. "0s"
+	SearchScrollTotal            int    `json:"search.scroll_total,string" alias:"scto,searchScrollTotal"`           // completed scroll contexts on primaries & replicas
+	PriSearchScrollTotal         int    `json:"pri.search.scroll_total,string"`                                      // completed scroll contexts on primaries
+	SearchThrottled              bool   `json:"search.throttled,string" alias:"sth"`                                 // indicates if the index is search throttled
+	SegmentsCount                int    `json:"segments.count,string" alias:"sc,segmentsCount"`                      // number of segments on primaries & replicas
+	PriSegmentsCount             int    `json:"pri.segments.count,string"`                                           // number of segments on primaries
+	SegmentsMemory               string `json:"segments.memory" alias:"sc,segmentsMemory"`                           // memory used by segments on primaries & replicas, e.g. "1.3kb"
+	PriSegmentsMemory            string `json:"pri.segments.memory"`                                                 // memory used by segments on primaries, e.g. "1.3kb"
+	SegmentsIndexWriterMemory    string `json:"segments.index_writer_memory" alias:"siwm,segmentsIndexWriterMemory"` // memory used by index writer on primaries & replicas, e.g. "0b"
+	PriSegmentsIndexWriterMemory string `json:"pri.segments.index_writer_memory"`                                    // memory used by index writer on primaries, e.g. "0b"
+	SegmentsVersionMapMemory     string `json:"segments.version_map_memory" alias:"svmm,segmentsVersionMapMemory"`   // memory used by version map on primaries & replicas, e.g. "0b"
+	PriSegmentsVersionMapMemory  string `json:"pri.segments.version_map_memory"`                                     // memory used by version map on primaries, e.g. "0b"
+	SegmentsFixedBitsetMemory    string `json:"segments.fixed_bitset_memory" alias:"sfbm,fixedBitsetMemory"`         // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries & replicas, e.g. "0b"
+	PriSegmentsFixedBitsetMemory string `json:"pri.segments.fixed_bitset_memory"`                                    // memory used by fixed bit sets for nested object field types and type filters for types referred in _parent fields on primaries, e.g. "0b"
+	WarmerCurrent                int    `json:"warmer.current,string" alias:"wc,warmerCurrent"`                      // current warmer ops on primaries & replicas
+	PriWarmerCurrent             int    `json:"pri.warmer.current,string"`                                           // current warmer ops on primaries
+	WarmerTotal                  int    `json:"warmer.total,string" alias:"wto,warmerTotal"`                         // total warmer ops on primaries & replicas
+	PriWarmerTotal               int    `json:"pri.warmer.total,string"`                                             // total warmer ops on primaries
+	WarmerTotalTime              string `json:"warmer.total_time" alias:"wtt,warmerTotalTime"`                       // time spent in warmers on primaries & replicas, e.g. "47s"
+	PriWarmerTotalTime           string `json:"pri.warmer.total_time"`                                               // time spent in warmers on primaries, e.g. "47s"
+	SuggestCurrent               int    `json:"suggest.current,string" alias:"suc,suggestCurrent"`                   // number of current suggest ops on primaries & replicas
+	PriSuggestCurrent            int    `json:"pri.suggest.current,string"`                                          // number of current suggest ops on primaries
+	SuggestTime                  string `json:"suggest.time" alias:"suti,suggestTime"`                               // time spend in suggest on primaries & replicas, "31s"
+	PriSuggestTime               string `json:"pri.suggest.time"`                                                    // time spend in suggest on primaries, e.g. "31s"
+	SuggestTotal                 int    `json:"suggest.total,string" alias:"suto,suggestTotal"`                      // number of suggest ops on primaries & replicas
+	PriSuggestTotal              int    `json:"pri.suggest.total,string"`                                            // number of suggest ops on primaries
+	MemoryTotal                  string `json:"memory.total" alias:"tm,memoryTotal"`                                 // total user memory on primaries & replicas, e.g. "1.5kb"
+	PriMemoryTotal               string `json:"pri.memory.total"`                                                    // total user memory on primaries, e.g. "1.5kb"
+}
+
+// catIndicesResponseRowAliasesMap holds the global compiled map for columns aliases
+// the map is used by CatIndicesService.buildURL
+var catIndicesResponseRowAliasesMap map[string]string
+
+// catIndicesResponseRowAliasesMap needs reflect to be built
+// but it is used once only on the the application start (so considered not harmful for performance)
+func init() {
+	catIndicesResponseRowAliasesMap = make(map[string]string)
+
+	valType := reflect.TypeOf(CatIndicesResponseRow{})
+
+	for i := 0; i < valType.NumField(); i++ {
+		field := valType.Field(i)
+
+		jsonVal := field.Tag.Get("json")
+		if jsonVal == "" {
+			continue
+		}
+
+		jsonVal = strings.Split(jsonVal, ",")[0]
+
+		aliasVal := field.Tag.Get("alias")
+		if aliasVal == "" {
+			continue
+		}
+
+		// for backwards compatibility some fields are able to have the same aliases
+		// that means that one alias can be translated to different columns (from different elastic versions)
+		// example for understanding: rto -> RefreshTotal, RefreshExternalTotal
+		for _, alias := range strings.Split(aliasVal, ",") {
+			if existed, ok := catIndicesResponseRowAliasesMap[alias]; ok {
+				catIndicesResponseRowAliasesMap[alias] = existed + "," + jsonVal
+			} else {
+				catIndicesResponseRowAliasesMap[alias] = jsonVal
+			}
+		}
+	}
+
+	return
 }

--- a/cat_indices_test.go
+++ b/cat_indices_test.go
@@ -26,3 +26,57 @@ func TestCatIndices(t *testing.T) {
 		t.Fatalf("Index[0]: want != %q, have %q", "", have)
 	}
 }
+
+// TestCatIndicesResponseRowAliasesMap tests if catIndicesResponseRowAliasesMap was inited
+func TestCatIndicesResponseRowAliasesMap(t *testing.T) {
+	if catIndicesResponseRowAliasesMap == nil {
+		t.Fatal("want catIndicesResponseRowAliasesMap to be not nil")
+	}
+
+	if len(catIndicesResponseRowAliasesMap) == 0 {
+		t.Fatal("want catIndicesResponseRowAliasesMap to be not empty")
+	}
+}
+
+// TestCatIndicesWithAliases makes a simple test (if ?h=h will be the same as ?h=health)
+func TestCatIndicesWithAliases(t *testing.T) {
+	client := setupTestClientAndCreateIndexAndAddDocs(t, SetDecoder(&strictDecoder{})) // , SetTraceLog(log.New(os.Stdout, "", 0)))
+	ctx := context.Background()
+	res, err := client.CatIndices().Columns("h").Do(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("want response, have nil")
+	}
+	if len(res) == 0 {
+		t.Fatalf("want response, have: %v", res)
+	}
+	if have := res[0].Health; have == "" {
+		t.Fatalf("Index[0]: want != %q, have %q", "", have)
+	}
+}
+
+// TestCatIndicesWithAliases makes a test with a double-alias
+// asking `?h=rti` will fill one of the refresh.external_time/refresh.time fields (depending on elasticsearch version)
+func TestCatIndicesWithAliases_Double(t *testing.T) {
+	client := setupTestClientAndCreateIndexAndAddDocs(t, SetDecoder(&strictDecoder{})) // , SetTraceLog(log.New(os.Stdout, "", 0)))
+	ctx := context.Background()
+	res, err := client.CatIndices().Columns("rti").Do(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("want response, have nil")
+	}
+	if len(res) == 0 {
+		t.Fatalf("want response, have: %v", res)
+	}
+
+	refreshTime := res[0].RefreshTime
+	refreshExternalTime := res[0].RefreshExternalTime
+
+	if refreshTime == "" && refreshExternalTime == "" {
+		t.Fatalf("Index[0]: want one of [refreshTime or refreshExternalTime] be not empty")
+	}
+}

--- a/cat_indices_test.go
+++ b/cat_indices_test.go
@@ -27,7 +27,7 @@ func TestCatIndices(t *testing.T) {
 	}
 }
 
-// TestCatIndicesResponseRowAliasesMap tests if catIndicesResponseRowAliasesMap was inited
+// TestCatIndicesResponseRowAliasesMap tests if catIndicesResponseRowAliasesMap is declared
 func TestCatIndicesResponseRowAliasesMap(t *testing.T) {
 	if catIndicesResponseRowAliasesMap == nil {
 		t.Fatal("want catIndicesResponseRowAliasesMap to be not nil")


### PR DESCRIPTION
### Feature: allow column (`?h=`) aliases in `cat indices API`

#### Why this should be part of the repo?

This repository allows to call any elastic request, so if elastic can execute `http://localhost:9200/_cat/indices?h=idx`, then this repo should too. (having `idx` instead of `index`)


#### Implementation

- in `cat_indices.go`, when url is built - given columns are looked up in the alias map and replaced if any
- an alias can be given to multiple original fields because of backwards compatibility (depending on which of 7.* version, you may have `refresh.time` or `refresh.external_time`, and they both have `rti` alias)
- alias map is constructed on the init stage (using `init()` function). It uses `reflect`, but as it's one-time on-startup call, I consider this not harmful.
Other option (to avoid reflect) is to manually declare the alias map. But this approach has a drawback as well: we declare fields in two places manually: the `CatIndicesResponseRow` struct and the aliases map. And when updating further, developer is required to update BOTH things, so it will become a danger place that can admit bugs when developer updates one thing and forgets about other.
- Tests are added:
  + very simple test to check if alias map exists
  + test on `?h=h` to be the same as `?h=health`
  + test on double alias with `?h=rti`