### PR TITLE
Removed Redacted() function from req.url

### DIFF
--- a/client.go
+++ b/client.go
@@ -1502,7 +1502,7 @@ func (c *Client) PerformRequest(ctx context.Context, opt PerformRequestOptions) 
 	duration := time.Now().UTC().Sub(start)
 	c.infof("%s %s [status:%d, request:%.3fs]",
 		strings.ToUpper(opt.Method),
-		req.URL.Redacted(),
+		req.URL,
 		resp.StatusCode,
 		float64(int64(duration/time.Millisecond))/1000)
 


### PR DESCRIPTION
Removed Redacted() function from from req.URL as it is creating issue while creating the go container. Getting compilation error while building the app. Seems like it doesn't support newer version of Go. My current version is 1.18. This issue is facing by a lot of users. Kindly fix that.