### PR TITLE
Add stream option to PerformRequest()

### DIFF
--- a/response_test.go
+++ b/response_test.go
@@ -29,7 +29,7 @@ func BenchmarkResponse(b *testing.B) {
 			StatusCode: http.StatusOK,
 		}
 		var err error
-		resp, err = c.newResponse(res, 0)
+		resp, err = c.newResponse(res, 0, false)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Add an option `Stream` to `PerformRequestOptions`, allowing a response to be parsed as a stream. Fixes #1444.