### PR TITLE
Fix aws v4 signer to not read body if already seeker, not read response

### DIFF
--- a/aws/v4/aws_v4.go
+++ b/aws/v4/aws_v4.go
@@ -6,6 +6,7 @@ package v4
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -53,37 +54,29 @@ func (st Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// Escaping path
 		req.URL.RawPath = url.PathEscape(req.URL.RawPath)
 	}
+
 	now := time.Now().UTC()
 	req.Header.Set("Date", now.Format(time.RFC3339))
+
 	var err error
 	switch req.Body {
 	case nil:
 		_, err = st.signer.Sign(req, nil, "es", st.region, now)
 	default:
-		buf, err := ioutil.ReadAll(req.Body)
-		if err != nil {
-			return nil, err
+		switch body := req.Body.(type) {
+		case io.ReadSeeker:
+			_, err = st.signer.Sign(req, body, "es", st.region, now)
+		default:
+			buf, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			req.Body = ioutil.NopCloser(bytes.NewReader(buf))
+			_, err = st.signer.Sign(req, bytes.NewReader(buf), "es", st.region, time.Now().UTC())
 		}
-		req.Body = ioutil.NopCloser(bytes.NewReader(buf))
-		_, err = st.signer.Sign(req, bytes.NewReader(buf), "es", st.region, time.Now().UTC())
 	}
 	if err != nil {
 		return nil, err
 	}
-	resp, err := st.client.Do(req)
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
-	}
-	if err != nil {
-		return nil, err
-	}
-	if resp.Body != nil {
-		buf := new(bytes.Buffer)
-		_, err = buf.ReadFrom(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		resp.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
-	}
-	return resp, nil
+	return st.client.Do(req)
 }


### PR DESCRIPTION
Related to comments in: https://github.com/olivere/elastic/issues/1306
1. Do not read the request body if it is already a ReaderSeeker
2. Do not read the whole response, let the caller do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/olivere/elastic/1307)
<!-- Reviewable:end -->
