### PR TITLE
Adding support for XPack rollup api

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,13 @@ Here are a few tips on how to get used to Elastic:
 - [ ] Nodes hot_threads
 - [ ] Cluster Allocation Explain API
 
+### Rollup APIs (XPack)
+- [x] Create Job
+- [x] Delete Job
+- [x] Get Job
+- [x] Start Job
+- [x] Stop Job
+
 ### Query DSL
 
 - [x] Match All Query

--- a/client.go
+++ b/client.go
@@ -2188,6 +2188,33 @@ func (c *Client) XPackSecurityDeleteUser(username string) *XPackSecurityDeleteUs
 	return NewXPackSecurityDeleteUserService(c).Username(username)
 }
 
+// -- X-Pack Rollup --
+
+// XPackRollupPut creates or updates a rollup job.
+func (c *Client) XPackRollupPut(jobId string) *XPackRollupPutService {
+	return NewXPackRollupPutService(c).JobId(jobId)
+}
+
+// XPackRollupGet gets a rollup job.
+func (c *Client) XPackRollupGet(jobId string) *XPackRollupGetService {
+	return NewXPackRollupGetService(c).JobId(jobId)
+}
+
+// XPackRollupDelete deletes a rollup job.
+func (c *Client) XPackRollupDelete(jobId string) *XPackRollupDeleteService {
+	return NewXPackRollupDeleteService(c).JobId(jobId)
+}
+
+// XPackRollupStart starts a rollup job.
+func (c *Client) XPackRollupStart(jobId string) *XPackRollupStartService {
+	return NewXPackRollupStartService(c).JobId(jobId)
+}
+
+// XPackRollupStop stops a rollup job.
+func (c *Client) XPackRollupStop(jobId string) *XPackRollupStopService {
+	return NewXPackRollupStopService(c).JobId(jobId)
+}
+
 // -- X-Pack Watcher --
 
 // XPackWatchPut adds a watch.

--- a/xpack_rollup_delete.go
+++ b/xpack_rollup_delete.go
@@ -1,0 +1,159 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/olivere/elastic/v7/uritemplates"
+)
+
+// XPackRollupDeleteService delete a rollup job by its job id.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rollup-delete-job.html.
+type XPackRollupDeleteService struct {
+	client *Client
+
+	pretty     *bool       // pretty format the returned JSON response
+	human      *bool       // return human readable values for statistics
+	errorTrace *bool       // include the stack trace of returned errors
+	filterPath []string    // list of filters used to reduce the response
+	headers    http.Header // custom request-level HTTP headers
+
+	jobId string
+}
+
+// XPackRollupDeleteService creates a new XPackRollupDeleteService.
+func NewXPackRollupDeleteService(client *Client) *XPackRollupDeleteService {
+	return &XPackRollupDeleteService{
+		client: client,
+	}
+}
+
+// Pretty tells Elasticsearch whether to return a formatted JSON response.
+func (s *XPackRollupDeleteService) Pretty(pretty bool) *XPackRollupDeleteService {
+	s.pretty = &pretty
+	return s
+}
+
+// Human specifies whether human readable values should be returned in
+// the JSON response, e.g. "7.5mb".
+func (s *XPackRollupDeleteService) Human(human bool) *XPackRollupDeleteService {
+	s.human = &human
+	return s
+}
+
+// ErrorTrace specifies whether to include the stack trace of returned errors.
+func (s *XPackRollupDeleteService) ErrorTrace(errorTrace bool) *XPackRollupDeleteService {
+	s.errorTrace = &errorTrace
+	return s
+}
+
+// FilterPath specifies a list of filters used to reduce the response.
+func (s *XPackRollupDeleteService) FilterPath(filterPath ...string) *XPackRollupDeleteService {
+	s.filterPath = filterPath
+	return s
+}
+
+// Header adds a header to the request.
+func (s *XPackRollupDeleteService) Header(name string, value string) *XPackRollupDeleteService {
+	if s.headers == nil {
+		s.headers = http.Header{}
+	}
+	s.headers.Add(name, value)
+	return s
+}
+
+// Headers specifies the headers of the request.
+func (s *XPackRollupDeleteService) Headers(headers http.Header) *XPackRollupDeleteService {
+	s.headers = headers
+	return s
+}
+
+// JobId is id of the rollup to delete.
+func (s *XPackRollupDeleteService) JobId(jobId string) *XPackRollupDeleteService {
+	s.jobId = jobId
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackRollupDeleteService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_rollup/job/{job_id}", map[string]string{
+		"job_id": s.jobId,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if v := s.pretty; v != nil {
+		params.Set("pretty", fmt.Sprint(*v))
+	}
+	if v := s.human; v != nil {
+		params.Set("human", fmt.Sprint(*v))
+	}
+	if v := s.errorTrace; v != nil {
+		params.Set("error_trace", fmt.Sprint(*v))
+	}
+	if len(s.filterPath) > 0 {
+		params.Set("filter_path", strings.Join(s.filterPath, ","))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackRollupDeleteService) Validate() error {
+	var invalid []string
+	if s.jobId == "" {
+		invalid = append(invalid, "Job ID")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackRollupDeleteService) Do(ctx context.Context) (*XPackRollupDeleteResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method:  "DELETE",
+		Path:    path,
+		Params:  params,
+		Headers: s.headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(XPackRollupDeleteResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// XPackRollupDeleteResponse is the response of XPackRollupDeleteService.Do.
+type XPackRollupDeleteResponse struct {
+	Acknowledged bool `json:"acknowledged"`
+}

--- a/xpack_rollup_delete_test.go
+++ b/xpack_rollup_delete_test.go
@@ -1,0 +1,51 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"testing"
+)
+
+func TestXPackRollupDeleteBuildURL(t *testing.T) {
+	client := setupTestClient(t)
+
+	tests := []struct {
+		JobId        string
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			"",
+			true,
+		},
+		{
+			"my-job",
+			"/_rollup/job/my-job",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackRollupDelete(test.JobId)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}

--- a/xpack_rollup_get.go
+++ b/xpack_rollup_get.go
@@ -1,0 +1,202 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/olivere/elastic/v7/uritemplates"
+)
+
+// XPackRollupGetService retrieves a role by its name.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rollup-apis.html.
+type XPackRollupGetService struct {
+	client *Client
+
+	pretty     *bool       // pretty format the returned JSON response
+	human      *bool       // return human readable values for statistics
+	errorTrace *bool       // include the stack trace of returned errors
+	filterPath []string    // list of filters used to reduce the response
+	headers    http.Header // custom request-level HTTP headers
+
+	jobId string
+}
+
+// NewXPackRollupGetService creates a new XPackRollupGetService.
+func NewXPackRollupGetService(client *Client) *XPackRollupGetService {
+	return &XPackRollupGetService{
+		client: client,
+	}
+}
+
+// Pretty tells Elasticsearch whether to return a formatted JSON response.
+func (s *XPackRollupGetService) Pretty(pretty bool) *XPackRollupGetService {
+	s.pretty = &pretty
+	return s
+}
+
+// Human specifies whether human readable values should be returned in
+// the JSON response, e.g. "7.5mb".
+func (s *XPackRollupGetService) Human(human bool) *XPackRollupGetService {
+	s.human = &human
+	return s
+}
+
+// ErrorTrace specifies whether to include the stack trace of returned errors.
+func (s *XPackRollupGetService) ErrorTrace(errorTrace bool) *XPackRollupGetService {
+	s.errorTrace = &errorTrace
+	return s
+}
+
+// FilterPath specifies a list of filters used to reduce the response.
+func (s *XPackRollupGetService) FilterPath(filterPath ...string) *XPackRollupGetService {
+	s.filterPath = filterPath
+	return s
+}
+
+// Header adds a header to the request.
+func (s *XPackRollupGetService) Header(name string, value string) *XPackRollupGetService {
+	if s.headers == nil {
+		s.headers = http.Header{}
+	}
+	s.headers.Add(name, value)
+	return s
+}
+
+// Headers specifies the headers of the request.
+func (s *XPackRollupGetService) Headers(headers http.Header) *XPackRollupGetService {
+	s.headers = headers
+	return s
+}
+
+// JobId is id of the rollup to retrieve.
+func (s *XPackRollupGetService) JobId(jobId string) *XPackRollupGetService {
+	s.jobId = jobId
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackRollupGetService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_rollup/job/{job_id}", map[string]string{
+		"job_id": s.jobId,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if v := s.pretty; v != nil {
+		params.Set("pretty", fmt.Sprint(*v))
+	}
+	if v := s.human; v != nil {
+		params.Set("human", fmt.Sprint(*v))
+	}
+	if v := s.errorTrace; v != nil {
+		params.Set("error_trace", fmt.Sprint(*v))
+	}
+	if len(s.filterPath) > 0 {
+		params.Set("filter_path", strings.Join(s.filterPath, ","))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackRollupGetService) Validate() error {
+	var invalid []string
+	if s.jobId == "" {
+		invalid = append(invalid, "Job ID")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackRollupGetService) Do(ctx context.Context) (*XPackRollupGetResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method:  "GET",
+		Path:    path,
+		Params:  params,
+		Headers: s.headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := XPackRollupGetResponse{}
+	if err := json.Unmarshal(res.Body, &ret); err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+// XPackRollupGetResponse is the response of XPackRollupGetService.Do.
+type XPackRollupGetResponse struct {
+	Jobs []XPackRollup `json:"jobs"`
+}
+
+// XPackRollup is the role object.
+type XPackRollup struct {
+	Config XPackRollupConfig `json:"config"`
+	Status XPackRollupStatus `json:"status"`
+	Stats  XPackRollupStats  `json:"stats"`
+}
+
+type XPackRollupConfig struct {
+	Id           string                 `json:"id"`
+	Cron         string                 `json:"cron"`
+	IndexPattern string                 `json:"index_pattern"`
+	RollupIndex  string                 `json:"rollup_index"`
+	Groups       map[string]interface{} `json:"groups"`
+	Metrics      []XPackRollupMetrics   `json:"metrics"`
+	Timeout      string                 `json:"timeout"`
+	PageSize     int                    `json:"page_size"`
+}
+
+type XPackRollupMetrics struct {
+	Field   string   `json:"field"`
+	Metrics []string `json:"metrics"`
+}
+
+type XPackRollupStatus struct {
+	JobState      string `json:"job_state"`
+	UpgradedDocId bool   `json:"upgraded_doc_id"`
+}
+
+type XPackRollupStats struct {
+	PageProcessed      int `json:"pages_processed"`
+	DocumentsProcessed int `json:"documents_processed"`
+	RollupsIndexed     int `json:"rollups_indexed"`
+	TriggerCount       int `json:"trigger_count"`
+	IndexFailures      int `json:"index_failures"`
+	IndexTimeInMs      int `json:"index_time_in_ms"`
+	IndexTotal         int `json:"index_total"`
+	SearchFailures     int `json:"search_failures"`
+	SearchTimeInMs     int `json:"search_time_in_ms"`
+	SearchTotal        int `json:"search_total"`
+	ProcessingTimeInMs int `json:"processing_time_in_ms"`
+	ProcessingTotal    int `json:"processing_total"`
+}

--- a/xpack_rollup_get_test.go
+++ b/xpack_rollup_get_test.go
@@ -1,0 +1,49 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import "testing"
+
+func TestXPackRollupGetBuildURL(t *testing.T) {
+	client := setupTestClient(t)
+
+	tests := []struct {
+		JobId        string
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			"",
+			true,
+		},
+		{
+			"my-job",
+			"/_rollup/job/my-job",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackRollupGet(test.JobId)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}

--- a/xpack_rollup_put.go
+++ b/xpack_rollup_put.go
@@ -1,0 +1,170 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/olivere/elastic/v7/uritemplates"
+)
+
+// XPackRollupPutService create or update a rollup job by its job id.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rollup-put-job.html.
+type XPackRollupPutService struct {
+	client *Client
+
+	pretty     *bool       // pretty format the returned JSON response
+	human      *bool       // return human readable values for statistics
+	errorTrace *bool       // include the stack trace of returned errors
+	filterPath []string    // list of filters used to reduce the response
+	headers    http.Header // custom request-level HTTP headers
+
+	jobId string
+	body  interface{}
+}
+
+// NewXPackRollupPutService creates a new XPackRollupPutService.
+func NewXPackRollupPutService(client *Client) *XPackRollupPutService {
+	return &XPackRollupPutService{
+		client: client,
+	}
+}
+
+// Pretty tells Elasticsearch whether to return a formatted JSON response.
+func (s *XPackRollupPutService) Pretty(pretty bool) *XPackRollupPutService {
+	s.pretty = &pretty
+	return s
+}
+
+// Human specifies whether human readable values should be returned in
+// the JSON response, e.g. "7.5mb".
+func (s *XPackRollupPutService) Human(human bool) *XPackRollupPutService {
+	s.human = &human
+	return s
+}
+
+// ErrorTrace specifies whether to include the stack trace of returned errors.
+func (s *XPackRollupPutService) ErrorTrace(errorTrace bool) *XPackRollupPutService {
+	s.errorTrace = &errorTrace
+	return s
+}
+
+// FilterPath specifies a list of filters used to reduce the response.
+func (s *XPackRollupPutService) FilterPath(filterPath ...string) *XPackRollupPutService {
+	s.filterPath = filterPath
+	return s
+}
+
+// Header adds a header to the request.
+func (s *XPackRollupPutService) Header(name string, value string) *XPackRollupPutService {
+	if s.headers == nil {
+		s.headers = http.Header{}
+	}
+	s.headers.Add(name, value)
+	return s
+}
+
+// Headers specifies the headers of the request.
+func (s *XPackRollupPutService) Headers(headers http.Header) *XPackRollupPutService {
+	s.headers = headers
+	return s
+}
+
+// JobId is id of the rollup to create.
+func (s *XPackRollupPutService) JobId(jobId string) *XPackRollupPutService {
+	s.jobId = jobId
+	return s
+}
+
+// Body specifies the role. Use a string or a type that will get serialized as JSON.
+func (s *XPackRollupPutService) Body(body interface{}) *XPackRollupPutService {
+	s.body = body
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackRollupPutService) buildURL() (string, url.Values, error) {
+	// Build URL
+	path, err := uritemplates.Expand("/_rollup/job/{job_id}", map[string]string{
+		"job_id": s.jobId,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if v := s.pretty; v != nil {
+		params.Set("pretty", fmt.Sprint(*v))
+	}
+	if v := s.human; v != nil {
+		params.Set("human", fmt.Sprint(*v))
+	}
+	if v := s.errorTrace; v != nil {
+		params.Set("error_trace", fmt.Sprint(*v))
+	}
+	if len(s.filterPath) > 0 {
+		params.Set("filter_path", strings.Join(s.filterPath, ","))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackRollupPutService) Validate() error {
+	var invalid []string
+	if s.jobId == "" {
+		invalid = append(invalid, "Job ID")
+	}
+	if s.body == nil {
+		invalid = append(invalid, "Body")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackRollupPutService) Do(ctx context.Context) (*XPackRollupPutResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method:  "PUT",
+		Path:    path,
+		Params:  params,
+		Body:    s.body,
+		Headers: s.headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(XPackRollupPutResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// XPackRollupPutResponse is the response of XPackRollupPutService.Do.
+type XPackRollupPutResponse struct {
+	Acknowledged bool `json:"acknowledged"`
+}

--- a/xpack_rollup_put_test.go
+++ b/xpack_rollup_put_test.go
@@ -1,0 +1,66 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"testing"
+)
+
+func TestXPackRollupPutBuildURL(t *testing.T) {
+	client := setupTestClient(t)
+
+	tests := []struct {
+		JobId        string
+		Body         interface{}
+		ExpectedPath string
+		ExpectErr    bool
+	}{
+		{
+			"",
+			nil,
+			"",
+			true,
+		},
+		{
+			"my-job",
+			nil,
+			"",
+			true,
+		},
+		{
+			"",
+			`{}`,
+			"",
+			true,
+		},
+		{
+			"my-job",
+			`{}`,
+			"/_rollup/job/my-job",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackRollupPut(test.JobId).Body(test.Body)
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.ExpectedPath {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.ExpectedPath, path)
+			}
+		}
+	}
+}

--- a/xpack_rollup_start.go
+++ b/xpack_rollup_start.go
@@ -1,0 +1,159 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/olivere/elastic/v7/uritemplates"
+)
+
+// XPackRollupStartService starts the rollup job if it is not already running.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rollup-start-job.html.
+type XPackRollupStartService struct {
+	client *Client
+
+	pretty     *bool       // pretty format the returned JSON response
+	human      *bool       // return human readable values for statistics
+	errorTrace *bool       // include the stack trace of returned errors
+	filterPath []string    // list of filters used to reduce the response
+	headers    http.Header // custom request-level HTTP headers
+
+	jobId string
+}
+
+// NewXPackRollupStartService creates a new XPackRollupStartService.
+func NewXPackRollupStartService(client *Client) *XPackRollupStartService {
+	return &XPackRollupStartService{
+		client: client,
+	}
+}
+
+// Pretty tells Elasticsearch whether to return a formatted JSON response.
+func (s *XPackRollupStartService) Pretty(pretty bool) *XPackRollupStartService {
+	s.pretty = &pretty
+	return s
+}
+
+// Human specifies whether human readable values should be returned in
+// the JSON response, e.g. "7.5mb".
+func (s *XPackRollupStartService) Human(human bool) *XPackRollupStartService {
+	s.human = &human
+	return s
+}
+
+// ErrorTrace specifies whether to include the stack trace of returned errors.
+func (s *XPackRollupStartService) ErrorTrace(errorTrace bool) *XPackRollupStartService {
+	s.errorTrace = &errorTrace
+	return s
+}
+
+// FilterPath specifies a list of filters used to reduce the response.
+func (s *XPackRollupStartService) FilterPath(filterPath ...string) *XPackRollupStartService {
+	s.filterPath = filterPath
+	return s
+}
+
+// Header adds a header to the request.
+func (s *XPackRollupStartService) Header(name string, value string) *XPackRollupStartService {
+	if s.headers == nil {
+		s.headers = http.Header{}
+	}
+	s.headers.Add(name, value)
+	return s
+}
+
+// Headers specifies the headers of the request.
+func (s *XPackRollupStartService) Headers(headers http.Header) *XPackRollupStartService {
+	s.headers = headers
+	return s
+}
+
+// JobId is id of the rollup to retrieve.
+func (s *XPackRollupStartService) JobId(jobId string) *XPackRollupStartService {
+	s.jobId = jobId
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackRollupStartService) buildURL() (string, url.Values, error) {
+	// Build URL path
+	path, err := uritemplates.Expand("/_rollup/job/{job_id}/_start", map[string]string{
+		"job_id": s.jobId,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if v := s.pretty; v != nil {
+		params.Set("pretty", fmt.Sprint(*v))
+	}
+	if v := s.human; v != nil {
+		params.Set("human", fmt.Sprint(*v))
+	}
+	if v := s.errorTrace; v != nil {
+		params.Set("error_trace", fmt.Sprint(*v))
+	}
+	if len(s.filterPath) > 0 {
+		params.Set("filter_path", strings.Join(s.filterPath, ","))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackRollupStartService) Validate() error {
+	var invalid []string
+	if s.jobId == "" {
+		invalid = append(invalid, "Job ID")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackRollupStartService) Do(ctx context.Context) (*XPackRollupStartResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method:  "POST",
+		Path:    path,
+		Params:  params,
+		Headers: s.headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(XPackRollupStartResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// XPackRollupStartResponse is the response of XPackRollupStartService.Do.
+type XPackRollupStartResponse struct {
+	Started bool `json:"started"`
+}

--- a/xpack_rollup_start_test.go
+++ b/xpack_rollup_start_test.go
@@ -1,0 +1,44 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"testing"
+)
+
+func TestXPackRollupStartBuildURL(t *testing.T) {
+	client := setupTestClient(t)
+
+	tests := []struct {
+		Expected  string
+		ExpectErr bool
+	}{
+		{
+			"/_rollup/job/my-job/_start",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackRollupStart("my-job")
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.Expected {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.Expected, path)
+			}
+		}
+	}
+}

--- a/xpack_rollup_stop.go
+++ b/xpack_rollup_stop.go
@@ -1,0 +1,159 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/olivere/elastic/v7/uritemplates"
+)
+
+// XPackRollupStartService stops the rollup job if it is running.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rollup-stop-job.html.
+type XPackRollupStopService struct {
+	client *Client
+
+	pretty     *bool       // pretty format the returned JSON response
+	human      *bool       // return human readable values for statistics
+	errorTrace *bool       // include the stack trace of returned errors
+	filterPath []string    // list of filters used to reduce the response
+	headers    http.Header // custom request-level HTTP headers
+
+	jobId string
+}
+
+// NewXPackRollupStopService creates a new XPackRollupStopService.
+func NewXPackRollupStopService(client *Client) *XPackRollupStopService {
+	return &XPackRollupStopService{
+		client: client,
+	}
+}
+
+// Pretty tells Elasticsearch whether to return a formatted JSON response.
+func (s *XPackRollupStopService) Pretty(pretty bool) *XPackRollupStopService {
+	s.pretty = &pretty
+	return s
+}
+
+// Human specifies whether human readable values should be returned in
+// the JSON response, e.g. "7.5mb".
+func (s *XPackRollupStopService) Human(human bool) *XPackRollupStopService {
+	s.human = &human
+	return s
+}
+
+// ErrorTrace specifies whether to include the stack trace of returned errors.
+func (s *XPackRollupStopService) ErrorTrace(errorTrace bool) *XPackRollupStopService {
+	s.errorTrace = &errorTrace
+	return s
+}
+
+// FilterPath specifies a list of filters used to reduce the response.
+func (s *XPackRollupStopService) FilterPath(filterPath ...string) *XPackRollupStopService {
+	s.filterPath = filterPath
+	return s
+}
+
+// Header adds a header to the request.
+func (s *XPackRollupStopService) Header(name string, value string) *XPackRollupStopService {
+	if s.headers == nil {
+		s.headers = http.Header{}
+	}
+	s.headers.Add(name, value)
+	return s
+}
+
+// Headers specifies the headers of the request.
+func (s *XPackRollupStopService) Headers(headers http.Header) *XPackRollupStopService {
+	s.headers = headers
+	return s
+}
+
+// JobId is id of the rollup to retrieve.
+func (s *XPackRollupStopService) JobId(jobId string) *XPackRollupStopService {
+	s.jobId = jobId
+	return s
+}
+
+// buildURL builds the URL for the operation.
+func (s *XPackRollupStopService) buildURL() (string, url.Values, error) {
+	// Build URL path
+	path, err := uritemplates.Expand("/_rollup/job/{job_id}/_stop", map[string]string{
+		"job_id": s.jobId,
+	})
+	if err != nil {
+		return "", url.Values{}, err
+	}
+
+	// Add query string parameters
+	params := url.Values{}
+	if v := s.pretty; v != nil {
+		params.Set("pretty", fmt.Sprint(*v))
+	}
+	if v := s.human; v != nil {
+		params.Set("human", fmt.Sprint(*v))
+	}
+	if v := s.errorTrace; v != nil {
+		params.Set("error_trace", fmt.Sprint(*v))
+	}
+	if len(s.filterPath) > 0 {
+		params.Set("filter_path", strings.Join(s.filterPath, ","))
+	}
+	return path, params, nil
+}
+
+// Validate checks if the operation is valid.
+func (s *XPackRollupStopService) Validate() error {
+	var invalid []string
+	if s.jobId == "" {
+		invalid = append(invalid, "Job ID")
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields: %v", invalid)
+	}
+	return nil
+}
+
+// Do executes the operation.
+func (s *XPackRollupStopService) Do(ctx context.Context) (*XPackRollupStopResponse, error) {
+	// Check pre-conditions
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	path, params, err := s.buildURL()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequestOptions{
+		Method:  "POST",
+		Path:    path,
+		Params:  params,
+		Headers: s.headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return operation response
+	ret := new(XPackRollupStopResponse)
+	if err := json.Unmarshal(res.Body, ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// XPackRollupStopResponse is the response of XPackRollupStopService.Do.
+type XPackRollupStopResponse struct {
+	Stoppeed bool `json:"stopped"`
+}

--- a/xpack_rollup_stop_test.go
+++ b/xpack_rollup_stop_test.go
@@ -1,0 +1,44 @@
+// Copyright 2012-present Oliver Eilhard. All rights reserved.
+// Use of this source code is governed by a MIT-license.
+// See http://olivere.mit-license.org/license.txt for details.
+
+package elastic
+
+import (
+	"testing"
+)
+
+func TestXPackRollupStopBuildURL(t *testing.T) {
+	client := setupTestClient(t)
+
+	tests := []struct {
+		Expected  string
+		ExpectErr bool
+	}{
+		{
+			"/_rollup/job/my-job/_stop",
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		builder := client.XPackRollupStop("my-job")
+		err := builder.Validate()
+		if err != nil {
+			if !test.ExpectErr {
+				t.Errorf("case #%d: %v", i+1, err)
+				continue
+			}
+		} else {
+			// err == nil
+			if test.ExpectErr {
+				t.Errorf("case #%d: expected error", i+1)
+				continue
+			}
+			path, _, _ := builder.buildURL()
+			if path != test.Expected {
+				t.Errorf("case #%d: expected %q; got: %q", i+1, test.Expected, path)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adding support for XPack Rollup API

- Create Job
- Delete Job
- Start Job, Stop Job
- Get Job

https://www.elastic.co/guide/en/elasticsearch/reference/7.0/rollup-apis.html