### PR TITLE
fix: example_test.go failed to parse mapping [_doc]

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -70,28 +70,26 @@ func Example() {
 		"number_of_replicas":0
 	},
 	"mappings":{
-		"doc":{
-			"properties":{
-				"user":{
-					"type":"keyword"
-				},
-				"message":{
-					"type":"text",
-					"store": true,
-					"fielddata": true
-				},
-                "retweets":{
-                    "type":"long"
-                },
-				"tags":{
-					"type":"keyword"
-				},
-				"location":{
-					"type":"geo_point"
-				},
-				"suggest_field":{
-					"type":"completion"
-				}
+		"properties":{
+			"user":{
+				"type":"keyword"
+			},
+			"message":{
+				"type":"text",
+				"store": true,
+				"fielddata": true
+			},
+			"retweets":{
+				"type":"long"
+			},
+			"tags":{
+				"type":"keyword"
+			},
+			"location":{
+				"type":"geo_point"
+			},
+			"suggest_field":{
+				"type":"completion"
 			}
 		}
 	}


### PR DESCRIPTION
hello, I am a newbie, when I read example, it failed to create a index, it's the problem of elastic search version, from v7 the mapping type field -doc is completely going away.