### PR TITLE
search: specify the length when declaring the slice

### DIFF
--- a/client.go
+++ b/client.go
@@ -908,11 +908,11 @@ func (c *Client) sniff(parentCtx context.Context, timeout time.Duration) error {
 
 	// Use all available URLs provided to sniff the cluster.
 	var urls []string
-	urlsMap := make(map[string]bool)
+	urlsMap := make(map[string]struct{}, len(c.urls))
 
 	// Add all URLs provided on startup
 	for _, url := range c.urls {
-		urlsMap[url] = true
+		urlsMap[url] = struct{}{}
 		urls = append(urls, url)
 	}
 	c.mu.RUnlock()

--- a/search.go
+++ b/search.go
@@ -691,7 +691,7 @@ func (r *SearchResult) Each(typ reflect.Type) []interface{} {
 	if r.Hits == nil || r.Hits.Hits == nil || len(r.Hits.Hits) == 0 {
 		return nil
 	}
-	var slice []interface{}
+	var slice = make([]interface{}, 0, len(r.Hits.Hits))
 	for _, hit := range r.Hits.Hits {
 		v := reflect.New(typ).Elem()
 		if hit.Source == nil {


### PR DESCRIPTION
Specify the length when declaring the slice to reduce the number of memory allocations.