### PR TITLE
Support for new case_insensitive wildcard queries

### DIFF
--- a/search_queries_wildcard.go
+++ b/search_queries_wildcard.go
@@ -13,13 +13,14 @@ package elastic
 // The wildcard query maps to Lucene WildcardQuery.
 //
 // For more details, see
-// https://www.elastic.co/guide/en/elasticsearch/reference/7.0/query-dsl-wildcard-query.html
+// https://www.elastic.co/guide/en/elasticsearch/reference/7.x/query-dsl-wildcard-query.html
 type WildcardQuery struct {
-	name      string
-	wildcard  string
-	boost     *float64
-	rewrite   string
-	queryName string
+	name            string
+	wildcard        string
+	boost           *float64
+	rewrite         string
+	queryName       string
+	caseInsensitive bool
 }
 
 // NewWildcardQuery creates and initializes a new WildcardQuery.
@@ -47,13 +48,20 @@ func (q *WildcardQuery) QueryName(queryName string) *WildcardQuery {
 	return q
 }
 
+// CaseInsensitive sets case insensitive matching of this query.
+func (q *WildcardQuery) CaseInsensitive(caseInsensitive bool) *WildcardQuery {
+	q.caseInsensitive = caseInsensitive
+	return q
+}
+
 // Source returns the JSON serializable body of this query.
 func (q *WildcardQuery) Source() (interface{}, error) {
 	// {
 	//	"wildcard" : {
 	//		"user" : {
-	//      "wildcard" : "ki*y",
-	//      "boost" : 1.0
+	//      "value" : "ki*y",
+	//      "boost" : 1.0,
+	//      "case_insensitive" : true
 	//    }
 	// }
 
@@ -65,7 +73,7 @@ func (q *WildcardQuery) Source() (interface{}, error) {
 	wq := make(map[string]interface{})
 	query[q.name] = wq
 
-	wq["wildcard"] = q.wildcard
+	wq["value"] = q.wildcard
 
 	if q.boost != nil {
 		wq["boost"] = *q.boost
@@ -75,6 +83,9 @@ func (q *WildcardQuery) Source() (interface{}, error) {
 	}
 	if q.queryName != "" {
 		wq["_name"] = q.queryName
+	}
+	if q.caseInsensitive {
+		wq["case_insensitive"] = true
 	}
 
 	return source, nil

--- a/search_queries_wildcard_test.go
+++ b/search_queries_wildcard_test.go
@@ -44,7 +44,7 @@ func TestWildcardQuery(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"wildcard":{"user":{"wildcard":"ki*y??"}}}`
+	expected := `{"wildcard":{"user":{"value":"ki*y??"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
@@ -61,7 +61,24 @@ func TestWildcardQueryWithBoost(t *testing.T) {
 		t.Fatalf("marshaling to JSON failed: %v", err)
 	}
 	got := string(data)
-	expected := `{"wildcard":{"user":{"boost":1.2,"wildcard":"ki*y??"}}}`
+	expected := `{"wildcard":{"user":{"boost":1.2,"value":"ki*y??"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestWildcardQueryWithCaseInsensitive(t *testing.T) {
+	q := elastic.NewWildcardQuery("user", "ki*y??").CaseInsensitive(true)
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"wildcard":{"user":{"case_insensitive":true,"value":"ki*y??"}}}`
 	if got != expected {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}


### PR DESCRIPTION
Elasticsearch 7.10.0 added support for case_insensitive wildcard queries:

https://www.elastic.co/guide/en/elasticsearch/reference/7.x/query-dsl-wildcard-query.html

This provides support for the new option, and renames wildcard field to value to match the current API docs. I'm not really sure what the process is for mid-major-version feature support, so let me know if I need to submit this in a different way!