### PR TITLE
Add fields for script exceptions to error details

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -82,6 +82,21 @@ type ErrorDetails struct {
 	CausedBy     map[string]interface{}   `json:"caused_by,omitempty"`
 	RootCause    []*ErrorDetails          `json:"root_cause,omitempty"`
 	FailedShards []map[string]interface{} `json:"failed_shards,omitempty"`
+
+	// ScriptException adds the information in the following block.
+
+	ScriptStack []string             `json:"script_stack,omitempty"` // from ScriptException
+	Script      string               `json:"script,omitempty"`       // from ScriptException
+	Lang        string               `json:"lang,omitempty"`         // from ScriptException
+	Position    *ScriptErrorPosition `json:"position,omitempty"`     // from ScriptException (7.7+)
+}
+
+// ScriptErrorPosition specifies the position of the error
+// in a script. It is used in ErrorDetails for scripting errors.
+type ScriptErrorPosition struct {
+	Offset int `json:"offset"`
+	Start  int `json:"start"`
+	End    int `json:"end"`
 }
 
 // Error returns a string representation of the error.

--- a/tasks_get_task.go
+++ b/tasks_get_task.go
@@ -162,7 +162,8 @@ func (s *TasksGetTaskService) Do(ctx context.Context) (*TasksGetTaskResponse, er
 }
 
 type TasksGetTaskResponse struct {
-	Header    http.Header `json:"-"`
-	Completed bool        `json:"completed"`
-	Task      *TaskInfo   `json:"task,omitempty"`
+	Header    http.Header   `json:"-"`
+	Completed bool          `json:"completed"`
+	Task      *TaskInfo     `json:"task,omitempty"`
+	Error     *ErrorDetails `json:"error,omitempty"`
 }

--- a/tasks_get_task_test.go
+++ b/tasks_get_task_test.go
@@ -6,7 +6,9 @@ package elastic
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 )
 
 func TestTasksGetTaskBuildURL(t *testing.T) {
@@ -77,4 +79,69 @@ func TestTasksGetTask(t *testing.T) {
 			t.Fatalf("expected headers[%q]=%q; got: %q", "X-Opaque-Id", want, have)
 		}
 	*/
+}
+
+func TestTasksGetTaskWithError(t *testing.T) {
+	client := setupTestClientAndCreateIndexAndAddDocs(t) //, SetTraceLog(log.New(os.Stdout, "", 0)))
+
+	// Create a reindexing task
+	var taskID string
+	{
+		res, err := client.UpdateByQuery(testIndexName).
+			WaitForCompletion(false).
+			Conflicts("proceed").
+			Script(NewScript("kaboom")).
+			DoAsync(context.Background())
+		if err != nil {
+			t.Fatalf("unable to start update_by_query task: %v", err)
+		}
+		taskID = res.TaskId
+	}
+
+	var (
+		response *TasksGetTaskResponse
+		lastErr  error
+	)
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		for {
+			// Get the task by ID
+			res, err := client.TasksGetTask().
+				TaskId(taskID).
+				Do(context.Background())
+			if err != nil {
+				lastErr = err
+				return
+			}
+			if res == nil {
+				lastErr = errors.New("response is nil")
+				return
+			}
+			if res.Completed {
+				lastErr = nil
+				response = res
+				return
+			}
+			time.Sleep(1 * time.Second) // retry
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected to finish the task after 5 seconds")
+	}
+	if lastErr != nil {
+		t.Fatalf("expected no error, got %v", lastErr)
+	}
+	if response == nil {
+		t.Fatal("expected a response, got nil")
+	}
+	if response.Error == nil {
+		t.Fatal("expected a response with an error, got nil")
+	}
+	if want, have := "script_exception", response.Error.Type; want != have {
+		t.Fatalf("expected an error type of %q, got %q", want, have)
+	}
 }


### PR DESCRIPTION
When a task fails when run asynchronously, it returns the error in the
Task Get API. If it was a script exception, it returns four additional
fields that we added now.

Close #1302