### PR TITLE
Change in RangeQuery from, to, include_lower and include_upper parame…

### DIFF
--- a/search_queries_range.go
+++ b/search_queries_range.go
@@ -4,85 +4,57 @@
 
 package elastic
 
+const (
+	// (Default) Matches documents with a range field value that intersects the query’s range.
+	RelationIntersects string = "INTERSECTS"
+	// Matches documents with a range field value that entirely contains the query’s range.
+	RelationContains string = "CONTAINS"
+	// Matches documents with a range field value entirely within the query’s range.
+	RelationWithin string = "WITHIN"
+)
+
 // RangeQuery matches documents with fields that have terms within a certain range.
 //
-// For details, see
+// For details, see Elastic Documentation (6.8):
 // https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-range-query.html
 type RangeQuery struct {
-	name         string
-	from         interface{}
-	to           interface{}
-	timeZone     string
-	includeLower bool
-	includeUpper bool
-	boost        *float64
-	queryName    string
-	format       string
-	relation     string
+	name     string
+	gt       interface{}
+	gte      interface{}
+	lt       interface{}
+	lte      interface{}
+	format   string
+	relation string
+	timeZone string
+	boost    *float64
 }
 
 // NewRangeQuery creates and initializes a new RangeQuery.
 func NewRangeQuery(name string) *RangeQuery {
-	return &RangeQuery{name: name, includeLower: true, includeUpper: true}
+	return &RangeQuery{name: name}
 }
 
-// From indicates the from part of the RangeQuery.
-// Use nil to indicate an unbounded from part.
-func (q *RangeQuery) From(from interface{}) *RangeQuery {
-	q.from = from
+// Gt (Optional) Greater than.
+func (q *RangeQuery) Gt(gt interface{}) *RangeQuery {
+	q.gt = gt
 	return q
 }
 
-// Gt indicates a greater-than value for the from part.
-// Use nil to indicate an unbounded from part.
-func (q *RangeQuery) Gt(from interface{}) *RangeQuery {
-	q.from = from
-	q.includeLower = false
+// Gte (Optional) Greater than or equal to.
+func (q *RangeQuery) Gte(gte interface{}) *RangeQuery {
+	q.gte = gte
 	return q
 }
 
-// Gte indicates a greater-than-or-equal value for the from part.
-// Use nil to indicate an unbounded from part.
-func (q *RangeQuery) Gte(from interface{}) *RangeQuery {
-	q.from = from
-	q.includeLower = true
+// Lt (Optional) Less than.
+func (q *RangeQuery) Lt(lt interface{}) *RangeQuery {
+	q.lt = lt
 	return q
 }
 
-// To indicates the to part of the RangeQuery.
-// Use nil to indicate an unbounded to part.
-func (q *RangeQuery) To(to interface{}) *RangeQuery {
-	q.to = to
-	return q
-}
-
-// Lt indicates a less-than value for the to part.
-// Use nil to indicate an unbounded to part.
-func (q *RangeQuery) Lt(to interface{}) *RangeQuery {
-	q.to = to
-	q.includeUpper = false
-	return q
-}
-
-// Lte indicates a less-than-or-equal value for the to part.
-// Use nil to indicate an unbounded to part.
-func (q *RangeQuery) Lte(to interface{}) *RangeQuery {
-	q.to = to
-	q.includeUpper = true
-	return q
-}
-
-// IncludeLower indicates whether the lower bound should be included or not.
-// Defaults to true.
-func (q *RangeQuery) IncludeLower(includeLower bool) *RangeQuery {
-	q.includeLower = includeLower
-	return q
-}
-
-// IncludeUpper indicates whether the upper bound should be included or not.
-// Defaults to true.
-func (q *RangeQuery) IncludeUpper(includeUpper bool) *RangeQuery {
-	q.includeUpper = includeUpper
+// Lte (Optional) Less than or equal to.
+func (q *RangeQuery) Lte(lte interface{}) *RangeQuery {
+	q.lte = lte
 	return q
 }
 
@@ -92,29 +64,19 @@ func (q *RangeQuery) Boost(boost float64) *RangeQuery {
 	return q
 }
 
-// QueryName sets the query name for the filter that can be used when
-// searching for matched_filters per hit.
-func (q *RangeQuery) QueryName(queryName string) *RangeQuery {
-	q.queryName = queryName
-	return q
-}
-
-// TimeZone is used for date fields. In that case, we can adjust the
-// from/to fields using a timezone.
+// TimeZone (Optional, string) Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query to UTC.
 func (q *RangeQuery) TimeZone(timeZone string) *RangeQuery {
 	q.timeZone = timeZone
 	return q
 }
 
-// Format is used for date fields. In that case, we can set the format
-// to be used instead of the mapper format.
+// Format (Optional, string) Date format used to convert date values in the query.
 func (q *RangeQuery) Format(format string) *RangeQuery {
 	q.format = format
 	return q
 }
 
-// Relation is used for range fields. which can be one of
-// "within", "contains", "intersects" (default) and "disjoint".
+// Relation (Optional, string) Indicates how the range query matches values for range fields. Valid values are: INTERSECTS (Default), CONTAINS and WITHIN
 func (q *RangeQuery) Relation(relation string) *RangeQuery {
 	q.relation = relation
 	return q
@@ -130,8 +92,18 @@ func (q *RangeQuery) Source() (interface{}, error) {
 	params := make(map[string]interface{})
 	rangeQ[q.name] = params
 
-	params["from"] = q.from
-	params["to"] = q.to
+	if q.gt != nil {
+		params["gt"] = q.gt
+	}
+	if q.gte != nil {
+		params["gte"] = q.gte
+	}
+	if q.lt != nil {
+		params["lt"] = q.lt
+	}
+	if q.lte != nil {
+		params["lte"] = q.lte
+	}
 	if q.timeZone != "" {
 		params["time_zone"] = q.timeZone
 	}
@@ -143,12 +115,6 @@ func (q *RangeQuery) Source() (interface{}, error) {
 	}
 	if q.boost != nil {
 		params["boost"] = *q.boost
-	}
-	params["include_lower"] = q.includeLower
-	params["include_upper"] = q.includeUpper
-
-	if q.queryName != "" {
-		rangeQ["_name"] = q.queryName
 	}
 
 	return source, nil

--- a/search_queries_range_test.go
+++ b/search_queries_range_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 )
 
-func TestRangeQuery(t *testing.T) {
-	q := NewRangeQuery("postDate").From("2010-03-01").To("2010-04-01").Boost(3).Relation("within")
-	q = q.QueryName("my_query")
+func TestEmptyRangeQuery(t *testing.T) {
+	q := NewRangeQuery("postDate")
 	src, err := q.Source()
 	if err != nil {
 		t.Fatal(err)
@@ -21,7 +20,29 @@ func TestRangeQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"_name":"my_query","postDate":{"boost":3,"from":"2010-03-01","include_lower":true,"include_upper":true,"relation":"within","to":"2010-04-01"}}}`
+	expected := `{"range":{"postDate":{}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestRangeQuery(t *testing.T) {
+	q := NewRangeQuery("postDate").
+		Gte("2010-03-01").
+		Lte("2010-04-01").
+		Format("yyyy-MM-dd").
+		Boost(3).
+		Relation(RelationWithin)
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"range":{"postDate":{"boost":3,"format":"yyyy-MM-dd","gte":"2010-03-01","lte":"2010-04-01","relation":"WITHIN"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -41,7 +62,7 @@ func TestRangeQueryWithTimeZone(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"born":{"from":"2012-01-01","include_lower":true,"include_upper":true,"time_zone":"+1:00","to":"now"}}}`
+	expected := `{"range":{"born":{"gte":"2012-01-01","lte":"now","time_zone":"+1:00"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -61,7 +82,7 @@ func TestRangeQueryWithFormat(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"range":{"born":{"format":"yyyy/MM/dd","from":"2012/01/01","include_lower":true,"include_upper":true,"to":"now"}}}`
+	expected := `{"range":{"born":{"format":"yyyy/MM/dd","gte":"2012/01/01","lte":"now"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
…ters by gt, gte, lt, lte

See https://www.elastic.co/guide/en/elasticsearch/reference/0.90/query-dsl-range-query.html

Fix #1450 

I have used the official elastic documentation on public methods

I don't know if you want some verification about : 
+ at least one gt, gte, lt and lte
+ not at the same time gt + gte and lt + lte