### PR TITLE
[xpack role] Fix spelling of resources

### DIFF
--- a/xpack_security_get_role.go
+++ b/xpack_security_get_role.go
@@ -174,7 +174,7 @@ type XPackSecurityRole struct {
 type XPackSecurityApplicationPrivileges struct {
 	Application string   `json:"application"`
 	Privileges  []string `json:"privileges"`
-	Ressources  []string `json:"resources"`
+	Resources  []string `json:"resources"`
 }
 
 // XPackSecurityIndicesPermissions is the indices permission object


### PR DESCRIPTION
Not sure if this would be considered a breaking change to the API, but thought it may help others.

May be related to https://github.com/phillbaker/terraform-provider-elasticsearch/issues/128