### PR TITLE
Fix wrong url check

### DIFF
--- a/canonicalize.go
+++ b/canonicalize.go
@@ -21,7 +21,7 @@ import (
 func canonicalize(rawurls ...string) []string {
 	var canonicalized []string
 	for _, rawurl := range rawurls {
-		u, err := url.Parse(rawurl)
+		u, err := url.ParseRequestURI(rawurl)
 		if err == nil {
 			if u.Scheme == "http" || u.Scheme == "https" {
 				// Trim trailing slashes. Notice that strings.TrimSuffix will only remove the last slash,

--- a/client.go
+++ b/client.go
@@ -908,11 +908,11 @@ func (c *Client) sniff(parentCtx context.Context, timeout time.Duration) error {
 
 	// Use all available URLs provided to sniff the cluster.
 	var urls []string
-	urlsMap := make(map[string]bool)
+	urlsMap := make(map[string]struct{}, len(c.urls))
 
 	// Add all URLs provided on startup
 	for _, url := range c.urls {
-		urlsMap[url] = true
+		urlsMap[url] = struct{}{}
 		urls = append(urls, url)
 	}
 	c.mu.RUnlock()

--- a/client.go
+++ b/client.go
@@ -269,7 +269,7 @@ func NewSimpleClient(options ...ClientOptionFunc) (*Client, error) {
 	// If the URLs have auth info, use them here as an alternative to SetBasicAuth
 	if c.basicAuthUsername == "" && c.basicAuthPassword == "" {
 		for _, urlStr := range c.urls {
-			u, err := url.Parse(urlStr)
+			u, err := url.ParseRequestURI(urlStr)
 			if err == nil && u.User != nil {
 				c.basicAuthUsername = u.User.Username()
 				c.basicAuthPassword, _ = u.User.Password()
@@ -278,8 +278,8 @@ func NewSimpleClient(options ...ClientOptionFunc) (*Client, error) {
 		}
 	}
 
-	for _, url := range c.urls {
-		c.conns = append(c.conns, newConn(url, url))
+	for _, urlStr := range c.urls {
+		c.conns = append(c.conns, newConn(urlStr, urlStr))
 	}
 
 	// Ensure that we have at least one connection available
@@ -355,7 +355,7 @@ func DialContext(ctx context.Context, options ...ClientOptionFunc) (*Client, err
 	// If the URLs have auth info, use them here as an alternative to SetBasicAuth
 	if c.basicAuthUsername == "" && c.basicAuthPassword == "" {
 		for _, urlStr := range c.urls {
-			u, err := url.Parse(urlStr)
+			u, err := url.ParseRequestURI(urlStr)
 			if err == nil && u.User != nil {
 				c.basicAuthUsername = u.User.Username()
 				c.basicAuthPassword, _ = u.User.Password()
@@ -378,8 +378,8 @@ func DialContext(ctx context.Context, options ...ClientOptionFunc) (*Client, err
 		}
 	} else {
 		// Do not sniff the cluster initially. Use the provided URLs instead.
-		for _, url := range c.urls {
-			c.conns = append(c.conns, newConn(url, url))
+		for _, urlStr := range c.urls {
+			c.conns = append(c.conns, newConn(urlStr, urlStr))
 		}
 	}
 
@@ -508,7 +508,7 @@ func SetURL(urls ...string) ClientOptionFunc {
 		}
 		// Check URLs
 		for _, urlStr := range c.urls {
-			if _, err := url.Parse(urlStr); err != nil {
+			if _, err := url.ParseRequestURI(urlStr); err != nil {
 				return err
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -553,7 +553,7 @@ func TestClientSniffUpdatingNodeURL(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		u, err := url.Parse(nodeURL)
+		u, err := url.ParseRequestURI(nodeURL)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ func Parse(elasticURL string) (*Config, error) {
 		Sniff:    nil,
 	}
 
-	uri, err := url.Parse(elasticURL)
+	uri, err := url.ParseRequestURI(elasticURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing elastic parameter %q: %v", elasticURL, err)
 	}

--- a/search.go
+++ b/search.go
@@ -691,7 +691,7 @@ func (r *SearchResult) Each(typ reflect.Type) []interface{} {
 	if r.Hits == nil || r.Hits.Hits == nil || len(r.Hits.Hits) == 0 {
 		return nil
 	}
-	var slice []interface{}
+	var slice = make([]interface{}, 0, len(r.Hits.Hits))
 	for _, hit := range r.Hits.Hits {
 		v := reflect.New(typ).Elem()
 		if hit.Source == nil {


### PR DESCRIPTION
`url.Parse` cannot check the validity of the url.
Here is a simple uinttest function.

```
func TestCheckURL(t *testing.T) {
	//The value is true if the url is valid
	urls := map[string]bool{
		"http://elastic:elastic@localhost:9210": true,
		"https://google.com":                    true,
		"http://google.com/":                    true,
		"http:/google.com":                      true,
		"google.com":                            false,
		"google/com":                            false,
		"http//google.com":                      false,
		"":                                      false,
	}

	// http.Parse, all urls are right
	for u, _ := range urls {
		_, err := url.Parse(u)
		assert.Nil(t, err)
	}

	// http.ParseRequestURI, some are right, and some not.
	for u, b := range urls {
		_, err := url.ParseRequestURI(u)
		if b {
			assert.Nil(t, err)
		} else {
			assert.NotNil(t, err, u)
		}
	}
}
```

```
=== RUN   TestCheckURL
--- PASS: TestCheckURL (0.00s)
PASS
```
