### PR TITLE
set DefaultSnifferEnabled false

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ const (
 	DefaultHealthcheckInterval = 60 * time.Second
 
 	// DefaultSnifferEnabled specifies if the sniffer is enabled by default.
-	DefaultSnifferEnabled = true
+	DefaultSnifferEnabled = false
 
 	// DefaultSnifferInterval is the interval between two sniffing procedures,
 	// i.e. the lookup of all nodes in the cluster and their addition/removal


### PR DESCRIPTION
These days, many people use docker, so we use Elasticsearch on Docker.
In this Elasticsearch client, many people encount error `no active connection found`.
I am also one of them and wasted a few hours trying to resolve.
I want to change Default value!