### PR TITLE
fix: BottomLeftFromGeoPoint flipping lat and lng values

### DIFF
--- a/search_queries_geo_bounding_box.go
+++ b/search_queries_geo_bounding_box.go
@@ -65,7 +65,7 @@ func (q *GeoBoundingBoxQuery) BottomRightFromGeoHash(bottomRight string) *GeoBou
 
 // BottomLeft position from longitude (left) and latitude (bottom).
 func (q *GeoBoundingBoxQuery) BottomLeft(bottom, left float64) *GeoBoundingBoxQuery {
-	q.bottomLeft = []float64{bottom, left}
+	q.bottomLeft = []float64{left, bottom}
 	return q
 }
 


### PR DESCRIPTION
using `BottomLeftFromGeoHash` results in error as the lat lng values are flipped. this PR reverts it to the correct ordering