### PR TITLE
add include_type_name to GetMapping api

### DIFF
--- a/indices_get_mapping.go
+++ b/indices_get_mapping.go
@@ -34,6 +34,7 @@ type IndicesGetMappingService struct {
 	ignoreUnavailable *bool
 	allowNoIndices    *bool
 	expandWildcards   string
+	includeTypeName   *bool
 }
 
 // NewGetMappingService is an alias for NewIndicesGetMappingService.
@@ -118,6 +119,13 @@ func (s *IndicesGetMappingService) ExpandWildcards(expandWildcards string) *Indi
 	return s
 }
 
+// IncludeTypeName indicates whether to expect a mapping type.
+// If true, a mapping type is expected in the body of mappings. Defaults to false.
+func (s *IndicesGetMappingService) IncludeTypeName(includeTypeName bool) *IndicesGetMappingService {
+	s.includeTypeName = &includeTypeName
+	return s
+}
+
 // Local indicates whether to return local information, do not retrieve
 // the state from master node (default: false).
 func (s *IndicesGetMappingService) Local(local bool) *IndicesGetMappingService {
@@ -182,6 +190,9 @@ func (s *IndicesGetMappingService) buildURL() (string, url.Values, error) {
 	}
 	if s.local != nil {
 		params.Set("local", fmt.Sprintf("%v", *s.local))
+	}
+	if s.includeTypeName != nil {
+		params.Set("include_type_name", fmt.Sprintf("%v", *s.includeTypeName))
 	}
 	return path, params, nil
 }


### PR DESCRIPTION
Hi Olivere,

Thank you for this awesome project!

I submit a pr about adding include_type_name parameter to GetMapping api in order to making my open source project esdump can support migrating data between v7 and v6.

https://github.com/wubin1989/esdump/issues/1#issue-1270552298

Best Regards,
wubin1989