### PR TITLE
feature(query-interval): QueryIntervals implemented

### DIFF
--- a/search_queries_interval.go
+++ b/search_queries_interval.go
@@ -1,0 +1,43 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+// IntervalRule represents the generic matching rule interface. Matching Rule is
+// just a Query, but may be used only inside IntervalQuery. An extra method is added
+// just to separate *Rule objects from other queries
+type IntervalRule interface {
+	Query
+
+	// IsIntervalRule is never actually called, and is used just for Rule to differ from standard Query
+	IsIntervalRule() bool
+}
+
+// IntervalQuery returns documents based on the order and proximity of matching terms
+//
+// For more details, see
+// https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl-intervals-query.html
+type IntervalQuery struct {
+	field string
+	rule  IntervalRule
+}
+
+// NewIntervalQuery creates and initializes a new IntervalQuery.
+func NewIntervalQuery(field string, rule IntervalRule) *IntervalQuery {
+	return &IntervalQuery{field: field, rule: rule}
+}
+
+// Source returns JSON for the function score query.
+func (q *IntervalQuery) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	ruleSrc, err := q.rule.Source()
+	if err != nil {
+		return nil, err
+	}
+
+	source[q.field] = ruleSrc
+
+	return source, nil
+}

--- a/search_queries_interval.go
+++ b/search_queries_interval.go
@@ -4,14 +4,14 @@
 
 package elastic
 
-// IntervalRule represents the generic matching rule interface. Matching Rule is
+// IntervalQueryRule represents the generic matching interval rule interface. Interval Rule is actually
 // just a Query, but may be used only inside IntervalQuery. An extra method is added
-// just to separate *Rule objects from other queries
-type IntervalRule interface {
+// just to separate all its implementations (*Rule objects) from other query objects
+type IntervalQueryRule interface {
 	Query
 
-	// IsIntervalRule is never actually called, and is used just for Rule to differ from standard Query
-	IsIntervalRule() bool
+	// isIntervalQueryRule is never actually called, and is used just for Rule to differ from standard Query
+	isIntervalQueryRule() bool
 }
 
 // IntervalQuery returns documents based on the order and proximity of matching terms
@@ -20,11 +20,11 @@ type IntervalRule interface {
 // https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl-intervals-query.html
 type IntervalQuery struct {
 	field string
-	rule  IntervalRule
+	rule  IntervalQueryRule
 }
 
 // NewIntervalQuery creates and initializes a new IntervalQuery.
-func NewIntervalQuery(field string, rule IntervalRule) *IntervalQuery {
+func NewIntervalQuery(field string, rule IntervalQueryRule) *IntervalQuery {
 	return &IntervalQuery{field: field, rule: rule}
 }
 

--- a/search_queries_interval_rules_all_of.go
+++ b/search_queries_interval_rules_all_of.go
@@ -1,35 +1,35 @@
 package elastic
 
-type AllOfRule struct {
-	intervals []IntervalRule
+type IntervalQueryRuleAllOf struct {
+	intervals []IntervalQueryRule
 	maxGaps   *int
 	ordered   *bool
-	filter    *FilterRule
+	filter    *IntervalQueryRuleFilter
 }
 
-var _ IntervalRule = &AllOfRule{}
+var _ IntervalQueryRule = &IntervalQueryRuleAllOf{}
 
-func NewAllOfRule(intervals ...IntervalRule) *AllOfRule {
-	return &AllOfRule{intervals: intervals}
+func NewIntervalQueryRuleAllOf(intervals ...IntervalQueryRule) *IntervalQueryRuleAllOf {
+	return &IntervalQueryRuleAllOf{intervals: intervals}
 }
 
-func (r *AllOfRule) MaxGaps(maxGaps int) *AllOfRule {
+func (r *IntervalQueryRuleAllOf) MaxGaps(maxGaps int) *IntervalQueryRuleAllOf {
 	r.maxGaps = &maxGaps
 	return r
 }
 
-func (r *AllOfRule) Ordered(ordered bool) *AllOfRule {
+func (r *IntervalQueryRuleAllOf) Ordered(ordered bool) *IntervalQueryRuleAllOf {
 	r.ordered = &ordered
 	return r
 }
 
-func (r *AllOfRule) Filter(filter *FilterRule) *AllOfRule {
+func (r *IntervalQueryRuleAllOf) Filter(filter *IntervalQueryRuleFilter) *IntervalQueryRuleAllOf {
 	r.filter = filter
 	return r
 }
 
 // Source returns JSON for the function score query.
-func (r *AllOfRule) Source() (interface{}, error) {
+func (r *IntervalQueryRuleAllOf) Source() (interface{}, error) {
 	source := make(map[string]interface{})
 
 	intervalSources := make([]interface{}, 0)
@@ -61,6 +61,6 @@ func (r *AllOfRule) Source() (interface{}, error) {
 	return map[string]interface{}{"all_of": source}, nil
 }
 
-func (r *AllOfRule) IsIntervalRule() bool {
+func (r *IntervalQueryRuleAllOf) isIntervalQueryRule() bool {
 	return true
 }

--- a/search_queries_interval_rules_all_of.go
+++ b/search_queries_interval_rules_all_of.go
@@ -1,0 +1,66 @@
+package elastic
+
+type AllOfRule struct {
+	intervals []IntervalRule
+	maxGaps   *int
+	ordered   *bool
+	filter    *FilterRule
+}
+
+var _ IntervalRule = &AllOfRule{}
+
+func NewAllOfRule(intervals ...IntervalRule) *AllOfRule {
+	return &AllOfRule{intervals: intervals}
+}
+
+func (r *AllOfRule) MaxGaps(maxGaps int) *AllOfRule {
+	r.maxGaps = &maxGaps
+	return r
+}
+
+func (r *AllOfRule) Ordered(ordered bool) *AllOfRule {
+	r.ordered = &ordered
+	return r
+}
+
+func (r *AllOfRule) Filter(filter *FilterRule) *AllOfRule {
+	r.filter = filter
+	return r
+}
+
+// Source returns JSON for the function score query.
+func (r *AllOfRule) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	intervalSources := make([]interface{}, 0)
+	for _, interval := range r.intervals {
+		src, err := interval.Source()
+		if err != nil {
+			return nil, err
+		}
+
+		intervalSources = append(intervalSources, src)
+	}
+	source["intervals"] = intervalSources
+
+	if r.ordered != nil {
+		source["ordered"] = *r.ordered
+	}
+	if r.maxGaps != nil {
+		source["max_gaps"] = *r.maxGaps
+	}
+	if r.filter != nil {
+		src, err := r.filter.Source()
+		if err != nil {
+			return nil, err
+		}
+
+		source["filter"] = src
+	}
+
+	return map[string]interface{}{"all_of": source}, nil
+}
+
+func (r *AllOfRule) IsIntervalRule() bool {
+	return true
+}

--- a/search_queries_interval_rules_any_of.go
+++ b/search_queries_interval_rules_any_of.go
@@ -1,22 +1,22 @@
 package elastic
 
-type AnyOfRule struct {
-	intervals []IntervalRule
-	filter    *FilterRule
+type IntervalQueryRuleAnyOf struct {
+	intervals []IntervalQueryRule
+	filter    *IntervalQueryRuleFilter
 }
 
-var _ IntervalRule = &AnyOfRule{}
+var _ IntervalQueryRule = &IntervalQueryRuleAnyOf{}
 
-func NewAnyOfRule(intervals ...IntervalRule) *AnyOfRule {
-	return &AnyOfRule{intervals: intervals}
+func NewIntervalQueryRuleAnyOf(intervals ...IntervalQueryRule) *IntervalQueryRuleAnyOf {
+	return &IntervalQueryRuleAnyOf{intervals: intervals}
 }
-func (r *AnyOfRule) Filter(filter *FilterRule) *AnyOfRule {
+func (r *IntervalQueryRuleAnyOf) Filter(filter *IntervalQueryRuleFilter) *IntervalQueryRuleAnyOf {
 	r.filter = filter
 	return r
 }
 
 // Source returns JSON for the function score query.
-func (r *AnyOfRule) Source() (interface{}, error) {
+func (r *IntervalQueryRuleAnyOf) Source() (interface{}, error) {
 	source := make(map[string]interface{})
 
 	intervalSources := make([]interface{}, 0)
@@ -42,6 +42,6 @@ func (r *AnyOfRule) Source() (interface{}, error) {
 	return map[string]interface{}{"any_of": source}, nil
 }
 
-func (r *AnyOfRule) IsIntervalRule() bool {
+func (r *IntervalQueryRuleAnyOf) isIntervalQueryRule() bool {
 	return true
 }

--- a/search_queries_interval_rules_any_of.go
+++ b/search_queries_interval_rules_any_of.go
@@ -1,0 +1,47 @@
+package elastic
+
+type AnyOfRule struct {
+	intervals []IntervalRule
+	filter    *FilterRule
+}
+
+var _ IntervalRule = &AnyOfRule{}
+
+func NewAnyOfRule(intervals ...IntervalRule) *AnyOfRule {
+	return &AnyOfRule{intervals: intervals}
+}
+func (r *AnyOfRule) Filter(filter *FilterRule) *AnyOfRule {
+	r.filter = filter
+	return r
+}
+
+// Source returns JSON for the function score query.
+func (r *AnyOfRule) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	intervalSources := make([]interface{}, 0)
+	for _, interval := range r.intervals {
+		src, err := interval.Source()
+		if err != nil {
+			return nil, err
+		}
+
+		intervalSources = append(intervalSources, src)
+	}
+	source["intervals"] = intervalSources
+
+	if r.filter != nil {
+		src, err := r.filter.Source()
+		if err != nil {
+			return nil, err
+		}
+
+		source["filter"] = src
+	}
+
+	return map[string]interface{}{"any_of": source}, nil
+}
+
+func (r *AnyOfRule) IsIntervalRule() bool {
+	return true
+}

--- a/search_queries_interval_rules_filter.go
+++ b/search_queries_interval_rules_filter.go
@@ -1,0 +1,142 @@
+package elastic
+
+type FilterRule struct {
+	after          Query
+	before         Query
+	containedBy    Query
+	containing     Query
+	overlapping    Query
+	notContainedBy Query
+	notContaining  Query
+	notOverlapping Query
+	script         *Script
+}
+
+var _ IntervalRule = &FilterRule{}
+
+func NewFilterRule() *FilterRule {
+	return &FilterRule{}
+}
+
+func (r *FilterRule) After(after Query) *FilterRule {
+	r.after = after
+	return r
+}
+func (r *FilterRule) Before(before Query) *FilterRule {
+	r.before = before
+	return r
+}
+func (r *FilterRule) ContainedBy(containedBy Query) *FilterRule {
+	r.containedBy = containedBy
+	return r
+}
+func (r *FilterRule) Containing(containing Query) *FilterRule {
+	r.containing = containing
+	return r
+}
+func (r *FilterRule) Overlapping(overlapping Query) *FilterRule {
+	r.overlapping = overlapping
+	return r
+}
+func (r *FilterRule) NotContainedBy(notContainedBy Query) *FilterRule {
+	r.notContainedBy = notContainedBy
+	return r
+}
+func (r *FilterRule) NotContaining(notContaining Query) *FilterRule {
+	r.notContaining = notContaining
+	return r
+}
+func (r *FilterRule) NotOverlapping(notOverlapping Query) *FilterRule {
+	r.notOverlapping = notOverlapping
+	return r
+}
+func (r *FilterRule) Script(script *Script) *FilterRule {
+	r.script = script
+	return r
+}
+
+// Source returns JSON for the function score query.
+func (r *FilterRule) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	if r.before != nil {
+		src, err := r.before.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["before"] = src
+	}
+
+	if r.after != nil {
+		src, err := r.after.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["after"] = src
+	}
+
+	if r.containedBy != nil {
+		src, err := r.containedBy.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["contained_by"] = src
+	}
+
+	if r.containing != nil {
+		src, err := r.containing.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["containing"] = src
+	}
+
+	if r.overlapping != nil {
+		src, err := r.overlapping.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["overlapping"] = src
+	}
+
+	if r.notContainedBy != nil {
+		src, err := r.notContainedBy.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["not_contained_by"] = src
+	}
+
+	if r.notContaining != nil {
+		src, err := r.notContaining.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["not_containing"] = src
+	}
+
+	if r.notOverlapping != nil {
+		src, err := r.notOverlapping.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["not_overlapping"] = src
+	}
+
+	if r.script != nil {
+		src, err := r.script.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["script"] = src
+	}
+
+	// todo: not so clear from docs, if filter can be a top-level rule, and so
+	// 	if it does need a wrapper map[string]interface{}{"filter": ..} like other rules do
+
+	return source, nil
+}
+
+func (r *FilterRule) IsIntervalRule() bool {
+	return true
+}

--- a/search_queries_interval_rules_filter.go
+++ b/search_queries_interval_rules_filter.go
@@ -1,6 +1,6 @@
 package elastic
 
-type FilterRule struct {
+type IntervalQueryRuleFilter struct {
 	after          Query
 	before         Query
 	containedBy    Query
@@ -12,51 +12,51 @@ type FilterRule struct {
 	script         *Script
 }
 
-var _ IntervalRule = &FilterRule{}
+var _ IntervalQueryRule = &IntervalQueryRuleFilter{}
 
-func NewFilterRule() *FilterRule {
-	return &FilterRule{}
+func NewIntervalQueryRuleFilter() *IntervalQueryRuleFilter {
+	return &IntervalQueryRuleFilter{}
 }
 
-func (r *FilterRule) After(after Query) *FilterRule {
+func (r *IntervalQueryRuleFilter) After(after Query) *IntervalQueryRuleFilter {
 	r.after = after
 	return r
 }
-func (r *FilterRule) Before(before Query) *FilterRule {
+func (r *IntervalQueryRuleFilter) Before(before Query) *IntervalQueryRuleFilter {
 	r.before = before
 	return r
 }
-func (r *FilterRule) ContainedBy(containedBy Query) *FilterRule {
+func (r *IntervalQueryRuleFilter) ContainedBy(containedBy Query) *IntervalQueryRuleFilter {
 	r.containedBy = containedBy
 	return r
 }
-func (r *FilterRule) Containing(containing Query) *FilterRule {
+func (r *IntervalQueryRuleFilter) Containing(containing Query) *IntervalQueryRuleFilter {
 	r.containing = containing
 	return r
 }
-func (r *FilterRule) Overlapping(overlapping Query) *FilterRule {
+func (r *IntervalQueryRuleFilter) Overlapping(overlapping Query) *IntervalQueryRuleFilter {
 	r.overlapping = overlapping
 	return r
 }
-func (r *FilterRule) NotContainedBy(notContainedBy Query) *FilterRule {
+func (r *IntervalQueryRuleFilter) NotContainedBy(notContainedBy Query) *IntervalQueryRuleFilter {
 	r.notContainedBy = notContainedBy
 	return r
 }
-func (r *FilterRule) NotContaining(notContaining Query) *FilterRule {
+func (r *IntervalQueryRuleFilter) NotContaining(notContaining Query) *IntervalQueryRuleFilter {
 	r.notContaining = notContaining
 	return r
 }
-func (r *FilterRule) NotOverlapping(notOverlapping Query) *FilterRule {
+func (r *IntervalQueryRuleFilter) NotOverlapping(notOverlapping Query) *IntervalQueryRuleFilter {
 	r.notOverlapping = notOverlapping
 	return r
 }
-func (r *FilterRule) Script(script *Script) *FilterRule {
+func (r *IntervalQueryRuleFilter) Script(script *Script) *IntervalQueryRuleFilter {
 	r.script = script
 	return r
 }
 
 // Source returns JSON for the function score query.
-func (r *FilterRule) Source() (interface{}, error) {
+func (r *IntervalQueryRuleFilter) Source() (interface{}, error) {
 	source := make(map[string]interface{})
 
 	if r.before != nil {
@@ -137,6 +137,6 @@ func (r *FilterRule) Source() (interface{}, error) {
 	return source, nil
 }
 
-func (r *FilterRule) IsIntervalRule() bool {
+func (r *IntervalQueryRuleFilter) isIntervalQueryRule() bool {
 	return true
 }

--- a/search_queries_interval_rules_match.go
+++ b/search_queries_interval_rules_match.go
@@ -1,0 +1,71 @@
+package elastic
+
+type MatchRule struct {
+	query    string
+	maxGaps  *int
+	ordered  *bool
+	analyzer string
+	useField string
+	filter   *FilterRule
+}
+
+var _ IntervalRule = &MatchRule{}
+
+func NewMatchRule(query string) *MatchRule {
+	return &MatchRule{query: query}
+}
+
+func (r *MatchRule) MaxGaps(maxGaps int) *MatchRule {
+	r.maxGaps = &maxGaps
+	return r
+}
+func (r *MatchRule) Ordered(ordered bool) *MatchRule {
+	r.ordered = &ordered
+	return r
+}
+func (r *MatchRule) Analyzer(analyzer string) *MatchRule {
+	r.analyzer = analyzer
+	return r
+}
+func (r *MatchRule) UseField(useField string) *MatchRule {
+	r.useField = useField
+	return r
+}
+func (r *MatchRule) Filter(filter *FilterRule) *MatchRule {
+	r.filter = filter
+	return r
+}
+
+// Source returns JSON for the function score query.
+func (r *MatchRule) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	source["query"] = r.query
+
+	if r.ordered != nil {
+		source["ordered"] = *r.ordered
+	}
+	if r.maxGaps != nil {
+		source["max_gaps"] = *r.maxGaps
+	}
+	if r.analyzer != "" {
+		source["analyzer"] = r.analyzer
+	}
+	if r.useField != "" {
+		source["use_field"] = r.useField
+	}
+	if r.filter != nil {
+		filterRuleSource, err := r.filter.Source()
+		if err != nil {
+			return nil, err
+		}
+
+		source["filter"] = filterRuleSource
+	}
+
+	return map[string]interface{}{"match": source}, nil
+}
+
+func (r *MatchRule) IsIntervalRule() bool {
+	return true
+}

--- a/search_queries_interval_rules_match.go
+++ b/search_queries_interval_rules_match.go
@@ -1,43 +1,43 @@
 package elastic
 
-type MatchRule struct {
+type IntervalQueryRuleMatch struct {
 	query    string
 	maxGaps  *int
 	ordered  *bool
 	analyzer string
 	useField string
-	filter   *FilterRule
+	filter   *IntervalQueryRuleFilter
 }
 
-var _ IntervalRule = &MatchRule{}
+var _ IntervalQueryRule = &IntervalQueryRuleMatch{}
 
-func NewMatchRule(query string) *MatchRule {
-	return &MatchRule{query: query}
+func NewIntervalQueryRuleMatch(query string) *IntervalQueryRuleMatch {
+	return &IntervalQueryRuleMatch{query: query}
 }
 
-func (r *MatchRule) MaxGaps(maxGaps int) *MatchRule {
+func (r *IntervalQueryRuleMatch) MaxGaps(maxGaps int) *IntervalQueryRuleMatch {
 	r.maxGaps = &maxGaps
 	return r
 }
-func (r *MatchRule) Ordered(ordered bool) *MatchRule {
+func (r *IntervalQueryRuleMatch) Ordered(ordered bool) *IntervalQueryRuleMatch {
 	r.ordered = &ordered
 	return r
 }
-func (r *MatchRule) Analyzer(analyzer string) *MatchRule {
+func (r *IntervalQueryRuleMatch) Analyzer(analyzer string) *IntervalQueryRuleMatch {
 	r.analyzer = analyzer
 	return r
 }
-func (r *MatchRule) UseField(useField string) *MatchRule {
+func (r *IntervalQueryRuleMatch) UseField(useField string) *IntervalQueryRuleMatch {
 	r.useField = useField
 	return r
 }
-func (r *MatchRule) Filter(filter *FilterRule) *MatchRule {
+func (r *IntervalQueryRuleMatch) Filter(filter *IntervalQueryRuleFilter) *IntervalQueryRuleMatch {
 	r.filter = filter
 	return r
 }
 
 // Source returns JSON for the function score query.
-func (r *MatchRule) Source() (interface{}, error) {
+func (r *IntervalQueryRuleMatch) Source() (interface{}, error) {
 	source := make(map[string]interface{})
 
 	source["query"] = r.query
@@ -66,6 +66,6 @@ func (r *MatchRule) Source() (interface{}, error) {
 	return map[string]interface{}{"match": source}, nil
 }
 
-func (r *MatchRule) IsIntervalRule() bool {
+func (r *IntervalQueryRuleMatch) isIntervalQueryRule() bool {
 	return true
 }

--- a/search_queries_interval_rules_prefix.go
+++ b/search_queries_interval_rules_prefix.go
@@ -1,0 +1,42 @@
+package elastic
+
+type PrefixRule struct {
+	prefix   string
+	analyzer string
+	useField string
+}
+
+var _ IntervalRule = &PrefixRule{}
+
+func NewPrefixRule(prefix string) *PrefixRule {
+	return &PrefixRule{prefix: prefix}
+}
+
+func (r *PrefixRule) Analyzer(analyzer string) *PrefixRule {
+	r.analyzer = analyzer
+	return r
+}
+func (r *PrefixRule) UseField(useField string) *PrefixRule {
+	r.useField = useField
+	return r
+}
+
+// Source returns JSON for the function score query.
+func (r *PrefixRule) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	source["query"] = r.prefix
+
+	if r.analyzer != "" {
+		source["analyzer"] = r.analyzer
+	}
+	if r.useField != "" {
+		source["use_field"] = r.useField
+	}
+
+	return map[string]interface{}{"prefix": source}, nil
+}
+
+func (r *PrefixRule) IsIntervalRule() bool {
+	return true
+}

--- a/search_queries_interval_rules_prefix.go
+++ b/search_queries_interval_rules_prefix.go
@@ -1,28 +1,28 @@
 package elastic
 
-type PrefixRule struct {
+type IntervalQueryRulePrefix struct {
 	prefix   string
 	analyzer string
 	useField string
 }
 
-var _ IntervalRule = &PrefixRule{}
+var _ IntervalQueryRule = &IntervalQueryRulePrefix{}
 
-func NewPrefixRule(prefix string) *PrefixRule {
-	return &PrefixRule{prefix: prefix}
+func NewIntervalQueryRulePrefix(prefix string) *IntervalQueryRulePrefix {
+	return &IntervalQueryRulePrefix{prefix: prefix}
 }
 
-func (r *PrefixRule) Analyzer(analyzer string) *PrefixRule {
+func (r *IntervalQueryRulePrefix) Analyzer(analyzer string) *IntervalQueryRulePrefix {
 	r.analyzer = analyzer
 	return r
 }
-func (r *PrefixRule) UseField(useField string) *PrefixRule {
+func (r *IntervalQueryRulePrefix) UseField(useField string) *IntervalQueryRulePrefix {
 	r.useField = useField
 	return r
 }
 
 // Source returns JSON for the function score query.
-func (r *PrefixRule) Source() (interface{}, error) {
+func (r *IntervalQueryRulePrefix) Source() (interface{}, error) {
 	source := make(map[string]interface{})
 
 	source["query"] = r.prefix
@@ -37,6 +37,6 @@ func (r *PrefixRule) Source() (interface{}, error) {
 	return map[string]interface{}{"prefix": source}, nil
 }
 
-func (r *PrefixRule) IsIntervalRule() bool {
+func (r *IntervalQueryRulePrefix) isIntervalQueryRule() bool {
 	return true
 }

--- a/search_queries_interval_rules_wildcard.go
+++ b/search_queries_interval_rules_wildcard.go
@@ -1,28 +1,28 @@
 package elastic
 
-type WildcardRule struct {
+type IntervalQueryRuleWildcard struct {
 	pattern  string
 	analyzer string
 	useField string
 }
 
-var _ IntervalRule = &WildcardRule{}
+var _ IntervalQueryRule = &IntervalQueryRuleWildcard{}
 
-func NewWildcardRule(pattern string) *WildcardRule {
-	return &WildcardRule{pattern: pattern}
+func NewIntervalQueryRuleWildcard(pattern string) *IntervalQueryRuleWildcard {
+	return &IntervalQueryRuleWildcard{pattern: pattern}
 }
 
-func (r *WildcardRule) Analyzer(analyzer string) *WildcardRule {
+func (r *IntervalQueryRuleWildcard) Analyzer(analyzer string) *IntervalQueryRuleWildcard {
 	r.analyzer = analyzer
 	return r
 }
-func (r *WildcardRule) UseField(useField string) *WildcardRule {
+func (r *IntervalQueryRuleWildcard) UseField(useField string) *IntervalQueryRuleWildcard {
 	r.useField = useField
 	return r
 }
 
 // Source returns JSON for the function score query.
-func (r *WildcardRule) Source() (interface{}, error) {
+func (r *IntervalQueryRuleWildcard) Source() (interface{}, error) {
 	source := make(map[string]interface{})
 
 	source["pattern"] = r.pattern
@@ -37,6 +37,6 @@ func (r *WildcardRule) Source() (interface{}, error) {
 	return map[string]interface{}{"wildcard": source}, nil
 }
 
-func (r *WildcardRule) IsIntervalRule() bool {
+func (r *IntervalQueryRuleWildcard) isIntervalQueryRule() bool {
 	return true
 }

--- a/search_queries_interval_rules_wildcard.go
+++ b/search_queries_interval_rules_wildcard.go
@@ -1,0 +1,42 @@
+package elastic
+
+type WildcardRule struct {
+	pattern  string
+	analyzer string
+	useField string
+}
+
+var _ IntervalRule = &WildcardRule{}
+
+func NewWildcardRule(pattern string) *WildcardRule {
+	return &WildcardRule{pattern: pattern}
+}
+
+func (r *WildcardRule) Analyzer(analyzer string) *WildcardRule {
+	r.analyzer = analyzer
+	return r
+}
+func (r *WildcardRule) UseField(useField string) *WildcardRule {
+	r.useField = useField
+	return r
+}
+
+// Source returns JSON for the function score query.
+func (r *WildcardRule) Source() (interface{}, error) {
+	source := make(map[string]interface{})
+
+	source["pattern"] = r.pattern
+
+	if r.analyzer != "" {
+		source["analyzer"] = r.analyzer
+	}
+	if r.useField != "" {
+		source["use_field"] = r.useField
+	}
+
+	return map[string]interface{}{"wildcard": source}, nil
+}
+
+func (r *WildcardRule) IsIntervalRule() bool {
+	return true
+}


### PR DESCRIPTION
fix #1228 

WIP:
- [ ] automated tests are not there yet
- [ ] not full documentation comments are there yet
- [ ] some doubts on FilterRule (there is a `todo` placed there)
- [x] @olivere are you OK with the approach of declaring a new interface `IntervalRule`, that actually is just a `Query`? It is made just for the reason: so some methods like `NewIntervalsQuery` accept only those 6 types of rules (but not all the queries). `IntervalsQuery` is the first time library meets such thing