### PR TITLE
fix: res.Body must close

### DIFF
--- a/client.go
+++ b/client.go
@@ -1203,6 +1203,9 @@ func (c *Client) startupHealthcheck(parentCtx context.Context, timeout time.Dura
 			defer cancel()
 			req = req.WithContext(ctx)
 			res, err := c.c.Do(req)
+			if res != nil && res.Body != nil {
+				res.Body.Close()
+			}
 			if err != nil {
 				lastErr = err
 			} else if res.StatusCode >= 200 && res.StatusCode < 300 {


### PR DESCRIPTION
It appears that there may be a goroutine leak due to a failure to close `res.Body`. This issue arises because the business logic involves frequent creation of clients, and the omission of closing `res.Body` is likely the cause of the leak.