### PR TITLE
Use Pool to store and reuse GZIPWriters

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ package elastic
 import (
 	"bytes"
 	"context"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -101,6 +102,12 @@ var (
 	// noDeprecationLog is a no-op for logging deprecations.
 	noDeprecationLog = func(*http.Request, *http.Response) {}
 )
+
+var gzipWriterPool = sync.Pool {
+	New: func()interface{} {
+		return gzip.NewWriter(new(bytes.Buffer))
+	},
+}
 
 // ClientOptionFunc is a function that configures a Client.
 // It is used in NewClient.
@@ -1347,7 +1354,18 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 
 		// Set body
 		if opt.Body != nil {
-			err = req.SetBody(opt.Body, gzipEnabled)
+			var gzipWriter *gzip.Writer;
+			if gzipEnabled {
+				item := gzipWriterPool.Get()
+				if item == nil {
+					c.infof("Got nothing from the pool. Creating a new gzip compressor...")
+					gzipWriter = gzip.NewWriter(new(bytes.Buffer))
+				} else {
+					gzipWriter = item.(*gzip.Writer)
+				}
+				defer gzipWriterPool.Put(gzipWriter)
+			}
+			err = req.SetBody(opt.Body, gzipEnabled, gzipWriter)
 			if err != nil {
 				c.errorf("elastic: couldn't set body %+v for request: %v", opt.Body, err)
 				return nil, err

--- a/request_test.go
+++ b/request_test.go
@@ -4,7 +4,11 @@
 
 package elastic
 
-import "testing"
+import (
+	"bytes"
+	"compress/gzip"
+	"testing"
+)
 
 var testReq *Request // used as a temporary variable to avoid compiler optimizations in tests/benchmarks
 
@@ -29,7 +33,7 @@ func BenchmarkRequestSetBodyString(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		body := `{"query":{"match_all":{}}}`
-		err = req.SetBody(body, false)
+		err = req.SetBody(body, false, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -45,7 +49,7 @@ func BenchmarkRequestSetBodyStringGzip(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		body := `{"query":{"match_all":{}}}`
-		err = req.SetBody(body, true)
+		err = req.SetBody(body, true, gzip.NewWriter(new(bytes.Buffer)))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -61,7 +65,7 @@ func BenchmarkRequestSetBodyBytes(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		body := []byte(`{"query":{"match_all":{}}}`)
-		err = req.SetBody(body, false)
+		err = req.SetBody(body, false, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -77,7 +81,7 @@ func BenchmarkRequestSetBodyBytesGzip(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		body := []byte(`{"query":{"match_all":{}}}`)
-		err = req.SetBody(body, true)
+		err = req.SetBody(body, true, gzip.NewWriter(new(bytes.Buffer)))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -97,7 +101,7 @@ func BenchmarkRequestSetBodyMap(b *testing.B) {
 				"match_all": map[string]interface{}{},
 			},
 		}
-		err = req.SetBody(body, false)
+		err = req.SetBody(body, false, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -117,7 +121,7 @@ func BenchmarkRequestSetBodyMapGzip(b *testing.B) {
 				"match_all": map[string]interface{}{},
 			},
 		}
-		err = req.SetBody(body, true)
+		err = req.SetBody(body, true, gzip.NewWriter(new(bytes.Buffer)))
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
GZIPWriter are very expensive to create and leads
to allocating a lot of memory. They are perfect for reusing
(they have .reset method for this)

I profiled a web service inside my company and I noticed that creation of GZipWriter is responsible for 20% of memory allocation (in bytes). 

Inspired by
https://www.akshaydeo.com/blog/2017/12/23/How-did-I-improve-latency-by-700-percent-using-syncPool/
https://dzone.com/articles/memory-pooling-in-go-where-why-and-how

Could you help me to run unit tests?

I noticed there is a shell script ./run-es.sh which worked after I did
`sudo sysctl -w vm.max_map_count=262144` (my workstation is linux)

But `go test .` still fails for a lot of tests with
```
--- FAIL: TestSearchFilterPath (0.01s)
    setup_test.go:348: elastic: Error 400 (Bad Request): request [/elastic-test] contains unrecognized parameter: [include_type_name] [type=illegal_argument_exception]
```

I am quite puzzled

I also learned that I probably misuse `defer` (cause it is in the loop)
Current proposal with additional parameter looks a bit ugly too.
I will appreciate your feedback. This is my first pull request in go project (I am new to go)