### PR TITLE
Fixed GeoBoundingBox BottomLeft args order

### DIFF
--- a/search_queries_geo_bounding_box.go
+++ b/search_queries_geo_bounding_box.go
@@ -65,7 +65,7 @@ func (q *GeoBoundingBoxQuery) BottomRightFromGeoHash(bottomRight string) *GeoBou
 
 // BottomLeft position from longitude (left) and latitude (bottom).
 func (q *GeoBoundingBoxQuery) BottomLeft(bottom, left float64) *GeoBoundingBoxQuery {
-	q.bottomLeft = []float64{bottom, left}
+	q.bottomLeft = []float64{left, bottom}
 	return q
 }
 

--- a/search_queries_geo_bounding_box_test.go
+++ b/search_queries_geo_bounding_box_test.go
@@ -29,6 +29,26 @@ func TestGeoBoundingBoxQuery(t *testing.T) {
 	}
 }
 
+func TestGeoBoundingBoxQueryInverted(t *testing.T) {
+	q := NewGeoBoundingBoxQuery("pin.location")
+	q = q.TopRight(40.73, -74.1)
+	q = q.BottomLeft(40.01, -71.12)
+	q = q.Type("memory")
+	src, err := q.Source()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshaling to JSON failed: %v", err)
+	}
+	got := string(data)
+	expected := `{"geo_bounding_box":{"pin.location":{"bottom_left":[-71.12,40.01],"top_right":[-74.1,40.73]},"type":"memory"}}`
+	if got != expected {
+		t.Errorf("expected\n%s\n,got:\n%s", expected, got)
+	}
+}
+
 func TestGeoBoundingBoxQueryWithGeoPoint(t *testing.T) {
 	q := NewGeoBoundingBoxQuery("pin.location")
 	q = q.TopLeftFromGeoPoint(GeoPointFromLatLon(40.73, -74.1))


### PR DESCRIPTION
Hello.

The order of BottomLeft arguments in GeoBoundingBoxQuery was swapped, which has been corrected.

before: `"bottom_left":[40.01,-71.12],"top_right":[-74.1,40.73]}`

after: `bottom_left":[-71.12,40.01],"top_right":[-74.1,40.73]}`