### PR TITLE
[index template] Fix data stream timestamp field

### DIFF
--- a/indices_get_index_template.go
+++ b/indices_get_index_template.go
@@ -231,16 +231,20 @@ type IndicesGetIndexTemplateData struct {
 }
 
 type IndicesDataStream struct {
-	Name               string                 `json:"name,omitempty"`
-	TimestampField     string                 `json:"timestamp_field,omitempty"`
-	Indices            []string               `json:"indices,omitempty"`
-	Generation         int64                  `json:"generation,omitempty"`
-	Status             string                 `json:"status,omitempty"`
-	IndexTemplate      string                 `json:"template,omitempty"`
-	IlmPolicy          string                 `json:"ilm_policy,omitempty"`
-	Meta               map[string]interface{} `json:"_meta,omitempty"`
-	Hidden             bool                   `json:"hidden,omitempty"`
-	System             bool                   `json:"system,omitempty"`
-	AllowCustomRouting bool                   `json:"allow_custom_routing,omitempty"`
-	Replicated         bool                   `json:"replicated,omitempty"`
+	Name               string                           `json:"name,omitempty"`
+	TimestampField     *IndicesDataStreamTimestampField `json:"timestamp_field,omitempty"`
+	Indices            []string                         `json:"indices,omitempty"`
+	Generation         int64                            `json:"generation,omitempty"`
+	Status             string                           `json:"status,omitempty"`
+	IndexTemplate      string                           `json:"template,omitempty"`
+	IlmPolicy          string                           `json:"ilm_policy,omitempty"`
+	Meta               map[string]interface{}           `json:"_meta,omitempty"`
+	Hidden             bool                             `json:"hidden,omitempty"`
+	System             bool                             `json:"system,omitempty"`
+	AllowCustomRouting bool                             `json:"allow_custom_routing,omitempty"`
+	Replicated         bool                             `json:"replicated,omitempty"`
+}
+
+type IndicesDataStreamTimestampField struct {
+	Name string `json:"name,omitempty"`
 }


### PR DESCRIPTION
Related to https://github.com/olivere/elastic/pull/1550 and https://github.com/olivere/elastic/commit/3e406842c91fb5f7dfd1904dff173db10440983e.

Although this is a just a string on the Java object, it's expressed as an object in the JSON api, see: https://github.com/elastic/elasticsearch/blob/5c4330292ffead1218ddba896431ca04408f766c/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/DataStream.java#L162

The documentation concurs: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-data-stream.html#get-data-stream-api-example

(Looks like I missed this in my original PR as well)

Edit: Sorry, opened with work account instead of personal.