### PR TITLE
No need to force https in aws signer

### DIFF
--- a/aws/v4/aws_v4.go
+++ b/aws/v4/aws_v4.go
@@ -48,7 +48,6 @@ func (st Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return st.client.Do(req)
 	}
 
-	req.URL.Scheme = "https"
 	if strings.Contains(req.URL.RawPath, "%2C") {
 		// Escaping path
 		req.URL.RawPath = url.PathEscape(req.URL.RawPath)


### PR DESCRIPTION
There is no need to force https in the aws signer.
This already happens by default, and forcing it ruins the ability to test in dev against an elasticsearch docker container.

This is a backport to v6.

Close #1328 