### PR TITLE
Fix: Bulk processor retries indefinitely on failure

### DIFF
--- a/bulk_processor.go
+++ b/bulk_processor.go
@@ -580,12 +580,12 @@ func (w *bulkWorker) commit(ctx context.Context) error {
 	err := RetryNotify(commitFunc, w.p.backoff, notifyFunc)
 	w.updateStats(res)
 	if err != nil {
-		// After all retry attempts clear the requests for the next round. This is
-		// important when backoff is disabled or limited to a number of rounds, and
-		// the aftermath is a failure., because the commitFunc (and consequently the
-		// underlying BulkService.Do call) will not clear the requests from the
-		// worker. Without this the same requests will be used on the next round of
-		// execution of the worker.
+		// After exhausting all retry attempts, the worker must clear the requests
+		// for the next round. This is important when backoff is disabled or limited
+		// to a number of rounds, and the aftermath is a failure because the
+		// commitFunc (and consequently the underlying BulkService.Do call) will not
+		// clear the requests from the worker. Without this, the same requests will
+		// be used on the next round of execution of the worker.
 		w.service.Reset()
 
 		w.p.c.errorf("elastic: bulk processor %q failed: %v", w.p.name, err)


### PR DESCRIPTION
When all retries are exhausted the worker internal requests buffer needs to be cleared in failure scenarios. That is required because the `commitFunc` (and consequently the underlying `BulkService.Do` call) doesn't reset it when some error happens. Without clearing the internal buffer the worker will continue sending the same requests on the following rounds of execution.

Kudos for this solution goes to @rwynn and @raiRaiyan .

Resolves #1278