### PR TITLE
Fix XpackWatch struct

### DIFF
--- a/xpack_watcher_get_watch.go
+++ b/xpack_watcher_get_watch.go
@@ -202,13 +202,13 @@ type XPackWatchActionThrottle struct {
 }
 
 type XPackWatch struct {
-	Trigger                map[string]map[string]interface{}  `json:"trigger"`
-	Input                  map[string]map[string]interface{}  `json:"input"`
-	Condition              map[string]map[string]interface{}  `json:"condition"`
-	Transform              map[string]interface{}             `json:"transform,omitempty"`
-	ThrottlePeriod         string                             `json:"throttle_period,omitempty"`
-	ThrottlePeriodInMillis int64                              `json:"throttle_period_in_millis,omitempty"`
-	Actions                map[string]*XPackWatchActionStatus `json:"actions"`
-	Metadata               map[string]interface{}             `json:"metadata,omitempty"`
-	Status                 *XPackWatchStatus                  `json:"status,omitempty"`
+	Trigger                map[string]map[string]interface{} `json:"trigger"`
+	Input                  map[string]map[string]interface{} `json:"input"`
+	Condition              map[string]map[string]interface{} `json:"condition"`
+	Transform              map[string]interface{}            `json:"transform,omitempty"`
+	ThrottlePeriod         string                            `json:"throttle_period,omitempty"`
+	ThrottlePeriodInMillis int64                             `json:"throttle_period_in_millis,omitempty"`
+	Actions                map[string]interface{}            `json:"actions"`
+	Metadata               map[string]interface{}            `json:"metadata,omitempty"`
+	Status                 *XPackWatchStatus                 `json:"status,omitempty"`
 }


### PR DESCRIPTION
I found `XPackWatch` struct's Action fields have wrong type specification.

XPackWatchActionStatus is representing Status corresponding action, which represent status of watch actions. However, [watch get api](https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html) returns specification of actions in `XpackWatch.Actions` position. 