### PR TITLE
Fixed search_queries_geo_bounding_box problem 

### DIFF
--- a/search_queries_geo_bounding_box.go
+++ b/search_queries_geo_bounding_box.go
@@ -65,7 +65,7 @@ func (q *GeoBoundingBoxQuery) BottomRightFromGeoHash(bottomRight string) *GeoBou
 
 // BottomLeft position from longitude (left) and latitude (bottom).
 func (q *GeoBoundingBoxQuery) BottomLeft(bottom, left float64) *GeoBoundingBoxQuery {
-	q.bottomLeft = []float64{bottom, left}
+	q.bottomLeft = []float64{left, bottom}
 	return q
 }
 


### PR DESCRIPTION
Fixed the problem that the longitude and latitude were wrongly transmitted when using the bottom left parameter when querying the geo box. The bottom left parameter array should be longitude first, then latitude.