### PR TITLE
Fix: PIT Search Recipe NewPointInTime Call

### DIFF
--- a/recipes/search_with_point_in_time/search.go
+++ b/recipes/search_with_point_in_time/search.go
@@ -79,7 +79,7 @@ func main() {
 		).
 		Size(*size).
 		PointInTime(
-			elastic.NewPointInTime(pit.Id, "2m"),
+			elastic.NewPointInTimeWithKeepAlive(pit.Id, "2m"),
 		).
 		Do(context.Background())
 	if err != nil {


### PR DESCRIPTION
In [this commit](https://github.com/olivere/elastic/commit/d0ea877a6e58d9b607e4216f928f74e65af0921c), `keepAlive` was removed from `NewPointInTime` (and instead supported by `NewPointInTimeWithKeepAlive`), but the PIT Search recipe was not updated to reflect that change