### PR TITLE
[index template] Parse datastream object

### DIFF
--- a/indices_get_index_template.go
+++ b/indices_get_index_template.go
@@ -199,12 +199,24 @@ type IndicesGetIndexTemplates struct {
 	IndexTemplate *IndicesGetIndexTemplate `json:"index_template"`
 }
 
+type IndicesDataStream struct {
+	Name           string   `json:"name,omitempty"`
+	TimestampField string   `json:"timestamp_field,omitempty"`
+	Indices        []string `json:"indices,omitempty"`
+	Hidden         bool     `json:"hidden,omitempty"`
+	System         bool     `json:"system,omitempty"`
+	IlmPolicy      string   `json:"ilm_policy,omitempty"`
+	Status         string   `json:"status,omitempty"`
+	IndexTemplate  string   `json:"template,omitempty"`
+}
+
 type IndicesGetIndexTemplate struct {
 	IndexPatterns []string                     `json:"index_patterns,omitempty"`
 	ComposedOf    []string                     `json:"composed_of,omitempty"`
 	Priority      int                          `json:"priority,omitempty"`
 	Version       int                          `json:"version,omitempty"`
 	Template      *IndicesGetIndexTemplateData `json:"template,omitempty"`
+	DataStream    *IndicesDataStream           `json:"data_stream,omitempty"`
 }
 
 type IndicesGetIndexTemplateData struct {


### PR DESCRIPTION
Briefly mentioned in https://github.com/olivere/elastic/issues/1464 and related to https://github.com/olivere/elastic/issues/1484, but we saw this in https://github.com/phillbaker/terraform-provider-elasticsearch/issues/159. 

The data_stream element isn't really documented well by elasticsearch, the only docs I could find were tangential in the simulate API here: https://www.elastic.co/guide/en/elasticsearch/reference/7.12/indices-simulate-template.html#simulate-template-api-request-body. This seems to match this code in ES: https://github.com/elastic/elasticsearch/blob/9958c3c2fc49a3e253b04e96cfec2e653c39d2e7/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java#L22