### PR TITLE
Update errors.go

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -61,7 +61,7 @@ func createResponseError(res *http.Response) error {
 		if errReply.Details != nil && len(errReply.Details.CausedBy) > 0 {
 			reason := errReply.Details.CausedBy["reason"]
 			if reason != nil {
-				return fmt.Errorf(fmt.Sprintf("Error 400 (Bad Request): %v %v", errReply.Details.Type, reason))
+				return fmt.Errorf(fmt.Sprintf("Error %v: %v %v", res.StatusCode, errReply.Details.Type, reason))
 			}
 		}
 		return errReply

--- a/errors.go
+++ b/errors.go
@@ -58,6 +58,12 @@ func createResponseError(res *http.Response) error {
 		if errReply.Status == 0 {
 			errReply.Status = res.StatusCode
 		}
+		if errReply.Details != nil && len(errReply.Details.CausedBy) > 0 {
+			reason := errReply.Details.CausedBy["reason"]
+			if reason != nil {
+				return fmt.Errorf(fmt.Sprintf("%v : %v", errReply.Details.Type, reason))
+			}
+		}
 		return errReply
 	}
 	return &Error{Status: res.StatusCode}

--- a/errors.go
+++ b/errors.go
@@ -61,7 +61,7 @@ func createResponseError(res *http.Response) error {
 		if errReply.Details != nil && len(errReply.Details.CausedBy) > 0 {
 			reason := errReply.Details.CausedBy["reason"]
 			if reason != nil {
-				return fmt.Errorf(fmt.Sprintf("%v : %v", errReply.Details.Type, reason))
+				return fmt.Errorf(fmt.Sprintf("Error 400 (Bad Request): %v %v", errReply.Details.Type, reason))
 			}
 		}
 		return errReply


### PR DESCRIPTION
added support for reporting actual error for search/write failure

Error if search request contains sorting on text column without keyword:
request:
{
 "query": {"match_all": {}},
 "sort": [
    {
      "comment": {
        "order": "asc"
      }
    }
  ]
}

ES error:
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "Fielddata is disabled on text fields by default. Set fielddata=true on [comment] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead."
      }
    ],
    "type": "search_phase_execution_exception",
    "reason": "all shards failed",
    "phase": "query",
    "grouped": true,
    "failed_shards": [
      {
        "shard": 0,
        "index": "tim",
        "node": "YW-tkMpZRfeh_DfeZTFAdg",
        "reason": {
          "type": "illegal_argument_exception",
          "reason": "Fielddata is disabled on text fields by default. Set fielddata=true on [comment] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead."
        }
      }
    ],
    "caused_by": {
      "type": "illegal_argument_exception",
      "reason": "Fielddata is disabled on text fields by default. Set fielddata=true on [comment] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.",
      "caused_by": {
        "type": "illegal_argument_exception",
        "reason": "Fielddata is disabled on text fields by default. Set fielddata=true on [comment] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead."
      }
    }
  },
  "status": 400
}

Error reported by library:
search_phase_execution_exception : elastic: Error 400 (Bad Request): all shards failed [type=search_phase_execution_exception]