### PR TITLE
Fix uritemplates method in the godoc

### DIFF
--- a/uritemplates/uritemplates.go
+++ b/uritemplates/uritemplates.go
@@ -12,7 +12,7 @@
 //	values := make(map[string]interface{})
 //	values["user"] = "jtacoma"
 //	values["repo"] = "uritemplates"
-//	expanded, _ := template.ExpandString(values)
+//	expanded, _ := template.Expand(values)
 //	fmt.Printf(expanded)
 //
 package uritemplates


### PR DESCRIPTION
There is no `ExpandString` method for `*UriTemplate`.