### PR TITLE
use unsafeBytesToString to reuse memory

### DIFF
--- a/bulk_delete_request.go
+++ b/bulk_delete_request.go
@@ -179,7 +179,7 @@ func (r *BulkDeleteRequest) Source() ([]string, error) {
 		return nil, err
 	}
 
-	lines := []string{string(body)}
+	lines := []string{unsafeBytesToString(body)}
 	r.source = lines
 
 	return lines, nil

--- a/bulk_index_request.go
+++ b/bulk_index_request.go
@@ -231,7 +231,7 @@ func (r *BulkIndexRequest) Source() ([]string, error) {
 		return nil, err
 	}
 
-	lines[0] = string(body)
+	lines[0] = unsafeBytesToString(body)
 
 	// "field1" ...
 	if r.doc != nil {
@@ -241,7 +241,7 @@ func (r *BulkIndexRequest) Source() ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			lines[1] = string(body)
+			lines[1] = unsafeBytesToString(body)
 		case json.RawMessage:
 			lines[1] = string(t)
 		case *json.RawMessage:

--- a/bulk_update_request.go
+++ b/bulk_update_request.go
@@ -281,7 +281,7 @@ func (r *BulkUpdateRequest) Source() ([]string, error) {
 		return nil, err
 	}
 
-	lines[0] = string(body)
+	lines[0] = unsafeBytesToString(body)
 
 	// 2nd line: {"doc" : { ... }} or {"script": {...}}
 	var doc interface{}
@@ -327,7 +327,7 @@ func (r *BulkUpdateRequest) Source() ([]string, error) {
 		return nil, err
 	}
 
-	lines[1] = string(body)
+	lines[1] = unsafeBytesToString(body)
 
 	r.source = lines
 	return lines, nil

--- a/msearch.go
+++ b/msearch.go
@@ -137,7 +137,7 @@ func (s *MultiSearchService) Do(ctx context.Context) (*MultiSearchResult, error)
 		if err != nil {
 			return nil, err
 		}
-		lines = append(lines, string(header))
+		lines = append(lines, unsafeBytesToString(header))
 		lines = append(lines, body)
 	}
 	body := strings.Join(lines, "\n") + "\n" // add trailing \n

--- a/search_request.go
+++ b/search_request.go
@@ -523,7 +523,7 @@ func (r *SearchRequest) Body() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(body), nil
+		return unsafeBytesToString(body), nil
 	}
 	switch t := r.source.(type) {
 	default:
@@ -531,7 +531,7 @@ func (r *SearchRequest) Body() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(body), nil
+		return unsafeBytesToString(body), nil
 	case *SearchSource:
 		src, err := t.Source()
 		if err != nil {
@@ -541,7 +541,7 @@ func (r *SearchRequest) Body() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(body), nil
+		return unsafeBytesToString(body), nil
 	case json.RawMessage:
 		return string(t), nil
 	case *json.RawMessage:

--- a/unsafe.go
+++ b/unsafe.go
@@ -1,0 +1,11 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "unsafe"
+
+func unsafeBytesToString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}


### PR DESCRIPTION
I found that some operations are very expensive about mem alloc when string(bytes).
Such as: 

![image](https://user-images.githubusercontent.com/16250688/99495362-7e4d2c80-29ad-11eb-8e0c-c0713abca4cd.png)

So I try to reuse some mems by using unsafe.