### PR TITLE
Change MultiMatchQuery to always include fields

### DIFF
--- a/search_queries_multi_match.go
+++ b/search_queries_multi_match.go
@@ -39,7 +39,6 @@ type MultiMatchQuery struct {
 func NewMultiMatchQuery(text interface{}, fields ...string) *MultiMatchQuery {
 	q := &MultiMatchQuery{
 		text:        text,
-		fields:      make([]string, 0),
 		fieldBoosts: make(map[string]*float64),
 	}
 	q.fields = append(q.fields, fields...)
@@ -209,19 +208,21 @@ func (q *MultiMatchQuery) Source() (interface{}, error) {
 
 	multiMatch["query"] = q.text
 
-	if len(q.fields) > 0 {
-		var fields []string
-		for _, field := range q.fields {
-			if boost, found := q.fieldBoosts[field]; found {
-				if boost != nil {
-					fields = append(fields, fmt.Sprintf("%s^%f", field, *boost))
-				} else {
-					fields = append(fields, field)
-				}
+	var fields []string
+	for _, field := range q.fields {
+		if boost, found := q.fieldBoosts[field]; found {
+			if boost != nil {
+				fields = append(fields, fmt.Sprintf("%s^%f", field, *boost))
 			} else {
 				fields = append(fields, field)
 			}
+		} else {
+			fields = append(fields, field)
 		}
+	}
+	if fields == nil {
+		multiMatch["fields"] = []string{}
+	} else {
 		multiMatch["fields"] = fields
 	}
 

--- a/search_queries_multi_match_test.go
+++ b/search_queries_multi_match_test.go
@@ -26,6 +26,23 @@ func TestMultiMatchQuery(t *testing.T) {
 	}
 }
 
+func TestMultiMatchQueryWithNoFields(t *testing.T) {
+	q := NewMultiMatchQuery("accident")
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"multi_match":{"fields":[],"query":"accident"}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
 func TestMultiMatchQueryBestFields(t *testing.T) {
 	q := NewMultiMatchQuery("this is a test", "subject", "message").Type("best_fields")
 	src, err := q.Source()


### PR DESCRIPTION
This commit changes the `MultiMatchQuery` to always include the
`"fields"`, even when empty. They are serialized as `"fields":[]` now
instead of being omitted from the request.

Close #1268