### PR TITLE
Add runtime fields/mappings

### DIFF
--- a/.github/workflows/codeql-v7.yml
+++ b/.github/workflows/codeql-v7.yml
@@ -14,7 +14,7 @@ jobs:
   codeql:
     strategy:
       matrix:
-        go: [1.15.x, 1.16.x]
+        go: [1.16.x, 1.17.x]
         os: [ubuntu-latest]
     name: Run ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-v7.yml
+++ b/.github/workflows/test-v7.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.15.x, 1.16.x]
+        go: [1.16.x, 1.17.x]
         os: [ubuntu-latest]
     name: Run ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -1,6 +1,6 @@
 services:
   es1:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.13.4}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.14.0}
     hostname: es1
     environment:
       - bootstrap.memory_lock=true
@@ -26,7 +26,7 @@ services:
       - 9200:9200
 
   es2:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.13.4}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.14.0}
     hostname: es2
     environment:
       - bootstrap.memory_lock=true
@@ -52,7 +52,7 @@ services:
       - 9201:9200
 
   es3:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.13.4}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.14.0}
     hostname: es3
     environment:
       - bootstrap.memory_lock=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.13.4}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.14.0}
     hostname: elasticsearch
     environment:
       - cluster.name=elasticsearch
@@ -28,7 +28,7 @@ services:
     ports:
       - 9200:9200
   platinum:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.13.4}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION:-7.14.0}
     hostname: elasticsearch-platinum
     environment:
       - cluster.name=platinum

--- a/field_caps_test.go
+++ b/field_caps_test.go
@@ -96,25 +96,25 @@ func TestFieldCapsResponse(t *testing.T) {
 				"failed": 0
 		},
 		"fields": {
-			"rating": { 
+			"rating": {
 				"long": {
 					"searchable": true,
 					"aggregatable": false,
 					"indices": ["index1", "index2"],
-					"non_aggregatable_indices": ["index1"] 
+					"non_aggregatable_indices": ["index1"]
 				},
 				"keyword": {
 					"searchable": false,
 					"aggregatable": true,
 					"indices": ["index3", "index4"],
-					"non_searchable_indices": ["index4"] 
+					"non_searchable_indices": ["index4"]
 				}
 			},
-			"title": { 
+			"title": {
 				"text": {
 					"searchable": true,
 					"aggregatable": false
-	
+
 				}
 			}
 		}

--- a/runtime_mappings.go
+++ b/runtime_mappings.go
@@ -1,0 +1,16 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+// RuntimeMappings specify fields that are evaluated at query time.
+//
+// See https://www.elastic.co/guide/en/elasticsearch/reference/7.14/runtime.html
+// for details.
+type RuntimeMappings map[string]interface{}
+
+// Source deserializes the runtime mappings.
+func (m *RuntimeMappings) Source() (interface{}, error) {
+	return m, nil
+}

--- a/runtime_mappings_test.go
+++ b/runtime_mappings_test.go
@@ -1,0 +1,148 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestRuntimeMappingsSource(t *testing.T) {
+	rm := RuntimeMappings{
+		"day_of_week": map[string]interface{}{
+			"type": "keyword",
+		},
+	}
+	src, err := rm.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `{"day_of_week":{"type":"keyword"}}`
+	if want, have := expected, string(data); want != have {
+		t.Fatalf("want %s, have %s", want, have)
+	}
+}
+
+func TestRuntimeMappings(t *testing.T) {
+	client := setupTestClient(t) //, SetTraceLog(log.New(os.Stdout, "", 0)))
+
+	ctx := context.Background()
+	indexName := testIndexName
+
+	// Create index
+	createIndex, err := client.CreateIndex(indexName).Do(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if createIndex == nil {
+		t.Errorf("expected result to be != nil; got: %v", createIndex)
+	}
+
+	mapping := `{
+		"dynamic": "runtime",
+		"properties": {
+			"@timestamp": {
+				"type":"date"
+			}
+		},
+		"runtime": {
+			"day_of_week": {
+				"type": "keyword",
+				"script": {
+					"source": "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
+				}
+			}
+		}
+	}`
+	type Doc struct {
+		Timestamp time.Time `json:"@timestamp"`
+	}
+	type DynamicDoc struct {
+		Timestamp time.Time `json:"@timestamp"`
+		DayOfWeek string    `json:"day_of_week"`
+	}
+
+	// Create mapping
+	putResp, err := client.PutMapping().
+		Index(indexName).
+		BodyString(mapping).
+		Do(ctx)
+	if err != nil {
+		t.Fatalf("expected put mapping to succeed; got: %v", err)
+	}
+	if putResp == nil {
+		t.Fatalf("expected put mapping response; got: %v", putResp)
+	}
+	if !putResp.Acknowledged {
+		t.Fatalf("expected put mapping ack; got: %v", putResp.Acknowledged)
+	}
+
+	// Add a document
+	timestamp := time.Date(2021, 1, 17, 23, 24, 25, 26, time.UTC)
+	indexResult, err := client.Index().
+		Index(indexName).
+		Id("1").
+		BodyJson(&Doc{
+			Timestamp: timestamp,
+		}).
+		Refresh("wait_for").
+		Do(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if indexResult == nil {
+		t.Errorf("expected result to be != nil; got: %v", indexResult)
+	}
+
+	// Execute a search to check for runtime fields
+	searchResp, err := client.Search(indexName).
+		Query(NewMatchAllQuery()).
+		DocvalueFields("@timestamp", "day_of_week").
+		Do(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if searchResp == nil {
+		t.Errorf("expected result to be != nil; got: %v", searchResp)
+	}
+	if want, have := int64(1), searchResp.TotalHits(); want != have {
+		t.Fatalf("expected %d search hits, got %d", want, have)
+	}
+
+	// The hit should not have the "day_of_week"
+	hit := searchResp.Hits.Hits[0]
+	var doc DynamicDoc
+	if err := json.Unmarshal(hit.Source, &doc); err != nil {
+		t.Fatalf("unable to deserialize hit: %v", err)
+	}
+	if want, have := timestamp, doc.Timestamp; want != have {
+		t.Fatalf("expected timestamp=%v, got %v", want, have)
+	}
+	if want, have := "", doc.DayOfWeek; want != have {
+		t.Fatalf("expected day_of_week=%q, got %q", want, have)
+	}
+
+	// The fields should include a "day_of_week" of ["Sunday"]
+	dayOfWeekIntfSlice, ok := hit.Fields["day_of_week"].([]interface{})
+	if !ok {
+		t.Fatalf("expected a slice of strings, got %T", hit.Fields["day_of_week"])
+	}
+	if want, have := 1, len(dayOfWeekIntfSlice); want != have {
+		t.Fatalf("expected a slice of size %d, have %d", want, have)
+	}
+	dayOfWeek, ok := dayOfWeekIntfSlice[0].(string)
+	if !ok {
+		t.Fatalf("expected an element of string, got %T", dayOfWeekIntfSlice[0])
+	}
+	if want, have := "Sunday", dayOfWeek; want != have {
+		t.Fatalf("expected day_of_week=%q, have %q", want, have)
+	}
+}

--- a/search_source.go
+++ b/search_source.go
@@ -42,7 +42,8 @@ type SearchSource struct {
 	collapse                 *CollapseBuilder // collapse
 	profile                  bool             // profile
 	// TODO extBuilders []SearchExtBuilder // ext
-	pointInTime *PointInTime // pit
+	pointInTime     *PointInTime // pit
+	runtimeMappings RuntimeMappings
 }
 
 // NewSearchSource initializes a new SearchSource.
@@ -375,6 +376,12 @@ func (s *SearchSource) PointInTime(pointInTime *PointInTime) *SearchSource {
 	return s
 }
 
+// RuntimeMappings specifies optional runtime mappings.
+func (s *SearchSource) RuntimeMappings(runtimeMappings RuntimeMappings) *SearchSource {
+	s.runtimeMappings = runtimeMappings
+	return s
+}
+
 // Source returns the serializable JSON for the source builder.
 func (s *SearchSource) Source() (interface{}, error) {
 	source := make(map[string]interface{})
@@ -612,6 +619,14 @@ func (s *SearchSource) Source() (interface{}, error) {
 			return nil, err
 		}
 		source["pit"] = src
+	}
+
+	if s.runtimeMappings != nil {
+		src, err := s.runtimeMappings.Source()
+		if err != nil {
+			return nil, err
+		}
+		source["runtime_mappings"] = src
 	}
 
 	return source, nil

--- a/search_source_test.go
+++ b/search_source_test.go
@@ -316,3 +316,45 @@ func TestSearchSourceSeqNoAndPrimaryTerm(t *testing.T) {
 		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
 	}
 }
+
+func TestSearchSourcePointInTime(t *testing.T) {
+	matchAllQ := NewMatchAllQuery()
+	builder := NewSearchSource().Query(matchAllQ).PointInTime(
+		NewPointInTime("pit_id", "2m"),
+	)
+	src, err := builder.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"pit":{"id":"pit_id","keep_alive":"2m"},"query":{"match_all":{}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
+func TestSearchSourceRuntimeMappings(t *testing.T) {
+	matchAllQ := NewMatchAllQuery()
+	builder := NewSearchSource().Query(matchAllQ).RuntimeMappings(RuntimeMappings{
+		"day_of_week": map[string]interface{}{
+			"type": "keyword",
+		},
+	})
+	src, err := builder.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"query":{"match_all":{}},"runtime_mappings":{"day_of_week":{"type":"keyword"}}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}


### PR DESCRIPTION
This commit adds runtime fields/mappings to the client.

See https://www.elastic.co/guide/en/elasticsearch/reference/7.14/runtime.html
for details.

Close #1527