### PR TITLE
Add wait_for_no_initializing_shards to cluster health API

### DIFF
--- a/cluster_health.go
+++ b/cluster_health.go
@@ -34,6 +34,7 @@ type ClusterHealthService struct {
 	timeout                   string
 	waitForActiveShards       *int
 	waitForNodes              string
+	waitForNoInitializingShards *bool
 	waitForNoRelocatingShards *bool
 	waitForStatus             string
 }
@@ -131,6 +132,12 @@ func (s *ClusterHealthService) WaitForNodes(waitForNodes string) *ClusterHealthS
 }
 
 // WaitForNoRelocatingShards can be used to wait until all shard relocations are finished.
+func (s *ClusterHealthService) WaitForNoInitializingShards(waitForNoInitializingShards bool) *ClusterHealthService {
+	s.waitForNoInitializingShards = &waitForNoInitializingShards
+	return s
+}
+
+// WaitForNoRelocatingShards can be used to wait until all shard relocations are finished.
 func (s *ClusterHealthService) WaitForNoRelocatingShards(waitForNoRelocatingShards bool) *ClusterHealthService {
 	s.waitForNoRelocatingShards = &waitForNoRelocatingShards
 	return s
@@ -200,6 +207,9 @@ func (s *ClusterHealthService) buildURL() (string, url.Values, error) {
 	}
 	if s.waitForNodes != "" {
 		params.Set("wait_for_nodes", s.waitForNodes)
+	}
+	if s.waitForNoInitializingShards != nil {
+		params.Set("wait_for_no_initializing_shards", fmt.Sprintf("%v", *s.waitForNoInitializingShards))
 	}
 	if s.waitForNoRelocatingShards != nil {
 		params.Set("wait_for_no_relocating_shards", fmt.Sprintf("%v", *s.waitForNoRelocatingShards))


### PR DESCRIPTION
This PR adds wait_for_no_initializing_shards to cluster health API which has been available on all 7.x releases.

See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/cluster-health.html

>  wait_for_no_initializing_shards
>    (Optional, Boolean) A boolean value which controls whether to wait (until the timeout provided) for the cluster to have no shard initializations. Defaults to false, which means it will not wait for initializing shards. 