### PR TITLE
Redact password from URL in infof logging

### DIFF
--- a/client.go
+++ b/client.go
@@ -1502,7 +1502,7 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 	duration := time.Now().UTC().Sub(start)
 	c.infof("%s %s [status:%d, request:%.3fs]",
 		strings.ToUpper(opt.Method),
-		req.URL,
+		req.URL.Redacted(),
 		resp.StatusCode,
 		float64(int64(duration/time.Millisecond))/1000)
 


### PR DESCRIPTION
The infof call that logs requests currently leaks the basic auth password through the URL. By using [URL.Redacted()](https://pkg.go.dev/net/url#URL.Redacted), we can replace the password with "xxxxx" in the log message.